### PR TITLE
fix: onboarding issue

### DIFF
--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -42,26 +42,27 @@ final _logger = AppLogger('AppRouter');
 /// - Preserves deep links for post-login redirection
 /// - Automatically refreshes when auth state changes
 final appRouterProvider = Provider<GoRouter>((ref) {
-  final authState = ref.watch(authProvider);
-  final onboardingRepo = ref.watch(onboardingRepositoryProvider);
-
-  _logger.debug('Creating router with auth state: ${authState.isLoggedIn}');
+  // Use ref.read so the router is created once and never recreated on auth
+  // state changes. The refreshListenable handles redirect re-evaluation when
+  // auth state changes, and the redirect closure reads the current state each time.
+  final onboardingRepo = ref.read(onboardingRepositoryProvider);
 
   return GoRouter(
     initialLocation: AppRoutes.home,
     debugLogDiagnostics: true,
 
-    // Refresh router when auth state changes
+    // Re-evaluate redirect whenever auth state changes.
     refreshListenable: GoRouterRefreshStream(
-      ref.watch(authProvider.notifier).stream,
+      ref.read(authProvider.notifier).stream,
     ),
 
-    // Route guard for authentication and authorization
+    // Route guard for authentication and authorization.
+    // Always reads the latest auth state — do NOT capture it in the closure.
     redirect: (context, state) async {
       return await RouteGuard.redirect(
         context,
         state,
-        authState,
+        ref.read(authProvider),
         onboardingRepo,
       );
     },

--- a/lib/core/config/router/app_routes.dart
+++ b/lib/core/config/router/app_routes.dart
@@ -78,7 +78,7 @@ class AppRoutes {
   // ========== ROUTE CATEGORIES ==========
 
   /// Routes that don't require any authentication
-  static const Set<String> publicRoutes = {onboarding, login};
+  static const Set<String> publicRoutes = {login};
 
   /// Routes accessible to guest users (includes sub-routes automatically)
   static const Set<String> guestAccessibleRoutes = {

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -27,8 +27,15 @@ class StorageKeys {
   // ========== ONBOARDING ==========
   /// Onboarding preferences JSON
   static const String onboardingPreferences = 'onboarding_preferences';
-  /// Onboarding completion flag
+  /// Device-level onboarding completion flag (legacy / guest fallback)
   static const String onboardingCompleted = 'onboarding_completed';
+  /// Per-user onboarding completion key — one entry per user ID.
+  /// Use this to check/set completion for a specific account.
+  static String onboardingCompletedForUser(String userId) =>
+      'onboarding_completed_$userId';
+  /// ID of the currently logged-in user, written before the router fires
+  /// so the route guard can read the correct per-user onboarding key.
+  static const String currentUserId = 'current_user_id';
   /// Current onboarding step
   static const String onboardingStep = 'onboarding_step';
   /// Onboarding data JSON

--- a/lib/features/auth/presentation/providers/auth_notifier.dart
+++ b/lib/features/auth/presentation/providers/auth_notifier.dart
@@ -1,5 +1,9 @@
 // Riverpod provider and logic for authentication state.
+import 'dart:convert';
+
+import 'package:flutter_pecha/core/storage/storage_keys.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/core/utils/local_storage_service.dart';
 import 'package:flutter_pecha/features/auth/domain/entities/auth_credentials.dart';
 import 'package:flutter_pecha/features/auth/domain/usecases/clear_guest_mode_and_onboarding_usecase.dart';
 import 'package:flutter_pecha/features/auth/domain/usecases/clear_guest_mode_usecase.dart';
@@ -56,6 +60,22 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> _restoreLoginState() async {
     _logger.debug('Restoring login state');
 
+    // Detect fresh install or reinstall.
+    // iOS Keychain survives uninstall; SharedPreferences does not.
+    // If SP has no install marker, stale keychain tokens may exist from a
+    // previous install. Clear them so the user always sees the login screen
+    // on a clean install rather than being silently auto-logged in.
+    final isKnownInstall = await ref
+        .read(localStorageServiceProvider)
+        .get<bool>(StorageKeys.firstLaunch);
+    if (isKnownInstall == null) {
+      await _localLogoutUseCase(const NoParams());
+      await ref
+          .read(localStorageServiceProvider)
+          .set(StorageKeys.firstLaunch, true);
+      _logger.info('Fresh install detected — cleared stale keychain tokens');
+    }
+
     // Initialize auth
     final initResult = await _initializeAuthUseCase(const NoParams());
     initResult.fold(
@@ -88,35 +108,46 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> _restoreCredentials() async {
     final credentialsResult = await _getCredentialsUseCase(const NoParams());
+
+    // Extract result outside fold so we can await async operations below.
+    // fpdart's fold() is synchronous and will not await returned Futures.
+    AuthCredentials? credentials;
     credentialsResult.fold(
       (failure) {
         _logger.error('Failed to get credentials: ${failure.message}');
-        _checkGuestMode();
       },
-      (credentials) {
-        // Validate credentials were actually retrieved
-        if (credentials != null && credentials.idToken.isNotEmpty) {
-          state = state.copyWith(
-            isLoggedIn: true,
-            isLoading: false,
-            isGuest: false,
-            errorMessage: null,
-          );
-          _logger.info('Login state restored');
-
-          // Initialize user data
-          try {
-            ref.read(userProvider.notifier).initializeUser();
-          } catch (e) {
-            _logger.warning('Could not initialize user data', e);
-            // Non-critical, user can still use the app
-          }
-        } else {
-          _logger.debug('Credentials check returned null or invalid credentials');
-          _checkGuestMode();
-        }
-      },
+      (creds) => credentials = creds,
     );
+
+    if (credentials == null || credentials!.idToken.isEmpty) {
+      _logger.debug('Credentials check returned null or invalid credentials');
+      _checkGuestMode();
+      return;
+    }
+
+    // Store currentUserId BEFORE updating auth state so the route guard
+    // can check the per-user onboarding key when the router refreshes.
+    final userId = _extractUserIdFromToken(credentials!.idToken);
+    if (userId != null) {
+      await ref
+          .read(localStorageServiceProvider)
+          .set(StorageKeys.currentUserId, userId);
+      _logger.debug('Restored currentUserId for onboarding tracking');
+    }
+
+    state = state.copyWith(
+      isLoggedIn: true,
+      isLoading: false,
+      isGuest: false,
+      errorMessage: null,
+    );
+    _logger.info('Login state restored');
+
+    try {
+      ref.read(userProvider.notifier).initializeUser();
+    } catch (e) {
+      _logger.warning('Could not initialize user data', e);
+    }
   }
 
   Future<void> _checkGuestMode() async {
@@ -199,61 +230,64 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   Future<void> _handleSuccessfulLogin(AuthCredentials credentials) async {
-    // Check if user was previously in guest mode
-    final guestModeResult = await _isGuestModeUseCase(const NoParams());
-    guestModeResult.fold(
-      (failure) {
-        _logger.warning('Failed to check guest mode: ${failure.message}');
-      },
-      (wasPreviouslyGuest) {
-        final wasGuest = state.isGuest || wasPreviouslyGuest;
+    // 1. Clear the guest mode flag from storage before the router fires.
+    await _clearGuestMode();
 
-        // Clear guest mode when user authenticates
-        _clearGuestModeAndOnboarding(wasGuest);
-      },
-    );
+    // 2. Persist the user's ID before updating auth state.
+    //    The router refreshes the moment auth state changes, so currentUserId
+    //    must already be in storage when the route guard checks onboarding.
+    final userId = _extractUserIdFromToken(credentials.idToken);
+    if (userId != null) {
+      await ref
+          .read(localStorageServiceProvider)
+          .set(StorageKeys.currentUserId, userId);
+      _logger.debug('Stored currentUserId for onboarding tracking');
+    }
 
+    // 3. Update auth state — triggers the router refresh.
     state = state.copyWith(
       isLoggedIn: true,
       isLoading: false,
       isGuest: false,
       errorMessage: null,
     );
-    _logger.info('User authenticated, guest mode cleared');
+    _logger.info('User authenticated');
 
-    // Fetch and save user data from backend on first login
+    // 4. Fetch full user profile. Non-critical — routing is already correct.
     try {
       await ref.read(userProvider.notifier).initializeUser();
       _logger.info('User data fetched and saved locally');
     } catch (e) {
       _logger.warning('Failed to fetch user data: $e');
-      // Don't fail the login if user data fetch fails
     }
   }
 
-  Future<void> _clearGuestModeAndOnboarding(bool wasGuest) async {
-    final clearResult = await _clearGuestModeAndOnboardingUseCase(
-      ClearGuestModeAndOnboardingParams(wasGuest: wasGuest),
+  /// Clears the guest mode flag from storage.
+  /// Onboarding completion is intentionally NOT touched here — it is tracked
+  /// per user ID and must survive login/logout/guest transitions.
+  Future<void> _clearGuestMode() async {
+    final result = await _clearGuestModeAndOnboardingUseCase(
+      const ClearGuestModeAndOnboardingParams(wasGuest: false),
     );
-
-    clearResult.fold(
-      (failure) {
-        _logger.warning('Failed to clear guest mode and onboarding: ${failure.message}');
-      },
-      (_) {
-        _logger.debug('Guest mode and onboarding cleared');
-      },
+    result.fold(
+      (failure) =>
+          _logger.warning('Failed to clear guest mode: ${failure.message}'),
+      (_) => _logger.debug('Guest mode cleared'),
     );
+  }
 
-    // If user was a guest, clear onboarding completion so they see onboarding
-    if (wasGuest) {
-      try {
-        final onboardingRepo = ref.read(onboardingRepositoryProvider);
-        await onboardingRepo.clearPreferences();
-        _logger.info('Guest converted to authenticated user, onboarding reset');
-      } catch (e) {
-        _logger.warning('Failed to clear guest onboarding', e);
-      }
+  /// Extracts the user ID (sub claim) from a JWT ID token without verification.
+  /// Used only to identify the user for onboarding tracking — not for auth.
+  static String? _extractUserIdFromToken(String idToken) {
+    try {
+      final parts = idToken.split('.');
+      if (parts.length != 3) return null;
+      final payload = base64Url.decode(base64Url.normalize(parts[1]));
+      final claims =
+          jsonDecode(utf8.decode(payload)) as Map<String, dynamic>;
+      return claims['sub'] as String?;
+    } catch (_) {
+      return null;
     }
   }
 
@@ -294,24 +328,28 @@ class AuthNotifier extends StateNotifier<AuthState> {
       },
     );
 
-    // Clear user data on logout
+    // Clear user profile data and the stored user ID.
+    // Onboarding completion is NOT cleared — it persists per user ID
+    // so the user never sees onboarding again on re-login.
     await ref.read(userProvider.notifier).clearUser();
+    await ref
+        .read(localStorageServiceProvider)
+        .remove(StorageKeys.currentUserId);
 
     state = state.copyWith(
       isLoggedIn: false,
       isLoading: false,
       isGuest: false,
     );
-
     _logger.info('User logged out, auth and user state cleared');
   }
 
-  /// Completely clear all user data (use for account deletion or privacy reset)
+  /// Completely clear all user data (account deletion or privacy reset).
+  /// This is the only place where onboarding completion is reset.
   Future<void> clearAllUserData() async {
     try {
       await ref.read(userProvider.notifier).clearUser();
 
-      // Also clear onboarding preferences for complete reset
       final onboardingRepo = ref.read(onboardingRepositoryProvider);
       await onboardingRepo.clearPreferences();
 
@@ -321,13 +359,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
     }
   }
 
-  /// Reset onboarding status (for testing or manual reset)
-  /// This allows a user to go through onboarding again
+  /// Reset onboarding status (for testing or manual reset).
   Future<void> resetOnboarding() async {
     try {
       final onboardingRepo = ref.read(onboardingRepositoryProvider);
       await onboardingRepo.clearPreferences();
-      _logger.info('Onboarding status reset - user will see onboarding on next navigation');
+      _logger.info('Onboarding reset — user will see onboarding on next login');
     } catch (e) {
       _logger.warning('Failed to reset onboarding: $e');
     }

--- a/lib/features/onboarding/application/onboarding_notifier.dart
+++ b/lib/features/onboarding/application/onboarding_notifier.dart
@@ -97,33 +97,38 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
     }
   }
 
-  /// Submit preferences and complete onboarding.
-  Future<void> submitPreferences() async {
+  /// Submit preferences and mark onboarding as complete.
+  /// Returns true only when completion was successfully persisted to storage.
+  Future<bool> submitPreferences() async {
     state = state.copyWithLoading(true);
     try {
-      // Save preferences
       final saveResult = await _saveOnboardingPreferencesUseCase(
         SavePreferencesParams(preferences: state.preferences),
       );
       saveResult.fold(
         (failure) => _logger.error('Error saving preferences', failure),
-        (_) => _logger.debug('Preferences saved successfully'),
+        (_) => _logger.debug('Preferences saved'),
       );
 
-      // Complete onboarding
+      bool completed = false;
       final completeResult = await _completeOnboardingUseCase(const NoParams());
       completeResult.fold(
-        (failure) => _logger.error('Error completing onboarding', failure),
-        (_) => _logger.debug('Onboarding completed successfully'),
+        (failure) {
+          _logger.error('Error completing onboarding', failure);
+          state = state.copyWithError('Failed to save progress. Please try again.');
+        },
+        (_) {
+          _logger.debug('Onboarding completed');
+          completed = true;
+        },
       );
 
-      // TODO: Enable when API is ready — sync all preferences to backend
-      // Add a SyncPreferencesToRemoteUseCase and call it here.
-
       state = state.copyWithLoading(false);
+      return completed;
     } catch (e) {
       _logger.error('Error submitting preferences', e);
       state = state.copyWithLoading(false);
+      return false;
     }
   }
 

--- a/lib/features/onboarding/data/datasource/onboarding_local_datasource.dart
+++ b/lib/features/onboarding/data/datasource/onboarding_local_datasource.dart
@@ -40,27 +40,86 @@ class OnboardingLocalDatasource {
     }
   }
 
-  /// Clear preferences from local storage.
+  /// Clears all onboarding data for the current user.
+  /// Only called on account deletion — never on logout or guest transitions.
   Future<void> clearPreferences() async {
     await _localStorageService.remove(StorageKeys.onboardingPreferences);
     await _localStorageService.remove(StorageKeys.onboardingCompleted);
-    _logger.info('Preferences cleared');
+
+    final userId = await _localStorageService.get<String>(
+      StorageKeys.currentUserId,
+    );
+    if (userId != null && userId.isNotEmpty) {
+      await _localStorageService.remove(
+        StorageKeys.onboardingCompletedForUser(userId),
+      );
+    }
+    _logger.info('Onboarding data cleared');
   }
 
-  /// Check if onboarding has been completed.
+  /// Returns true if the current user has already completed onboarding.
+  ///
+  /// Checks the per-user key first (keyed by [StorageKeys.currentUserId]).
+  /// Falls back to the legacy device-level key and migrates it on first read,
+  /// so existing users are not asked to repeat onboarding after an update.
   Future<bool> hasCompletedOnboarding() async {
-    final completed = await _localStorageService.get<bool>(
-      StorageKeys.onboardingCompleted,
+    final userId = await _localStorageService.get<String>(
+      StorageKeys.currentUserId,
     );
-    return completed ?? false;
+
+    if (userId != null && userId.isNotEmpty) {
+      final userKey = StorageKeys.onboardingCompletedForUser(userId);
+      final perUserValue = await _localStorageService.get<bool>(userKey);
+
+      if (perUserValue != null) return perUserValue;
+
+      // One-time migration: promote the legacy device-level flag to the
+      // per-user key so existing users are not shown onboarding again.
+      // The legacy key is cleared after migration so it cannot be
+      // incorrectly adopted by a different user logging in later.
+      final legacy = await _localStorageService.get<bool>(
+        StorageKeys.onboardingCompleted,
+      );
+      if (legacy == true) {
+        await _localStorageService.set(userKey, true);
+        await _localStorageService.remove(StorageKeys.onboardingCompleted);
+        _logger.info('Migrated onboarding completion to per-user key');
+        return true;
+      }
+      return false;
+    }
+
+    // Fallback: no user ID in storage (safe default, should not occur
+    // after a normal login flow).
+    return await _localStorageService.get<bool>(
+          StorageKeys.onboardingCompleted,
+        ) ??
+        false;
   }
 
-  /// Mark onboarding as complete.
+  /// Marks onboarding as complete for the current user.
+  ///
+  /// Writes to the per-user key (primary) and the legacy device-level key
+  /// (kept for the backward-compatibility migration path).
   Future<void> markOnboardingComplete() async {
-    await _localStorageService.set<bool>(
-      StorageKeys.onboardingCompleted,
-      true,
+    final userId = await _localStorageService.get<String>(
+      StorageKeys.currentUserId,
     );
-    _logger.info('Onboarding marked complete');
+
+    if (userId != null && userId.isNotEmpty) {
+      await _localStorageService.set(
+        StorageKeys.onboardingCompletedForUser(userId),
+        true,
+      );
+    } else {
+      // Only write the legacy device-level key when no user ID is available.
+      // With per-user tracking active the legacy key is not needed and would
+      // cause false positives for other users via the migration path.
+      await _localStorageService.set<bool>(
+          StorageKeys.onboardingCompleted, true);
+    }
+    _logger.info(
+      'Onboarding marked complete${userId != null ? " for $userId" : ""}',
+    );
   }
 }

--- a/lib/features/onboarding/presentation/screens/onboarding_wrapper.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_wrapper.dart
@@ -35,11 +35,9 @@ class _OnboardingWrapperState extends ConsumerState<OnboardingWrapper> {
   }
 
   Future<void> _completeOnboarding() async {
-    // Submit onboarding preferences and mark as complete
-    await ref.read(onboardingProvider.notifier).submitPreferences();
-
-    // Navigate to home screen
-    if (mounted) {
+    // Only navigate if onboarding was successfully persisted.
+    final completed = await ref.read(onboardingProvider.notifier).submitPreferences();
+    if (mounted && completed) {
       context.go(RouteConfig.home);
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -977,26 +977,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1526,10 +1526,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
 fix: onboarding re-triggers on login (#213)                                                                                                                                   
                                                                                                                                                                                
  Root cause: on login, the app was calling clearPreferences() on the                                                                                                           
  onboarding repo whenever a guest session was active, wiping the                                                                                                               
  onboarding_completed flag and causing onboarding to re-show for                                                                                                               
  accounts that had already completed it.                             