### PR TITLE
Feat/event-enrolment

### DIFF
--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -192,7 +192,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               }
               return PlanDetails(
                 plan: plan,
-                selectedDay: selectedDay ?? 0,
+                selectedDay: selectedDay ?? 1,
                 startDate: startDate ?? DateTime.now(),
               );
             },
@@ -237,7 +237,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   }
                   return PlanDetails(
                     plan: plan,
-                    selectedDay: selectedDay ?? 0,
+                    selectedDay: selectedDay ?? 1,
                     startDate: startDate ?? DateTime.now(),
                   );
                 },

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/features/home/presentation/screens/main_navigation_screen.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
@@ -60,6 +61,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       _log.warning(
         'NotificationService not initialized, skipping permission request',
       );
+      _navigateToPendingPlanIfNeeded();
       return;
     }
 
@@ -77,6 +79,37 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     } catch (e) {
       _log.warning('Error requesting notification permissions: $e');
     }
+
+    // After the permission flow (dialog shown or already granted), check
+    // whether onboarding left a plan waiting to be opened in Practice.
+    _navigateToPendingPlanIfNeeded();
+  }
+
+  /// Consumes [pendingOnboardingPlanProvider] and navigates to the Practice
+  /// tab + plan detail screen. Called once, right after notification setup.
+  void _navigateToPendingPlanIfNeeded() {
+    if (!mounted) return;
+    final plan = ref.read(pendingOnboardingPlanProvider);
+    if (plan == null) return;
+
+    // Clear immediately so back-navigation never re-triggers this.
+    ref.read(pendingOnboardingPlanProvider.notifier).state = null;
+
+    // Push plan details FIRST while HomeScreen is still mounted.
+    // Switching the tab index BEFORE the push would unmount HomeScreen,
+    // making the subsequent context.push a no-op.
+    context.push(
+      '/practice/details',
+      extra: {
+        'plan': plan,
+        'selectedDay': 1,
+        'startDate': plan.startedAt,
+      },
+    );
+
+    // Switch bottom-nav to Practice so popping back from plan details
+    // lands on the Practice tab rather than Home.
+    ref.read(mainNavigationIndexProvider.notifier).state = 2;
   }
 
   /// Manual refetch/retry method that can be called from UI

--- a/lib/features/home/presentation/screens/main_navigation_screen.dart
+++ b/lib/features/home/presentation/screens/main_navigation_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/features/connect/presentation/screens/connect_screen.dart';
@@ -11,6 +12,12 @@ import 'package:flutter_pecha/shared/widgets/appBottomNavBar/app_bottom_nav_item
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final mainNavigationIndexProvider = StateProvider<int>((ref) => 0);
+
+/// Holds an enrolled plan that should be opened after the home screen's
+/// notification-permission flow completes. Set during onboarding completion,
+/// consumed once by [HomeScreen], and cleared immediately after navigation.
+final pendingOnboardingPlanProvider =
+    StateProvider<UserPlansModel?>((ref) => null);
 
 class MainNavigationScreen extends ConsumerWidget {
   const MainNavigationScreen({super.key});

--- a/lib/features/notifications/data/channels/notification_channels.dart
+++ b/lib/features/notifications/data/channels/notification_channels.dart
@@ -42,6 +42,9 @@ class NotificationChannels {
   /// Full platform-specific NotificationDetails for routine block notifications.
   static NotificationDetails routineBlockDetails({
     String icon = 'ic_notification',
+    StyleInformation? styleInformation,
+    FilePathAndroidBitmap? largeIcon,
+    DarwinNotificationDetails? iOSDetails,
   }) =>
       NotificationDetails(
         android: AndroidNotificationDetails(
@@ -50,12 +53,14 @@ class NotificationChannels {
           channelDescription: routineBlockDescription,
           importance: Importance.high,
           priority: Priority.high,
+          styleInformation: styleInformation,
           icon: icon,
+          largeIcon: largeIcon,
           enableVibration: true,
           playSound: true,
           sound: routineAndroidSound,
         ),
-        iOS: DarwinNotificationDetails(
+        iOS: iOSDetails ?? DarwinNotificationDetails(
           sound: routineIosSoundFile,
           presentAlert: true,
           presentBadge: true,

--- a/lib/features/notifications/data/services/routine_notification_service.dart
+++ b/lib/features/notifications/data/services/routine_notification_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/data/channels/notification_channels.dart';
 import 'package:flutter_pecha/features/notifications/data/services/notification_service.dart';
 import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:timezone/timezone.dart' as tz;
 
 final _logger = AppLogger('RoutineNotificationService');
@@ -125,12 +127,21 @@ class RoutineNotificationService {
           ? jsonEncode({'itemId': firstItem.id, 'itemType': firstItem.type.name})
           : null;
 
+      // Add image support
+      final androidStyle = await _buildBigPictureStyle(firstItem);
+      final iosDetails = await _buildIOSNotificationDetails(firstItem);
+      final largeIcon = await _getLargeIcon(firstItem);
+
       await _plugin.zonedSchedule(
         block.notificationId,
-        'Time for your practice',
+        firstItem?.title ?? 'Time for your practice',
         body,
         scheduledDate,
-        NotificationChannels.routineBlockDetails(),
+        NotificationChannels.routineBlockDetails(
+          styleInformation: androidStyle,
+          largeIcon: largeIcon,
+          iOSDetails: iosDetails,
+        ),
         androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
         matchDateTimeComponents: DateTimeComponents.time,
         payload: payload,
@@ -256,5 +267,117 @@ class RoutineNotificationService {
     if (remaining == 1) return '$firstItem and 1 other';
     if (remaining > 1) return '$firstItem and $remaining others';
     return firstItem;
+  }
+
+  /// Builds Android BigPictureStyle for rich image notifications.
+  Future<StyleInformation> _buildBigPictureStyle(RoutineItem? item) async {
+    if (item == null || item.imageUrl == null || item.imageUrl!.isEmpty) {
+      return BigTextStyleInformation(
+        item?.title ?? 'Time for your practice',
+        htmlFormatBigText: true,
+        contentTitle: item?.title,
+        htmlFormatContentTitle: true,
+      );
+    }
+
+    try {
+      final imagePath = await _downloadAndCacheImage(item.imageUrl!);
+      if (imagePath != null) {
+        return BigPictureStyleInformation(
+          FilePathAndroidBitmap(imagePath),
+          largeIcon: await _getLargeIcon(item),
+          contentTitle: item.title,
+          summaryText: 'Time for your practice',
+          htmlFormatContentTitle: true,
+          htmlFormatSummaryText: true,
+        );
+      }
+    } catch (e) {
+      _logger.warning('Failed to load image for notification: $e');
+    }
+
+    return BigTextStyleInformation(
+      item.title,
+      htmlFormatBigText: true,
+      contentTitle: item.title,
+      htmlFormatContentTitle: true,
+    );
+  }
+
+  /// Builds iOS notification details with attachments.
+  Future<DarwinNotificationDetails> _buildIOSNotificationDetails(
+    RoutineItem? item,
+  ) async {
+    if (item?.imageUrl != null && item!.imageUrl!.isNotEmpty) {
+      try {
+        final imagePath = await _downloadAndCacheImage(item.imageUrl!);
+        if (imagePath != null) {
+          return DarwinNotificationDetails(
+            attachments: [DarwinNotificationAttachment(imagePath)],
+            threadIdentifier: 'routine_notifications',
+          );
+        }
+      } catch (e) {
+        _logger.warning('Failed to attach image for iOS notification: $e');
+      }
+    }
+
+    return const DarwinNotificationDetails(
+      threadIdentifier: 'routine_notifications',
+    );
+  }
+
+  /// Downloads and caches an image URL to local storage.
+  Future<String?> _downloadAndCacheImage(String imageUrl) async {
+    try {
+      // Generate a safe filename using hash to avoid length issues
+      final imageHash = imageUrl.hashCode.toString();
+      final extension = imageUrl.contains('.jpg') ? '.jpg' :
+                       imageUrl.contains('.png') ? '.png' : '.jpg';
+      final filename = 'notif_$imageHash$extension';
+
+      final directory = await getTemporaryDirectory();
+      final filePath = '${directory.path}/notification_images/$filename';
+
+      // Check if already cached
+      final file = File(filePath);
+      if (await file.exists()) {
+        return filePath;
+      }
+
+      // Create directory if it doesn't exist
+      await file.parent.create(recursive: true);
+
+      // Download the image
+      final request = await HttpClient().getUrl(Uri.parse(imageUrl));
+      final response = await request.close();
+
+      if (response.statusCode == 200) {
+        final bytes = await response.toList();
+        await file.writeAsBytes(bytes.expand((b) => b).toList());
+        return filePath;
+      }
+    } catch (e) {
+      _logger.warning('Error downloading image: $e');
+    }
+    return null;
+  }
+
+  /// Gets the large icon for Android notification.
+  Future<FilePathAndroidBitmap?> _getLargeIcon(RoutineItem? item) async {
+    if (item?.imageUrl == null || item!.imageUrl!.isEmpty) {
+      return null;
+    }
+
+    try {
+      final imagePath = await _downloadAndCacheImage(item.imageUrl!);
+      if (imagePath != null) {
+        return FilePathAndroidBitmap(imagePath);
+      }
+    } catch (e) {
+      _logger.warning('Failed to load large icon: $e');
+    }
+
+    return null;
   }
 }

--- a/lib/features/onboarding/application/event_enrollment_service.dart
+++ b/lib/features/onboarding/application/event_enrollment_service.dart
@@ -5,21 +5,30 @@ import 'package:flutter_pecha/features/plans/domain/usecases/user_plans_usecases
 import 'package:flutter_pecha/features/practice/data/models/routine_api_models.dart';
 import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
 import 'package:flutter_pecha/features/practice/domain/usecases/routine_api_usecases.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_api_providers.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Coordinates the two-step event enrollment:
+/// Coordinates event enrollment during onboarding:
 ///   1. Subscribe the user to the plan via `POST /users/me/plans`
-///   2. Add the plan to the user's daily routine at 09:00 AM
-///   3. Return the enrolled [UserPlansModel] for post-onboarding navigation
+///   2. Add the plan to the user's daily routine at 09:00 AM (server)
+///   3. Persist the resulting routine to local Hive AND schedule device-local
+///      notifications via [RoutineNotifier.saveRoutine] — exactly like
+///      `edit_routine_screen` does on save. Without this step the server has
+///      the time block but the device has no AlarmManager entry, so the
+///      9:00 AM reminder never fires.
+///   4. Return the enrolled [UserPlansModel] for post-onboarding navigation
 ///
-/// Both subscription and time-block creation are best-effort and idempotent:
-/// if the user is already enrolled or a time-block conflict exists, we log
-/// and continue rather than surfacing an error.
+/// Subscription and time-block creation are best-effort and idempotent: if
+/// the user is already enrolled or a time-block conflict exists, we log and
+/// continue rather than surfacing an error.
 class EventEnrollmentService {
   final SubscribeToPlanUseCase _subscribeToPlanUseCase;
   final GetUserRoutineUseCase _getUserRoutineUseCase;
   final CreateRoutineWithTimeBlockUseCase _createRoutineWithTimeBlockUseCase;
   final CreateTimeBlockUseCase _createTimeBlockUseCase;
   final GetUserPlansUseCase _getUserPlansUseCase;
+  final Ref _ref;
 
   final _logger = AppLogger('EventEnrollmentService');
 
@@ -29,11 +38,13 @@ class EventEnrollmentService {
     required CreateRoutineWithTimeBlockUseCase createRoutineWithTimeBlockUseCase,
     required CreateTimeBlockUseCase createTimeBlockUseCase,
     required GetUserPlansUseCase getUserPlansUseCase,
+    required Ref ref,
   })  : _subscribeToPlanUseCase = subscribeToPlanUseCase,
         _getUserRoutineUseCase = getUserRoutineUseCase,
         _createRoutineWithTimeBlockUseCase = createRoutineWithTimeBlockUseCase,
         _createTimeBlockUseCase = createTimeBlockUseCase,
-        _getUserPlansUseCase = getUserPlansUseCase;
+        _getUserPlansUseCase = getUserPlansUseCase,
+        _ref = ref;
 
   /// Enrolls the user in all [planIds] and returns the resulting [UserPlansModel]
   /// list (those that were found in the user's plan list after enrollment).
@@ -45,6 +56,11 @@ class EventEnrollmentService {
       await _subscribeToPlan(planId);
       await _addToRoutine(planId);
     }
+
+    // Mirror the practice-tab edit-routine save flow: persist the final
+    // server routine to Hive and schedule device-local notifications.
+    await _persistRoutineLocallyAndScheduleNotifications();
+
     return _fetchEnrolledPlans(planIds);
   }
 
@@ -120,7 +136,43 @@ class EventEnrollmentService {
     }
   }
 
-  // ─── Step 3: Fetch enrolled plan models ───
+  // ─── Step 3: Persist routine to Hive + schedule local notifications ───
+
+  /// Re-fetches the routine from the server (now includes the newly-added
+  /// time blocks) and routes it through [RoutineNotifier.saveRoutine] which:
+  ///   - persists blocks to Hive (so startup sync works on next app launch),
+  ///   - calls [RoutineNotificationService.syncNotifications] which schedules
+  ///     a daily AlarmManager / flutter_local_notifications entry per block.
+  ///
+  /// Also invalidates [userRoutineProvider] so any UI watching it refreshes.
+  Future<void> _persistRoutineLocallyAndScheduleNotifications() async {
+    final routineResult = await _getUserRoutineUseCase();
+    final routineData = routineResult.fold((_) => null, (data) => data);
+
+    if (routineData == null || routineData.blocks.isEmpty) {
+      _logger.warning(
+        'No routine returned after enrollment — skipping local persist & notification scheduling',
+      );
+      return;
+    }
+
+    try {
+      _logger.info(
+        '[ONBOARD-SAVE] persisting ${routineData.blocks.length} blocks to Hive + scheduling notifications',
+      );
+      await _ref.read(routineProvider.notifier).saveRoutine(routineData.blocks);
+      _ref.invalidate(userRoutineProvider);
+      _logger.info('[ONBOARD-SAVE] done');
+    } catch (e, st) {
+      _logger.error(
+        '[ONBOARD-SAVE] failed to persist routine / schedule notifications',
+        e,
+        st,
+      );
+    }
+  }
+
+  // ─── Step 4: Fetch enrolled plan models ───
 
   Future<List<UserPlansModel>> _fetchEnrolledPlans(List<String> planIds) async {
     final result = await _getUserPlansUseCase(

--- a/lib/features/onboarding/application/event_enrollment_service.dart
+++ b/lib/features/onboarding/application/event_enrollment_service.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/plans/data/models/response/user_plan_list_response_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+import 'package:flutter_pecha/features/plans/domain/usecases/user_plans_usecases.dart';
+import 'package:flutter_pecha/features/practice/data/models/routine_api_models.dart';
+import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
+import 'package:flutter_pecha/features/practice/domain/usecases/routine_api_usecases.dart';
+
+/// Coordinates the two-step event enrollment:
+///   1. Subscribe the user to the plan via `POST /users/me/plans`
+///   2. Add the plan to the user's daily routine at 09:00 AM
+///   3. Return the enrolled [UserPlansModel] for post-onboarding navigation
+///
+/// Both subscription and time-block creation are best-effort and idempotent:
+/// if the user is already enrolled or a time-block conflict exists, we log
+/// and continue rather than surfacing an error.
+class EventEnrollmentService {
+  final SubscribeToPlanUseCase _subscribeToPlanUseCase;
+  final GetUserRoutineUseCase _getUserRoutineUseCase;
+  final CreateRoutineWithTimeBlockUseCase _createRoutineWithTimeBlockUseCase;
+  final CreateTimeBlockUseCase _createTimeBlockUseCase;
+  final GetUserPlansUseCase _getUserPlansUseCase;
+
+  final _logger = AppLogger('EventEnrollmentService');
+
+  EventEnrollmentService({
+    required SubscribeToPlanUseCase subscribeToPlanUseCase,
+    required GetUserRoutineUseCase getUserRoutineUseCase,
+    required CreateRoutineWithTimeBlockUseCase createRoutineWithTimeBlockUseCase,
+    required CreateTimeBlockUseCase createTimeBlockUseCase,
+    required GetUserPlansUseCase getUserPlansUseCase,
+  })  : _subscribeToPlanUseCase = subscribeToPlanUseCase,
+        _getUserRoutineUseCase = getUserRoutineUseCase,
+        _createRoutineWithTimeBlockUseCase = createRoutineWithTimeBlockUseCase,
+        _createTimeBlockUseCase = createTimeBlockUseCase,
+        _getUserPlansUseCase = getUserPlansUseCase;
+
+  /// Enrolls the user in all [planIds] and returns the resulting [UserPlansModel]
+  /// list (those that were found in the user's plan list after enrollment).
+  ///
+  /// Throws a descriptive [Exception] if a critical step fails and the UI
+  /// should surface an error to the user.
+  Future<List<UserPlansModel>> enrollInEvents(List<String> planIds) async {
+    for (final planId in planIds) {
+      await _subscribeToPlan(planId);
+      await _addToRoutine(planId);
+    }
+    return _fetchEnrolledPlans(planIds);
+  }
+
+  // ─── Step 1: Subscribe ───
+
+  Future<void> _subscribeToPlan(String planId) async {
+    final result = await _subscribeToPlanUseCase(
+      SubscribeToPlanParams(planId: planId),
+    );
+    result.fold(
+      (failure) {
+        // Treat all subscription failures as warnings — the user may already
+        // be enrolled from a previous onboarding attempt.
+        _logger.warning('subscribe plan $planId: ${failure.message} (continuing)');
+      },
+      (_) => _logger.info('Subscribed to plan $planId'),
+    );
+  }
+
+  // ─── Step 2: Add to routine at 09:00 ───
+
+  Future<void> _addToRoutine(String planId) async {
+    final routineResult = await _getUserRoutineUseCase();
+    final routineData = routineResult.fold((_) => null, (data) => data);
+    final routineId = routineData?.apiRoutineId;
+
+    // Check if plan is already in routine to avoid duplicate time blocks
+    if (routineData != null) {
+      final alreadyInRoutine = routineData.blocks.any(
+        (block) => block.items.any(
+          (item) => item.id == planId && item.type == RoutineItemType.plan,
+        ),
+      );
+      if (alreadyInRoutine) {
+        _logger.info('Plan $planId already in routine, skipping time block creation');
+        return;
+      }
+    }
+
+    final request = TimeBlockRequest(
+      time: '09:00',
+      timeInt: 900,
+      notificationEnabled: true,
+      sessions: [
+        SessionRequest(
+          sessionType: SessionType.plan,
+          sourceId: planId,
+          displayOrder: 0,
+        ),
+      ],
+    );
+
+    if (routineId != null) {
+      final result = await _createTimeBlockUseCase(routineId, request);
+      result.fold(
+        (failure) => _logger.warning(
+          'create time-block for $planId: ${failure.message} (continuing)',
+        ),
+        (_) => _logger.info('Time block created at 09:00 for plan $planId'),
+      );
+    } else {
+      final result = await _createRoutineWithTimeBlockUseCase(request);
+      result.fold(
+        (failure) {
+          // ValidationFailure here likely means routine already exists (race).
+          // Not fatal — the subscription already succeeded.
+          _logger.warning(
+            'create routine+time-block for $planId: ${failure.message} (continuing)',
+          );
+        },
+        (_) => _logger.info('Routine created with 09:00 block for plan $planId'),
+      );
+    }
+  }
+
+  // ─── Step 3: Fetch enrolled plan models ───
+
+  Future<List<UserPlansModel>> _fetchEnrolledPlans(List<String> planIds) async {
+    final result = await _getUserPlansUseCase(
+      const GetUserPlansParams(language: 'en', skip: 0, limit: 50),
+    );
+
+    return result.fold(
+      (failure) {
+        _logger.warning('fetch user plans after enrollment: ${failure.message}');
+        // Return empty — enrollment succeeded, navigation will fall back gracefully.
+        return [];
+      },
+      (response) => _filterEnrolledPlans(response, planIds),
+    );
+  }
+
+  List<UserPlansModel> _filterEnrolledPlans(
+    UserPlanListResponseModel response,
+    List<String> planIds,
+  ) {
+    final planSet = planIds.toSet();
+    return response.userPlans.where((p) => planSet.contains(p.id)).toList();
+  }
+}

--- a/lib/features/onboarding/application/onboarding_notifier.dart
+++ b/lib/features/onboarding/application/onboarding_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/onboarding/application/onboarding_state.dart';
 import 'package:flutter_pecha/features/onboarding/domain/usecases/onboarding_usecases.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/shared/domain/base_classes/usecase.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -130,6 +131,15 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
       state = state.copyWithLoading(false);
       return false;
     }
+  }
+
+  /// Records plans enrolled from the onboarding event page.
+  /// Persists plan IDs to preferences and stores the full models for post-onboarding navigation.
+  Future<void> setEnrolledPlans(List<UserPlansModel> plans) async {
+    final planIds = plans.map((p) => p.id).toList();
+    final updatedPrefs = state.preferences.copyWith(enrolledEventPlanIds: planIds);
+    state = state.copyWith(preferences: updatedPrefs, enrolledPlans: plans);
+    await _savePreferences();
   }
 
   /// Clear all preferences and reset state.

--- a/lib/features/onboarding/application/onboarding_state.dart
+++ b/lib/features/onboarding/application/onboarding_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_pecha/features/onboarding/domain/entities/onboarding_preferences.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 
 /// State for onboarding flow management
 class OnboardingState {
@@ -7,12 +8,17 @@ class OnboardingState {
     required this.currentPage,
     required this.isLoading,
     this.error,
+    this.enrolledPlans = const [],
   });
 
   final OnboardingPreferences preferences;
   final int currentPage;
   final bool isLoading;
   final String? error;
+
+  /// Plans enrolled from the event page. Transient — used only for post-onboarding
+  /// navigation to the plan detail screen. Not persisted beyond this session.
+  final List<UserPlansModel> enrolledPlans;
 
   /// Initial state
   factory OnboardingState.initial() {
@@ -33,6 +39,7 @@ class OnboardingState {
       currentPage: currentPage,
       isLoading: loading,
       error: error,
+      enrolledPlans: enrolledPlans,
     );
   }
 
@@ -43,6 +50,7 @@ class OnboardingState {
       currentPage: currentPage,
       isLoading: false,
       error: null,
+      enrolledPlans: enrolledPlans,
     );
   }
 
@@ -53,6 +61,7 @@ class OnboardingState {
       currentPage: currentPage,
       isLoading: false,
       error: errorMessage,
+      enrolledPlans: enrolledPlans,
     );
   }
 
@@ -63,6 +72,7 @@ class OnboardingState {
       currentPage: page,
       isLoading: isLoading,
       error: error,
+      enrolledPlans: enrolledPlans,
     );
   }
 
@@ -72,12 +82,14 @@ class OnboardingState {
     int? currentPage,
     bool? isLoading,
     String? error,
+    List<UserPlansModel>? enrolledPlans,
   }) {
     return OnboardingState(
       preferences: preferences ?? this.preferences,
       currentPage: currentPage ?? this.currentPage,
       isLoading: isLoading ?? this.isLoading,
       error: error ?? this.error,
+      enrolledPlans: enrolledPlans ?? this.enrolledPlans,
     );
   }
 

--- a/lib/features/onboarding/domain/entities/onboarding_preferences.dart
+++ b/lib/features/onboarding/domain/entities/onboarding_preferences.dart
@@ -1,6 +1,35 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_pecha/shared/domain/entities/base_entity.dart';
 
+/// A hardcoded event shown on the onboarding event page.
+class OnboardingEventPlan {
+  final String planId;
+  final String eventLabel;
+  final String planName;
+  final String description;
+  final int totalDays;
+
+  const OnboardingEventPlan({
+    required this.planId,
+    required this.eventLabel,
+    required this.planName,
+    required this.description,
+    required this.totalDays,
+  });
+}
+
+/// All events shown on the onboarding event selection page.
+/// Add more entries here as new events are launched.
+const kOnboardingEvents = <OnboardingEventPlan>[
+  OnboardingEventPlan(
+    planId: 'b42c9270-8bc9-4a98-b375-924a948ab18e',
+    eventLabel: 'ITCC',
+    planName: 'Abhidhamma in a Year',
+    description: 'Daily Abhidhamma study over 8 days',
+    totalDays: 8,
+  ),
+];
+
 /// Onboarding preferences entity.
 class OnboardingPreferences extends BaseEntity {
   final String userId;
@@ -11,6 +40,10 @@ class OnboardingPreferences extends BaseEntity {
   final DateTime completedAt;
   final List<String> selectedPaths;
 
+  /// Plan IDs the user opted into from the onboarding event page.
+  /// Empty when the user skipped or unchecked all events.
+  final List<String> enrolledEventPlanIds;
+
   const OnboardingPreferences({
     required this.userId,
     this.interests = const [],
@@ -19,6 +52,7 @@ class OnboardingPreferences extends BaseEntity {
     this.preferredPracticeTypes = const [],
     required this.completedAt,
     this.selectedPaths = const [],
+    this.enrolledEventPlanIds = const [],
   });
 
   /// Creates a copy with the specified fields replaced with new values
@@ -30,6 +64,7 @@ class OnboardingPreferences extends BaseEntity {
     List<String>? preferredPracticeTypes,
     DateTime? completedAt,
     List<String>? selectedPaths,
+    List<String>? enrolledEventPlanIds,
   }) {
     return OnboardingPreferences(
       userId: userId ?? this.userId,
@@ -39,6 +74,7 @@ class OnboardingPreferences extends BaseEntity {
       preferredPracticeTypes: preferredPracticeTypes ?? this.preferredPracticeTypes,
       completedAt: completedAt ?? this.completedAt,
       selectedPaths: selectedPaths ?? this.selectedPaths,
+      enrolledEventPlanIds: enrolledEventPlanIds ?? this.enrolledEventPlanIds,
     );
   }
 
@@ -51,6 +87,7 @@ class OnboardingPreferences extends BaseEntity {
     preferredPracticeTypes,
     completedAt,
     selectedPaths,
+    enrolledEventPlanIds,
   ];
 }
 

--- a/lib/features/onboarding/presentation/providers/event_enrollment_providers.dart
+++ b/lib/features/onboarding/presentation/providers/event_enrollment_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_pecha/features/onboarding/application/event_enrollment_service.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/use_case_providers.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_api_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the [EventEnrollmentService] wired up with all required use cases.
+final eventEnrollmentServiceProvider = Provider<EventEnrollmentService>((ref) {
+  return EventEnrollmentService(
+    subscribeToPlanUseCase: ref.read(subscribeToPlanUseCaseProvider),
+    getUserRoutineUseCase: ref.read(getUserRoutineUseCaseProvider),
+    createRoutineWithTimeBlockUseCase: ref.read(createRoutineWithTimeBlockUseCaseProvider),
+    createTimeBlockUseCase: ref.read(createTimeBlockUseCaseProvider),
+    getUserPlansUseCase: ref.read(getUserPlansUseCaseProvider),
+  );
+});

--- a/lib/features/onboarding/presentation/providers/event_enrollment_providers.dart
+++ b/lib/features/onboarding/presentation/providers/event_enrollment_providers.dart
@@ -11,5 +11,6 @@ final eventEnrollmentServiceProvider = Provider<EventEnrollmentService>((ref) {
     createRoutineWithTimeBlockUseCase: ref.read(createRoutineWithTimeBlockUseCaseProvider),
     createTimeBlockUseCase: ref.read(createTimeBlockUseCaseProvider),
     getUserPlansUseCase: ref.read(getUserPlansUseCaseProvider),
+    ref: ref,
   );
 });

--- a/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
@@ -1,0 +1,368 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/features/onboarding/application/onboarding_provider.dart';
+import 'package:flutter_pecha/features/onboarding/domain/entities/onboarding_preferences.dart';
+import 'package:flutter_pecha/features/onboarding/presentation/providers/event_enrollment_providers.dart';
+import 'package:flutter_pecha/features/onboarding/presentation/widgets/onboarding_back_button.dart';
+import 'package:flutter_pecha/features/onboarding/presentation/widgets/onboarding_question_title.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Onboarding event page: lets the user opt into upcoming Buddhist events.
+/// Each event maps to a plan that gets auto-enrolled with a 9:00 AM time block.
+class OnboardingScreenEvent extends ConsumerStatefulWidget {
+  const OnboardingScreenEvent({
+    super.key,
+    required this.onNext,
+    required this.onBack,
+  });
+
+  final VoidCallback onNext;
+  final VoidCallback onBack;
+
+  @override
+  ConsumerState<OnboardingScreenEvent> createState() =>
+      _OnboardingScreenEventState();
+}
+
+class _OnboardingScreenEventState extends ConsumerState<OnboardingScreenEvent> {
+  /// Plan IDs currently checked by the user. All events are checked by default.
+  late Set<String> _checkedPlanIds;
+
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkedPlanIds = {for (final e in kOnboardingEvents) e.planId};
+  }
+
+  void _toggleEvent(String planId) {
+    setState(() {
+      if (_checkedPlanIds.contains(planId)) {
+        _checkedPlanIds.remove(planId);
+      } else {
+        _checkedPlanIds.add(planId);
+      }
+      _errorMessage = null;
+    });
+  }
+
+  Future<void> _handleContinue() async {
+    if (_isLoading) return;
+
+    // If nothing selected, just advance — enrollment is optional.
+    if (_checkedPlanIds.isEmpty) {
+      widget.onNext();
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final service = ref.read(eventEnrollmentServiceProvider);
+      final enrolledPlans = await service.enrollInEvents(_checkedPlanIds.toList());
+
+      await ref.read(onboardingProvider.notifier).setEnrolledPlans(enrolledPlans);
+
+      if (mounted) widget.onNext();
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'Could not enroll. Please check your connection and try again.';
+        });
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 24),
+              OnboardingBackButton(onBack: widget.onBack),
+              const SizedBox(height: 40),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const OnboardingQuestionTitle(
+                        title: 'Join an\nupcoming event?',
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Optional · Uncheck to skip',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w400,
+                          letterSpacing: -0.2,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.5),
+                        ),
+                      ),
+                      const SizedBox(height: 36),
+                      ...kOnboardingEvents.map(
+                        (event) => _EventCard(
+                          event: event,
+                          isSelected: _checkedPlanIds.contains(event.planId),
+                          isDark: isDark,
+                          onTap: () => _toggleEvent(event.planId),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      _ReminderNote(isDark: isDark),
+                      if (_errorMessage != null) ...[
+                        const SizedBox(height: 16),
+                        Text(
+                          _errorMessage!,
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Theme.of(context).colorScheme.error,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                      const Spacer(),
+                      Center(child: _ContinueButton(
+                        isLoading: _isLoading,
+                        onPressed: _handleContinue,
+                      )),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Private widgets ───
+
+class _EventCard extends StatelessWidget {
+  const _EventCard({
+    required this.event,
+    required this.isSelected,
+    required this.isDark,
+    required this.onTap,
+  });
+
+  final OnboardingEventPlan event;
+  final bool isSelected;
+  final bool isDark;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = isSelected
+        ? AppColors.primary
+        : (isDark ? AppColors.greyMedium : const Color(0xFFE0E0E0));
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: borderColor,
+              width: isSelected ? 2 : 1.5,
+            ),
+            color: isSelected
+                ? AppColors.primary.withValues(alpha: isDark ? 0.12 : 0.06)
+                : Colors.transparent,
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Event badge
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.primary.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        event.eventLabel.toUpperCase(),
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.6,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    // Plan name
+                    Text(
+                      event.planName,
+                      style: TextStyle(
+                        fontSize: 17,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: -0.3,
+                        color: isDark
+                            ? AppColors.textPrimaryDark
+                            : AppColors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    // Description + duration
+                    Text(
+                      '${event.description} · ${event.totalDays} days',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w400,
+                        color: isDark
+                            ? AppColors.textTertiaryDark
+                            : AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              _Checkbox(isSelected: isSelected),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Checkbox extends StatelessWidget {
+  const _Checkbox({required this.isSelected});
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isSelected ? AppColors.primary : AppColors.greyMedium,
+          width: 2,
+        ),
+        color: isSelected ? AppColors.primary : Colors.transparent,
+      ),
+      child: isSelected
+          ? const Center(
+              child: Icon(Icons.check, size: 14, color: Colors.white),
+            )
+          : null,
+    );
+  }
+}
+
+class _ReminderNote extends StatelessWidget {
+  const _ReminderNote({required this.isDark});
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          Icons.notifications_outlined,
+          size: 16,
+          color: isDark ? AppColors.textTertiaryDark : AppColors.textSecondary,
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            'Selected events will be added to your practice with a 9:00 AM daily reminder.',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w400,
+              height: 1.5,
+              color: isDark
+                  ? AppColors.textTertiaryDark
+                  : AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ContinueButton extends StatelessWidget {
+  const _ContinueButton({required this.isLoading, required this.onPressed});
+  final bool isLoading;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.6,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: isLoading ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: AppColors.primary.withValues(alpha: 0.6),
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 16),
+        ),
+        child: isLoading
+            ? const SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.5,
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+              )
+            : const Text(
+                'Continue',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -0.306,
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/screens/onboarding_wrapper.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_wrapper.dart
@@ -1,15 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/config/router/route_config.dart';
+import 'package:flutter_pecha/features/home/presentation/screens/main_navigation_screen.dart';
 import 'package:flutter_pecha/features/onboarding/application/onboarding_provider.dart';
 import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_screen_1.dart';
 import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_screen_3.dart';
 import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_screen_4.dart';
 import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_screen_5.dart';
+import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_screen_event.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:go_router/go_router.dart';
-import 'package:flutter_pecha/core/config/router/route_config.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Wrapper for onboarding screens with Riverpod state management
-/// Manages navigation between multiple onboarding screens
+/// Wrapper for onboarding screens with Riverpod state management.
+/// Page order:
+///   0 – Welcome
+///   1 – Language
+///   2 – Tradition
+///   3 – Events (new)
+///   4 – Finish / "Begin Your Practice"
 class OnboardingWrapper extends ConsumerStatefulWidget {
   const OnboardingWrapper({super.key});
 
@@ -35,11 +43,24 @@ class _OnboardingWrapperState extends ConsumerState<OnboardingWrapper> {
   }
 
   Future<void> _completeOnboarding() async {
-    // Only navigate if onboarding was successfully persisted.
-    final completed = await ref.read(onboardingProvider.notifier).submitPreferences();
-    if (mounted && completed) {
-      context.go(RouteConfig.home);
+    final completed =
+        await ref.read(onboardingProvider.notifier).submitPreferences();
+    if (!mounted || !completed) return;
+
+    // Grab enrolled plans before navigating away (state will be invalidated).
+    final enrolledPlans =
+        List<UserPlansModel>.from(ref.read(onboardingProvider).enrolledPlans);
+
+    // If the user enrolled in events, store the first plan as a pending
+    // navigation target. HomeScreen will pick this up after the notification-
+    // permission flow completes, then switch to the Practice tab and open the
+    // plan detail. This ensures the system notification dialog is shown first.
+    if (enrolledPlans.isNotEmpty) {
+      ref.read(pendingOnboardingPlanProvider.notifier).state =
+          enrolledPlans.first;
     }
+
+    if (mounted) context.go(RouteConfig.home);
   }
 
   @override
@@ -48,29 +69,26 @@ class _OnboardingWrapperState extends ConsumerState<OnboardingWrapper> {
       onboardingProvider.select((state) => state.currentPage),
     );
 
-    // Listen to page changes and sync PageController
-    ref.listen<int>(onboardingProvider.select((state) => state.currentPage), (
-      previous,
-      next,
-    ) {
-      if (_pageController.hasClients && previous != next) {
-        _pageController.animateToPage(
-          next,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeInOut,
-        );
-      }
-    });
+    ref.listen<int>(
+      onboardingProvider.select((state) => state.currentPage),
+      (previous, next) {
+        if (_pageController.hasClients && previous != next) {
+          _pageController.animateToPage(
+            next,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        }
+      },
+    );
 
     return Scaffold(
       body: Stack(
         children: [
-          // Page view with onboarding screens
           PageView(
             controller: _pageController,
             physics: const NeverScrollableScrollPhysics(),
             onPageChanged: (int page) {
-              // Update provider if page changes manually
               if (page != currentPage) {
                 if (page > currentPage) {
                   ref.read(onboardingProvider.notifier).goToNextPage();
@@ -83,6 +101,7 @@ class _OnboardingWrapperState extends ConsumerState<OnboardingWrapper> {
               OnboardingScreen1(onNext: _nextPage),
               OnboardingScreen3(onNext: _nextPage, onBack: _previousPage),
               OnboardingScreen4(onNext: _nextPage, onBack: _previousPage),
+              OnboardingScreenEvent(onNext: _nextPage, onBack: _previousPage),
               OnboardingScreen5(onComplete: _completeOnboarding),
             ],
           ),


### PR DESCRIPTION
**Description**
Added event enrollment page (page 3) to onboarding with opt-in for "Abhidhamma in a Year" plan. Auto-enrolls users in selected plans with 9:00 AM time blocks. Post-onboarding
   navigation goes to Practice tab and opens enrolled plan details. duplicate detection event; network errors don't block completion. Events are scalable via `kOnboardingEvents` list.  
  
**Workflow**
  Install → RouteGuard → /login  
↓  
Login → Authenticated → /onboarding  
↓  
Page 0 (Welcome) → Continue  
↓  
Page 1 (Language) → Select → Continue  
↓  
Page 2 (Tradition) → Select → Continue  
↓  
Page 3 (Events) → Check/uncheck → Continue  
├─ If unchecked: Skip enrollment  
└─ If checked:  
   ├─ Subscribe to plan (POST /users/me/plans)  
   ├─ Add 9:00 AM time block (with duplicate check)  
   └─ Store plan in pendingOnboardingPlanProvider  
↓  
Page 4 (Finish) → "Begin Your Practice"  
├─ submitPreferences() → Mark onboarding complete  
└─ context.go('/home')  
↓  
Home Screen → Request notification permission  
↓  
_navigateToPendingPlanIfNeeded()  
├─ Check pendingOnboardingPlanProvider  
├─ If null: Stay on Home (tab 0)  
└─ If plan exists:  
   ├─ context.push('/practice/details', {plan, selectedDay: 1})  
   └─ Switch to Practice tab (tab 2)  
↓  
PlanDetails → Fetch day 1 content → Display tasks  