### PR TITLE
feat: content type text added

### DIFF
--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -14,6 +14,7 @@ import 'package:flutter_pecha/features/onboarding/presentation/providers/onboard
 import 'package:flutter_pecha/features/onboarding/presentation/screens/onboarding_wrapper.dart';
 import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+import 'package:flutter_pecha/features/plans/presentation/screens/plan_text_screen.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_track/plan_details.dart';
 import 'package:flutter_pecha/features/plans/presentation/plan_info.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_preview/plan_preview_details.dart';
@@ -283,6 +284,22 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: AppRoutes.notifications,
         name: "notifications",
         builder: (context, state) => const NotificationSettingsScreen(),
+      ),
+
+      // plan text route - inline TEXT subtasks (sibling to /reader)
+      GoRoute(
+        path: "/plan-text/:subtaskId",
+        name: "plan-text",
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! NavigationContext) {
+            _logger.warning(
+              'plan-text route called without NavigationContext extra',
+            );
+            return const MainNavigationScreen();
+          }
+          return PlanTextScreen(navigationContext: extra);
+        },
       ),
 
       // reader route - new refactored text reader

--- a/lib/core/config/router/app_routes.dart
+++ b/lib/core/config/router/app_routes.dart
@@ -69,6 +69,12 @@ class AppRoutes {
   // ========== READER ROUTES ==========
   static const String reader = '/reader';
 
+  // ========== PLAN TEXT ROUTES ==========
+  /// Inline plan text screen — renders subtasks where `content_type == "TEXT"`.
+  /// Path param is the subtask id; the actual content travels in `extra`
+  /// as a [NavigationContext] whose `currentItem` carries `inlineContent`.
+  static const String planText = '/plan-text';
+
   // ========== NOTIFICATIONS SUB ROUTES ==========
   static const String notificationSettings = '/notifications/settings';
 

--- a/lib/features/plans/domain/subtask_navigation.dart
+++ b/lib/features/plans/domain/subtask_navigation.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_pecha/features/plans/data/models/plan_subtasks_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/plan_tasks_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_subtasks_dto.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_tasks_dto.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+
+/// Single source of truth for converting plan subtasks into the unified
+/// [PlanTextItem] list used by the reader / plan-text navigation strip.
+///
+/// Validation rules (kept in one place):
+/// - SOURCE_REFERENCE → valid iff `sourceTextId` is non-null and non-empty.
+/// - TEXT             → valid iff `content.trim()` is non-empty.
+/// - Anything else (unknown content type, missing fields) is silently dropped.
+///
+/// Both task models (`UserTasksDto` for enrolled users, `PlanTasksModel` for
+/// preview) are normalised through the same code path, so navigation behaves
+/// identically regardless of which screen the user came from.
+class PlanSubtaskNavigation {
+  PlanSubtaskNavigation._();
+
+  /// Build the unified item list for an enrolled user.
+  /// Tasks are sorted by `displayOrder`; the first navigable subtask of each
+  /// task is included.
+  static List<PlanTextItem> fromUserTasks(List<UserTasksDto> tasks) {
+    final sorted = List<UserTasksDto>.from(tasks)
+      ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
+
+    final items = <PlanTextItem>[];
+    for (final task in sorted) {
+      final item = _firstNavigableUserSubtask(task);
+      if (item != null) items.add(item);
+    }
+    return items;
+  }
+
+  /// Build the unified item list for the preview (unenrolled) flow.
+  /// `subtaskId` and `isCompleted` are intentionally omitted — preview must
+  /// not call completion APIs.
+  static List<PlanTextItem> fromPlanTasks(List<PlanTasksModel> tasks) {
+    final sorted = List<PlanTasksModel>.from(tasks)..sort((a, b) {
+      final orderA = a.displayOrder ?? 0;
+      final orderB = b.displayOrder ?? 0;
+      return orderA.compareTo(orderB);
+    });
+
+    final items = <PlanTextItem>[];
+    for (final task in sorted) {
+      final item = _firstNavigablePlanSubtask(task);
+      if (item != null) items.add(item);
+    }
+    return items;
+  }
+
+  /// True if the given task has at least one navigable subtask
+  /// (SOURCE_REFERENCE or TEXT).
+  static bool isUserTaskNavigable(UserTasksDto task) {
+    return task.subTasks.any(_isUserSubtaskNavigable);
+  }
+
+  /// Same as [isUserTaskNavigable] for the preview model.
+  static bool isPlanTaskNavigable(PlanTasksModel task) {
+    return task.subtasks.any(_isPlanSubtaskNavigable);
+  }
+
+  // ─── Internal helpers ───────────────────────────────────────────────
+
+  static PlanTextItem? _firstNavigableUserSubtask(UserTasksDto task) {
+    for (final subtask in task.subTasks) {
+      final item = _toItemFromUserSubtask(subtask, task.title);
+      if (item != null) return item;
+    }
+    return null;
+  }
+
+  static PlanTextItem? _firstNavigablePlanSubtask(PlanTasksModel task) {
+    for (final subtask in task.subtasks) {
+      final item = _toItemFromPlanSubtask(subtask, task.title);
+      if (item != null) return item;
+    }
+    return null;
+  }
+
+  static bool _isUserSubtaskNavigable(UserSubtasksDto s) =>
+      _toItemFromUserSubtask(s, '') != null;
+
+  static bool _isPlanSubtaskNavigable(PlanSubtasksModel s) =>
+      _toItemFromPlanSubtask(s, '') != null;
+
+  static PlanTextItem? _toItemFromUserSubtask(
+    UserSubtasksDto subtask,
+    String title,
+  ) {
+    final type = PlanContentTypes.parse(subtask.contentType);
+    switch (type) {
+      case PlanItemContentType.sourceReference:
+        if (!_hasSourceText(subtask.sourceTextId)) return null;
+        return PlanTextItem.sourceReference(
+          textId: subtask.sourceTextId!,
+          title: title,
+          segmentIds: subtask.segmentIds,
+          subtaskId: subtask.id,
+          isCompleted: subtask.isCompleted,
+        );
+      case PlanItemContentType.inlineText:
+        if (!_hasInlineContent(subtask.content)) return null;
+        return PlanTextItem.inlineText(
+          content: subtask.content,
+          title: title,
+          subtaskId: subtask.id,
+          isCompleted: subtask.isCompleted,
+        );
+      case null:
+        return null;
+    }
+  }
+
+  static PlanTextItem? _toItemFromPlanSubtask(
+    PlanSubtasksModel subtask,
+    String title,
+  ) {
+    final type = PlanContentTypes.parse(subtask.contentType);
+    switch (type) {
+      case PlanItemContentType.sourceReference:
+        if (!_hasSourceText(subtask.sourceTextId)) return null;
+        return PlanTextItem.sourceReference(
+          textId: subtask.sourceTextId!,
+          title: title,
+          segmentIds: subtask.segmentIds,
+        );
+      case PlanItemContentType.inlineText:
+        if (!_hasInlineContent(subtask.content)) return null;
+        return PlanTextItem.inlineText(
+          content: subtask.content!,
+          title: title,
+        );
+      case null:
+        return null;
+    }
+  }
+
+  static bool _hasSourceText(String? sourceTextId) =>
+      sourceTextId != null && sourceTextId.isNotEmpty;
+
+  static bool _hasInlineContent(String? content) =>
+      content != null && content.trim().isNotEmpty;
+}

--- a/lib/features/plans/presentation/screens/plan_text_screen.dart
+++ b/lib/features/plans/presentation/screens/plan_text_screen.dart
@@ -108,12 +108,14 @@ class PlanTextScreen extends ConsumerWidget {
   ) {
     if (direction == SwipeDirection.next) {
       completeCurrentPlanSubtask(ref, navigationContext);
+      invalidatePlanProviders(ref, navigationContext);
     }
     PlanNavigator.navigateAdjacent(context, navigationContext, direction);
   }
 
   void _finish(BuildContext context, WidgetRef ref) {
     completeCurrentPlanSubtask(ref, navigationContext);
+    invalidatePlanProviders(ref, navigationContext);
     if (context.mounted) context.pop();
   }
 }

--- a/lib/features/plans/presentation/screens/plan_text_screen.dart
+++ b/lib/features/plans/presentation/screens/plan_text_screen.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+import 'package:flutter_pecha/features/reader/domain/services/navigation_service.dart';
+import 'package:flutter_pecha/features/reader/presentation/widgets/reader_app_bar/reader_font_size_bottom_sheet.dart';
+import 'package:flutter_pecha/features/reader/presentation/widgets/reader_app_bar/reader_font_size_button.dart';
+import 'package:flutter_pecha/features/texts/presentation/providers/font_size_notifier.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Lightweight reading screen for plan subtasks where
+/// `content_type == "TEXT"`. Shares the same bottom navigation strip with
+/// `ReaderScreen` so that prev/next/finish work identically across both
+/// content types in a mixed-type plan day.
+///
+/// Compared to `ReaderScreen`, this screen intentionally omits commentary,
+/// segment selection, copy/share, search, language switching and audio —
+/// inline plan text has no segments to attach those features to.
+class PlanTextScreen extends ConsumerWidget {
+  /// The current subtask's content + plan-list context. The body renders
+  /// `navigationContext.currentItem.inlineContent`.
+  final NavigationContext navigationContext;
+
+  const PlanTextScreen({super.key, required this.navigationContext});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentItem = navigationContext.currentItem;
+    final fontSize = ref.watch(fontSizeProvider);
+
+    if (currentItem == null || currentItem.inlineContent == null) {
+      return _buildMissingContentScaffold(context);
+    }
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () => context.pop(),
+        ),
+        title: Text(
+          currentItem.title,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+          overflow: TextOverflow.ellipsis,
+        ),
+        centerTitle: true,
+        actions: [
+          ReaderFontSizeButton(
+            onPressed: () => showFontSizeBottomSheet(context),
+          ),
+          const SizedBox(width: 12),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 16,
+                ),
+                child: SelectableText(
+                  currentItem.inlineContent!,
+                  style: TextStyle(
+                    fontSize: fontSize,
+                    height: 1.6,
+                  ),
+                ),
+              ),
+            ),
+            PlanNavigationBottomBar(
+              navigationContext: navigationContext,
+              fallbackTitle: currentItem.title,
+              onPreviousTap: () => _navigate(context, ref, SwipeDirection.previous),
+              onNextTap: () => _navigate(context, ref, SwipeDirection.next),
+              onFinishedTap: () => _finish(context, ref),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMissingContentScaffold(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: const Center(child: Text('No content available')),
+    );
+  }
+
+  void _navigate(
+    BuildContext context,
+    WidgetRef ref,
+    SwipeDirection direction,
+  ) {
+    if (direction == SwipeDirection.next) {
+      completeCurrentPlanSubtask(ref, navigationContext);
+    }
+    PlanNavigator.navigateAdjacent(context, navigationContext, direction);
+  }
+
+  void _finish(BuildContext context, WidgetRef ref) {
+    completeCurrentPlanSubtask(ref, navigationContext);
+    if (context.mounted) context.pop();
+  }
+}

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+
+/// Shared bottom navigation strip used by both `ReaderScreen` (for
+/// SOURCE_REFERENCE items) and `PlanTextScreen` (for inline TEXT items).
+///
+/// Renders one of three layouts based on the navigation context:
+/// - **Full controls** (canSwipe): prev arrow, "X of N" + title, next arrow,
+///   or a finish (✓) button on the last item.
+/// - **Single item** (one navigable subtask): title + finish (✓) button.
+/// - **Minimal** (no plan context, e.g. reader opened from search): title only.
+///
+/// All state — current index, total count, prev/next availability — is read
+/// from [navigationContext] so the strip stays in sync regardless of which
+/// screen hosts it.
+class PlanNavigationBottomBar extends StatelessWidget {
+  final NavigationContext? navigationContext;
+
+  /// Title shown in the centre when there is no [navigationContext]
+  /// (e.g. minimal reader). Ignored when a plan context is present —
+  /// in that case the current item's title is used.
+  final String fallbackTitle;
+
+  /// Optional font family applied to the centre title (used by the reader
+  /// to honour the script of the source text).
+  final String? fallbackTitleFontFamily;
+
+  final VoidCallback? onPreviousTap;
+  final VoidCallback? onNextTap;
+  final VoidCallback? onFinishedTap;
+
+  const PlanNavigationBottomBar({
+    super.key,
+    required this.navigationContext,
+    required this.fallbackTitle,
+    this.fallbackTitleFontFamily,
+    this.onPreviousTap,
+    this.onNextTap,
+    this.onFinishedTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ctx = navigationContext;
+    final canSwipe = ctx != null && ctx.canSwipe;
+    final isPlanNavigation = ctx != null && ctx.source == NavigationSource.plan;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).scaffoldBackgroundColor,
+        border: Border(
+          top: BorderSide(color: Theme.of(context).dividerColor, width: 1),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: canSwipe
+            ? _buildFullControls(context, ctx)
+            : isPlanNavigation
+                ? _buildSingleItemControls(context, ctx)
+                : _buildMinimalTitle(context),
+      ),
+    );
+  }
+
+  // ─── Layouts ────────────────────────────────────────────────────────
+
+  Widget _buildMinimalTitle(BuildContext context) {
+    return Center(
+      child: _TitleText(
+        text: fallbackTitle,
+        fontFamily: fallbackTitleFontFamily,
+      ),
+    );
+  }
+
+  Widget _buildSingleItemControls(BuildContext context, NavigationContext ctx) {
+    final title = ctx.currentItem?.title ?? fallbackTitle;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Expanded(
+          child: _TitleText(
+            text: title,
+            fontFamily: fallbackTitleFontFamily,
+          ),
+        ),
+        _NavigationButton(
+          icon: Icons.check,
+          isEnabled: true,
+          onTap: onFinishedTap ?? () => Navigator.of(context).maybePop(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFullControls(BuildContext context, NavigationContext ctx) {
+    final hasPrevious = ctx.hasPreviousText;
+    final hasNext = ctx.hasNextText;
+    final progress =
+        '${(ctx.currentTextIndex ?? 0) + 1} of ${ctx.planTextItems!.length}';
+    final title = ctx.currentItem?.title ?? fallbackTitle;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        if (hasPrevious)
+          _NavigationButton(
+            icon: Icons.chevron_left,
+            isEnabled: true,
+            onTap: onPreviousTap ?? () => Navigator.of(context).maybePop(),
+          ),
+        Expanded(
+          child: Column(
+            children: [
+              _TitleText(text: title),
+              Text(
+                progress,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.color
+                          ?.withAlpha(180),
+                      fontWeight: FontWeight.w500,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        if (hasNext)
+          _NavigationButton(
+            icon: Icons.chevron_right,
+            isEnabled: true,
+            onTap: onNextTap ?? () => Navigator.of(context).maybePop(),
+          )
+        else
+          _NavigationButton(
+            icon: Icons.check,
+            isEnabled: true,
+            onTap: onFinishedTap ?? () => Navigator.of(context).maybePop(),
+          ),
+      ],
+    );
+  }
+}
+
+class _TitleText extends StatelessWidget {
+  final String text;
+  final String? fontFamily;
+
+  const _TitleText({required this.text, this.fontFamily});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      overflow: TextOverflow.ellipsis,
+      maxLines: 1,
+      textAlign: TextAlign.center,
+      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            fontFamily: fontFamily,
+            fontWeight: FontWeight.bold,
+          ),
+    );
+  }
+}
+
+class _NavigationButton extends StatelessWidget {
+  final IconData icon;
+  final bool isEnabled;
+  final VoidCallback onTap;
+
+  const _NavigationButton({
+    required this.icon,
+    required this.isEnabled,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isEnabled
+        ? Theme.of(context).colorScheme.onSurface
+        : Theme.of(context).colorScheme.onSurface.withAlpha(80);
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(24),
+        child: Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: color.withAlpha(isEnabled ? 100 : 50),
+              width: 1,
+            ),
+          ),
+          child: Icon(icon, size: 24, color: color),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_pecha/core/config/router/app_routes.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+import 'package:flutter_pecha/features/reader/domain/services/navigation_service.dart';
+import 'package:go_router/go_router.dart';
+
+/// Centralised navigation between plan subtask screens.
+///
+/// A plan day's subtask list is a flat sequence of mixed content types
+/// (SOURCE_REFERENCE → ReaderScreen, TEXT → PlanTextScreen). When the user
+/// taps prev/next or swipes, the next item may live on a *different* screen
+/// than the current one. This helper picks the right route and replaces the
+/// current screen, so the user perceives a seamless "1/N → 2/N" sequence.
+class PlanNavigator {
+  PlanNavigator._();
+
+  /// Push the screen for [item], scrolling to its first segment (if any),
+  /// using the supplied [navigationContext].
+  ///
+  /// Use [push] for the initial entry from the activity list. For mid-sequence
+  /// transitions where the user shouldn't be able to back-stack to every prior
+  /// item, use [replace] instead.
+  static Future<T?> push<T>(
+    BuildContext context,
+    PlanTextItem item,
+    NavigationContext navigationContext,
+  ) {
+    return context.push<T>(_routeFor(item), extra: navigationContext);
+  }
+
+  /// Same as [push] but replaces the current screen, used by the bottom
+  /// bar's prev/next arrows and by horizontal swipes.
+  static void replace(
+    BuildContext context,
+    PlanTextItem item,
+    NavigationContext navigationContext,
+  ) {
+    context.pushReplacement(_routeFor(item), extra: navigationContext);
+  }
+
+  /// Move to the adjacent item in [direction]. Returns true if it navigated,
+  /// false if there is no neighbour in that direction.
+  static bool navigateAdjacent(
+    BuildContext context,
+    NavigationContext currentContext,
+    SwipeDirection direction,
+  ) {
+    const service = NavigationService();
+    final newContext = service.createNavigationContextForAdjacent(
+      currentContext,
+      direction,
+    );
+    final adjacent = service.getAdjacentText(currentContext, direction);
+    if (newContext == null || adjacent == null) return false;
+
+    replace(context, adjacent, newContext);
+    return true;
+  }
+
+  static String _routeFor(PlanTextItem item) {
+    switch (item.contentType) {
+      case PlanItemContentType.sourceReference:
+        return '${AppRoutes.reader}/${item.textId}';
+      case PlanItemContentType.inlineText:
+        // Subtask id is required for plan-text routes; fall back to a stable
+        // synthetic id only if the item came from preview (no subtaskId).
+        // Item identity is irrelevant to PlanTextScreen — it reads content
+        // from navigationContext.currentItem.
+        final id = item.subtaskId ?? 'preview';
+        return '${AppRoutes.planText}/$id';
+    }
+  }
+}

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart
@@ -6,18 +6,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final _logger = AppLogger('PlanSubtaskCompletion');
 
-/// Marks the current subtask in [navigationContext] as complete and
-/// invalidates the providers feeding the plan day screen so the UI refreshes
-/// when the user returns.
+/// Fires the complete-subtask API call for the current item in [navContext].
 ///
-/// No-ops in any of the following situations (preview or out-of-bounds):
-/// - source is not [NavigationSource.plan]
+/// Callers should invoke [invalidatePlanProviders] **synchronously before
+/// navigating away** so that plan-day providers refresh regardless of when
+/// this async call finishes and the widget's `ref` is still valid.
+///
+/// No-ops when:
+/// - [navContext] is null or source is not [NavigationSource.plan]
 /// - the current item has no `subtaskId` (preview mode)
 /// - the subtask is already completed
-/// - the index is out of bounds
-///
-/// Centralised here so both `ReaderScreen`'s swipe wrapper and
-/// `PlanTextScreen`'s bottom bar share identical completion behaviour.
 void completeCurrentPlanSubtask(WidgetRef ref, NavigationContext? navContext) {
   if (navContext == null || navContext.source != NavigationSource.plan) {
     return;
@@ -30,9 +28,6 @@ void completeCurrentPlanSubtask(WidgetRef ref, NavigationContext? navContext) {
   if (subtaskId == null || subtaskId.isEmpty) return;
   if (currentItem.isCompleted) return;
 
-  final planId = navContext.planId;
-  final dayNumber = navContext.dayNumber;
-
   Future.microtask(() async {
     try {
       final result = await ref.read(
@@ -41,20 +36,32 @@ void completeCurrentPlanSubtask(WidgetRef ref, NavigationContext? navContext) {
       result.fold(
         (failure) =>
             _logger.error('Failed to complete subtask: ${failure.message}'),
-        (_) {
-          _logger.info('Marked subtask $subtaskId as complete on navigation');
-          if (planId != null && dayNumber != null) {
-            ref.invalidate(
-              userPlanDayContentFutureProvider(
-                PlanDaysParams(planId: planId, dayNumber: dayNumber),
-              ),
-            );
-            ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
-          }
-        },
+        (_) => _logger.info('Marked subtask $subtaskId as complete'),
       );
+    } on StateError {
+      // Widget was disposed before the API call finished — the request was
+      // already in-flight and providers were invalidated synchronously by the
+      // caller before navigation, so the UI will still reflect the change.
     } catch (e) {
       _logger.error('Failed to complete subtask $subtaskId', e);
     }
   });
+}
+
+/// Invalidates the plan-day providers so the UI refreshes on return.
+///
+/// Call this **synchronously** (while the widget is still mounted) before
+/// navigating away after a completion action.
+void invalidatePlanProviders(WidgetRef ref, NavigationContext? navContext) {
+  if (navContext == null) return;
+  final planId = navContext.planId;
+  final dayNumber = navContext.dayNumber;
+  if (planId == null || dayNumber == null) return;
+
+  ref.invalidate(
+    userPlanDayContentFutureProvider(
+      PlanDaysParams(planId: planId, dayNumber: dayNumber),
+    ),
+  );
+  ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
 }

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final _logger = AppLogger('PlanSubtaskCompletion');
+
+/// Marks the current subtask in [navigationContext] as complete and
+/// invalidates the providers feeding the plan day screen so the UI refreshes
+/// when the user returns.
+///
+/// No-ops in any of the following situations (preview or out-of-bounds):
+/// - source is not [NavigationSource.plan]
+/// - the current item has no `subtaskId` (preview mode)
+/// - the subtask is already completed
+/// - the index is out of bounds
+///
+/// Centralised here so both `ReaderScreen`'s swipe wrapper and
+/// `PlanTextScreen`'s bottom bar share identical completion behaviour.
+void completeCurrentPlanSubtask(WidgetRef ref, NavigationContext? navContext) {
+  if (navContext == null || navContext.source != NavigationSource.plan) {
+    return;
+  }
+
+  final currentItem = navContext.currentItem;
+  if (currentItem == null) return;
+
+  final subtaskId = currentItem.subtaskId;
+  if (subtaskId == null || subtaskId.isEmpty) return;
+  if (currentItem.isCompleted) return;
+
+  final planId = navContext.planId;
+  final dayNumber = navContext.dayNumber;
+
+  Future.microtask(() async {
+    try {
+      final result = await ref.read(
+        completeSubTaskFutureProvider(subtaskId).future,
+      );
+      result.fold(
+        (failure) =>
+            _logger.error('Failed to complete subtask: ${failure.message}'),
+        (_) {
+          _logger.info('Marked subtask $subtaskId as complete on navigation');
+          if (planId != null && dayNumber != null) {
+            ref.invalidate(
+              userPlanDayContentFutureProvider(
+                PlanDaysParams(planId: planId, dayNumber: dayNumber),
+              ),
+            );
+            ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
+          }
+        },
+      );
+    } catch (e) {
+      _logger.error('Failed to complete subtask $subtaskId', e);
+    }
+  });
+}

--- a/lib/features/plans/presentation/widgets/plan_preview/preview_activity_list.dart
+++ b/lib/features/plans/presentation/widgets/plan_preview/preview_activity_list.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/plans/domain/subtask_navigation.dart';
 import 'package:flutter_pecha/features/plans/plans.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
-import 'package:go_router/go_router.dart';
 
 /// A read-only activity list for previewing plan tasks before enrollment.
-/// Unlike ActivityList, this widget:
-/// - Works with PlanTasksModel (non-enrolled data)
-/// - Has no checkbox/completion toggle (preview only)
-/// - Navigates to ReaderScreen with sourceTextId and NavigationContext
+/// Mirrors `ActivityList` but works with `PlanTasksModel` (non-enrolled
+/// data) and never tracks subtask completion.
+///
+/// Tapping a row opens the appropriate screen (ReaderScreen for
+/// SOURCE_REFERENCE, PlanTextScreen for TEXT) with the unified
+/// [PlanTextItem] list, so the bottom-bar progress works the same as in
+/// the enrolled flow.
 class PreviewActivityList extends StatelessWidget {
   final String language;
   final List<PlanTasksModel> tasks;
@@ -48,13 +52,13 @@ class PreviewActivityList extends StatelessWidget {
       itemCount: sortedTasks.length,
       itemBuilder: (context, index) {
         final task = sortedTasks[index];
-        final hasSourceText = _hasSourceText(task);
+        final isNavigable = PlanSubtaskNavigation.isPlanTaskNavigable(task);
         return Container(
           margin: const EdgeInsets.symmetric(vertical: 10),
           child: _PreviewTaskItem(
             language: language,
             task: task,
-            hasSourceText: hasSourceText,
+            hasNavigableContent: isNavigable,
             onTap: () => _handleActivityTap(context, task),
           ),
         );
@@ -63,72 +67,27 @@ class PreviewActivityList extends StatelessWidget {
   }
 
   void _handleActivityTap(BuildContext context, PlanTasksModel task) {
-    final planTextItems = _buildPlanTextItems();
+    final planTextItems = PlanSubtaskNavigation.fromPlanTasks(tasks);
     if (planTextItems.isEmpty) return;
-    final PlanSubtasksModel? subtaskWithText = _getSubtaskWithText(task);
 
-    if (subtaskWithText != null) {
-      final sourceTextId = subtaskWithText.sourceTextId;
-      final segmentId = _getFirstSegmentId(subtaskWithText);
+    // Find this task's position in the unified list. Without subtaskId
+    // (preview mode) we match on title — task titles are unique within
+    // a day in practice, and a stale match still navigates somewhere
+    // reasonable in the same list.
+    final index = planTextItems.indexWhere((item) => item.title == task.title);
+    if (index < 0) return;
 
-      final currentTextIndex = planTextItems.indexWhere(
-        (item) => item.textId == sourceTextId,
-      );
-
-      final navigationContext = NavigationContext(
-        source: NavigationSource.plan,
-        planId: planId,
-        dayNumber: dayNumber,
-        targetSegmentId: segmentId,
-        planTextItems: planTextItems,
-        currentTextIndex: currentTextIndex >= 0 ? currentTextIndex : 0,
-      );
-
-      context.push('/reader/$sourceTextId', extra: navigationContext);
-    }
-  }
-
-  /// Build list of plan text items for swipe navigation.
-  /// One PlanTextItem per task with full segmentIds list.
-  List<PlanTextItem> _buildPlanTextItems() {
-    final items = <PlanTextItem>[];
-    final sortedTasks = _sortedTasks;
-    for (final task in sortedTasks) {
-      if (task.subtasks.isEmpty) continue;
-      final subtask = task.subtasks[0];
-      if (subtask.sourceTextId != null && subtask.sourceTextId!.isNotEmpty) {
-        items.add(
-          PlanTextItem(
-            textId: subtask.sourceTextId!,
-            segmentIds: subtask.segmentIds,
-            title: task.title,
-          ),
-        );
-      }
-    }
-    return items;
-  }
-
-  /// Check if any subtask has a sourceTextId
-  bool _hasSourceText(PlanTasksModel task) {
-    return task.subtasks.any(
-      (s) => s.sourceTextId != null && s.sourceTextId!.isNotEmpty,
+    final target = planTextItems[index];
+    final navigationContext = NavigationContext(
+      source: NavigationSource.plan,
+      planId: planId,
+      dayNumber: dayNumber,
+      targetSegmentId: target.firstSegmentId,
+      planTextItems: planTextItems,
+      currentTextIndex: index,
     );
-  }
 
-  PlanSubtasksModel? _getSubtaskWithText(PlanTasksModel task) {
-    for (final PlanSubtasksModel subtask in task.subtasks) {
-      if (subtask.sourceTextId != null && subtask.sourceTextId!.isNotEmpty) {
-        return subtask;
-      }
-    }
-    return null;
-  }
-
-  String? _getFirstSegmentId(PlanSubtasksModel subtask) {
-    final List<String>? segmentIds = subtask.segmentIds;
-    if (segmentIds == null || segmentIds.isEmpty) return null;
-    return segmentIds.first;
+    PlanNavigator.push(context, target, navigationContext);
   }
 }
 
@@ -137,13 +96,13 @@ class _PreviewTaskItem extends StatelessWidget {
   const _PreviewTaskItem({
     required this.language,
     required this.task,
-    required this.hasSourceText,
+    required this.hasNavigableContent,
     required this.onTap,
   });
 
   final String language;
   final PlanTasksModel task;
-  final bool hasSourceText;
+  final bool hasNavigableContent;
   final VoidCallback onTap;
 
   @override
@@ -151,7 +110,7 @@ class _PreviewTaskItem extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: hasSourceText ? onTap : null,
+        onTap: hasNavigableContent ? onTap : null,
         borderRadius: BorderRadius.circular(8),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
@@ -162,11 +121,11 @@ class _PreviewTaskItem extends StatelessWidget {
                   task.title,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
+                        fontWeight: FontWeight.w500,
+                      ),
                 ),
               ),
-              if (hasSourceText) ...[
+              if (hasNavigableContent) ...[
                 const SizedBox(width: 8),
                 Icon(
                   Icons.arrow_forward_ios,

--- a/lib/features/plans/presentation/widgets/plan_track/activity_list.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/activity_list.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/features/plans/data/models/author/author_dto_model.dart';
+import 'package:flutter_pecha/features/plans/domain/subtask_navigation.dart';
 import 'package:flutter_pecha/features/plans/plans.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
-import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+/// Activity list for the *enrolled* plan flow. Each row is one task; the
+/// chevron on a row is enabled iff at least one of its subtasks is
+/// navigable (SOURCE_REFERENCE with text id, or TEXT with non-blank
+/// content). Tapping the row opens the appropriate screen for the task's
+/// first navigable subtask, with a unified [PlanTextItem] list so the
+/// bottom-bar progress reads "1 of N", "2 of N", ... across all tasks
+/// regardless of content type.
 class ActivityList extends StatelessWidget {
   final String language;
   final List<UserTasksDto> tasks;
@@ -40,23 +48,21 @@ class ActivityList extends StatelessWidget {
       itemCount: sortedTasks.length,
       itemBuilder: (context, index) {
         final task = sortedTasks[index];
-        final isCompleted = task.isCompleted;
-        final taskId = task.id;
-        final hasSourceText = _hasSourceText(task);
+        final isNavigable = PlanSubtaskNavigation.isUserTaskNavigable(task);
         return Container(
           margin: const EdgeInsets.symmetric(vertical: 10),
           child: Row(
             children: [
               _TaskCheckbox(
-                isCompleted: isCompleted,
-                onTap: () => onActivityToggled(taskId),
+                isCompleted: task.isCompleted,
+                onTap: () => onActivityToggled(task.id),
               ),
               const SizedBox(width: 10),
               Expanded(
                 child: _TaskTitleButton(
                   language: language,
                   title: task.title,
-                  hasSourceText: hasSourceText,
+                  hasNavigableContent: isNavigable,
                   onTap: () => _handleActivityTap(context, task),
                 ),
               ),
@@ -68,75 +74,29 @@ class ActivityList extends StatelessWidget {
   }
 
   void _handleActivityTap(BuildContext context, UserTasksDto task) {
-    final planTextItems = _buildPlanTextItems();
+    final planTextItems = PlanSubtaskNavigation.fromUserTasks(tasks);
     if (planTextItems.isEmpty) return;
-    final UserSubtasksDto? subtaskWithText = _getSubtaskWithText(task);
 
-    if (subtaskWithText != null) {
-      final sourceTextId = subtaskWithText.sourceTextId as String;
-      final segmentId = _getFirstSegmentId(subtaskWithText);
-
-      final currentTextIndex = planTextItems.indexWhere(
-        (item) => item.textId == sourceTextId,
-      );
-
-      final navigationContext = NavigationContext(
-        source: NavigationSource.plan,
-        planId: planId,
-        dayNumber: dayNumber,
-        targetSegmentId: segmentId,
-        planTextItems: planTextItems,
-        currentTextIndex: currentTextIndex >= 0 ? currentTextIndex : 0,
-      );
-
-      context.push('/reader/$sourceTextId', extra: navigationContext).then((_) {
-        onReaderClosed?.call();
-      });
-    }
-  }
-
-  /// Build list of plan text items for swipe navigation.
-  /// One PlanTextItem per task with full segmentIds list.
-  List<PlanTextItem> _buildPlanTextItems() {
-    final items = <PlanTextItem>[];
-    for (final task in tasks) {
-      if (task.subTasks.isEmpty) continue;
-      final subtask = task.subTasks[0];
-      if (subtask.sourceTextId != null && subtask.sourceTextId!.isNotEmpty) {
-        items.add(
-          PlanTextItem(
-            textId: subtask.sourceTextId!,
-            segmentIds: subtask.segmentIds,
-            title: task.title,
-            subtaskId: subtask.id,
-            isCompleted: subtask.isCompleted,
-          ),
-        );
-      }
-    }
-    return items;
-  }
-
-  /// Check if any subtask has a sourceTextId
-  bool _hasSourceText(UserTasksDto task) {
-    return task.subTasks.any(
-      (s) => s.sourceTextId != null && s.sourceTextId!.isNotEmpty,
+    // Tapping a row should open *that* task. Find its position in the
+    // unified list (one item per task that has a navigable subtask).
+    final index = planTextItems.indexWhere(
+      (item) => item.subtaskId != null &&
+          task.subTasks.any((s) => s.id == item.subtaskId),
     );
-  }
+    if (index < 0) return;
 
-  UserSubtasksDto? _getSubtaskWithText(UserTasksDto task) {
-    for (final UserSubtasksDto subtask in task.subTasks) {
-      if (subtask.sourceTextId != null && subtask.sourceTextId!.isNotEmpty) {
-        return subtask;
-      }
-    }
-    return null;
-  }
+    final target = planTextItems[index];
+    final navigationContext = NavigationContext(
+      source: NavigationSource.plan,
+      planId: planId,
+      dayNumber: dayNumber,
+      targetSegmentId: target.firstSegmentId,
+      planTextItems: planTextItems,
+      currentTextIndex: index,
+    );
 
-  String? _getFirstSegmentId(UserSubtasksDto subtask) {
-    final List<String>? segmentIds = subtask.segmentIds;
-    if (segmentIds == null || segmentIds.isEmpty) return null;
-    return segmentIds.first;
+    PlanNavigator.push(context, target, navigationContext)
+        .then((_) => onReaderClosed?.call());
   }
 }
 
@@ -157,17 +117,16 @@ class _TaskCheckbox extends StatelessWidget {
         child: Container(
           width: 24,
           height: 24,
-          decoration:
-              isCompleted
-                  ? null
-                  : BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                      color: Theme.of(context).iconTheme.color!,
-                      width: 1,
-                    ),
-                    color: Colors.transparent,
+          decoration: isCompleted
+              ? null
+              : BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: Theme.of(context).iconTheme.color!,
+                    width: 1,
                   ),
+                  color: Colors.transparent,
+                ),
           child: isCompleted ? Icon(PhosphorIconsBold.check, size: 20) : null,
         ),
       ),
@@ -181,20 +140,20 @@ class _TaskTitleButton extends StatelessWidget {
     required this.title,
     required this.onTap,
     required this.language,
-    required this.hasSourceText,
+    required this.hasNavigableContent,
   });
 
   final String title;
   final VoidCallback onTap;
   final String language;
-  final bool hasSourceText;
+  final bool hasNavigableContent;
 
   @override
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: hasSourceText ? onTap : null,
+        onTap: hasNavigableContent ? onTap : null,
         borderRadius: BorderRadius.circular(8),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
@@ -205,11 +164,11 @@ class _TaskTitleButton extends StatelessWidget {
                   title,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
+                        fontWeight: FontWeight.w500,
+                      ),
                 ),
               ),
-              if (hasSourceText) ...[
+              if (hasNavigableContent) ...[
                 const SizedBox(width: 8),
                 Icon(
                   Icons.arrow_forward_ios,

--- a/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
@@ -11,9 +11,10 @@ import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_p
 import 'package:flutter_pecha/features/plans/data/models/plan_days_model.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_tasks_dto.dart';
+import 'package:flutter_pecha/features/plans/domain/subtask_navigation.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../day_completion_bottom_sheet.dart';
 import '../plan_cover_image.dart';
@@ -514,31 +515,11 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     );
   }
 
-  List<PlanTextItem> _buildPlanTextItems(List<UserTasksDto> tasks) {
-    final items = <PlanTextItem>[];
-    for (final task in tasks) {
-      if (task.subTasks.isEmpty) continue;
-      final subtask = task.subTasks[0];
-      if (subtask.sourceTextId != null && subtask.sourceTextId!.isNotEmpty) {
-        items.add(
-          PlanTextItem(
-            textId: subtask.sourceTextId!,
-            segmentIds: subtask.segmentIds,
-            title: task.title,
-            subtaskId: subtask.id,
-            isCompleted: subtask.isCompleted,
-          ),
-        );
-      }
-    }
-    return items;
-  }
-
   void _startReading(List<UserTasksDto> tasks) {
-    final planTextItems = _buildPlanTextItems(tasks);
+    final planTextItems = PlanSubtaskNavigation.fromUserTasks(tasks);
     if (planTextItems.isEmpty) return;
 
-    // Find first uncompleted task with source text; fall back to first item
+    // Find first uncompleted item of any content type; fall back to first.
     final targetIndex = planTextItems.indexWhere((item) => !item.isCompleted);
     final index = targetIndex >= 0 ? targetIndex : 0;
     final target = planTextItems[index];
@@ -552,11 +533,8 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
       currentTextIndex: index,
     );
 
-    context.push('/reader/${target.textId}', extra: navigationContext).then((
-      _,
-    ) {
-      _onReaderClosed();
-    });
+    PlanNavigator.push(context, target, navigationContext)
+        .then((_) => _onReaderClosed());
   }
 
   Widget _buildStartReadingButton(
@@ -576,12 +554,7 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     );
 
     final hasReadableContent =
-        tasks != null &&
-        tasks.any(
-          (t) => t.subTasks.any(
-            (s) => s.sourceTextId != null && s.sourceTextId!.isNotEmpty,
-          ),
-        );
+        tasks != null && tasks.any(PlanSubtaskNavigation.isUserTaskNavigable);
 
     return SafeArea(
       child: Padding(

--- a/lib/features/reader/data/models/navigation_context.dart
+++ b/lib/features/reader/data/models/navigation_context.dart
@@ -6,42 +6,152 @@ enum NavigationSource {
   deepLink,
 }
 
-/// Represents a text item within a plan for swipe navigation
+/// Discriminator for the kind of content a [PlanTextItem] carries.
+///
+/// - [sourceReference] points at a remote text via [PlanTextItem.textId]
+///   and is rendered by `ReaderScreen`.
+/// - [inlineText] carries inline content via [PlanTextItem.inlineContent]
+///   and is rendered by `PlanTextScreen`.
+enum PlanItemContentType {
+  sourceReference,
+  inlineText,
+}
+
+/// API-level content type strings used by the plan endpoints.
+class PlanContentTypes {
+  PlanContentTypes._();
+
+  static const String sourceReference = 'SOURCE_REFERENCE';
+  static const String text = 'TEXT';
+
+  /// Map a raw API value to a [PlanItemContentType], or null if unknown.
+  static PlanItemContentType? parse(String? raw) {
+    switch (raw) {
+      case sourceReference:
+        return PlanItemContentType.sourceReference;
+      case text:
+        return PlanItemContentType.inlineText;
+      default:
+        return null;
+    }
+  }
+}
+
+/// Represents a navigable subtask within a plan.
+///
+/// Plan subtasks come in two flavours, both of which appear in the same
+/// linear navigation strip ("1 of N", "2 of N", ...):
+///
+/// - **SOURCE_REFERENCE** — opens `ReaderScreen` for [textId] and scrolls
+///   to the first segment in [segmentIds]. Has full reader features
+///   (commentary, copy/share, search, language, audio, ...).
+/// - **TEXT** — opens `PlanTextScreen` and renders [inlineContent] directly.
+///   Stripped-down view: title in app bar, font size control, no other
+///   reader features.
+///
+/// Construct via [PlanTextItem.sourceReference] or [PlanTextItem.inlineText]
+/// to get compile-time validation of which fields are required.
 class PlanTextItem {
+  final PlanItemContentType contentType;
+
+  /// SOURCE_REFERENCE only: the remote text id used by the route
+  /// `/reader/:textId`. Empty string for inline TEXT items.
   final String textId;
+
+  /// SOURCE_REFERENCE only: ordered list of segments to scroll through.
+  /// Null/empty for inline TEXT items.
   final List<String>? segmentIds;
+
+  /// TEXT only: the inline content rendered by `PlanTextScreen`.
+  /// Null for SOURCE_REFERENCE items.
+  final String? inlineContent;
+
+  /// Display title used in app bars and bottom-bar progress text.
   final String title;
 
-  /// The subtask ID associated with this text item.
-  /// When non-null, navigating to this item will auto-track subtask completion.
-  /// Left null in preview mode to prevent tracking for unenrolled plans.
+  /// The subtask ID associated with this item.
+  /// When non-null, navigating away from this item will mark the subtask
+  /// complete. Left null in preview mode to prevent tracking for
+  /// unenrolled plans.
   final String? subtaskId;
 
-  /// Whether the subtask is already completed.
-  /// When true, prevents duplicate completion API calls.
+  /// Whether the subtask is already completed. Prevents duplicate
+  /// completion API calls.
   final bool isCompleted;
 
-  const PlanTextItem({
+  const PlanTextItem._({
+    required this.contentType,
     required this.textId,
-    this.segmentIds,
     required this.title,
+    this.segmentIds,
+    this.inlineContent,
     this.subtaskId,
     this.isCompleted = false,
   });
 
+  /// Build a SOURCE_REFERENCE item. Throws if [textId] is empty.
+  factory PlanTextItem.sourceReference({
+    required String textId,
+    required String title,
+    List<String>? segmentIds,
+    String? subtaskId,
+    bool isCompleted = false,
+  }) {
+    assert(textId.isNotEmpty, 'sourceReference requires non-empty textId');
+    return PlanTextItem._(
+      contentType: PlanItemContentType.sourceReference,
+      textId: textId,
+      title: title,
+      segmentIds: segmentIds,
+      subtaskId: subtaskId,
+      isCompleted: isCompleted,
+    );
+  }
+
+  /// Build a TEXT item. Throws if [content] is blank.
+  factory PlanTextItem.inlineText({
+    required String content,
+    required String title,
+    String? subtaskId,
+    bool isCompleted = false,
+  }) {
+    assert(content.trim().isNotEmpty, 'inlineText requires non-blank content');
+    return PlanTextItem._(
+      contentType: PlanItemContentType.inlineText,
+      textId: '',
+      inlineContent: content,
+      title: title,
+      subtaskId: subtaskId,
+      isCompleted: isCompleted,
+    );
+  }
+
+  /// True if this item is a SOURCE_REFERENCE.
+  bool get isSourceReference =>
+      contentType == PlanItemContentType.sourceReference;
+
+  /// True if this item is an inline TEXT item.
+  bool get isInlineText => contentType == PlanItemContentType.inlineText;
+
   /// Get the first segment ID for initial scroll position
-  String? get firstSegmentId => segmentIds?.isNotEmpty == true ? segmentIds!.first : null;
+  /// (SOURCE_REFERENCE only).
+  String? get firstSegmentId =>
+      segmentIds?.isNotEmpty == true ? segmentIds!.first : null;
 
   PlanTextItem copyWith({
+    PlanItemContentType? contentType,
     String? textId,
     List<String>? segmentIds,
+    String? inlineContent,
     String? title,
     String? subtaskId,
     bool? isCompleted,
   }) {
-    return PlanTextItem(
+    return PlanTextItem._(
+      contentType: contentType ?? this.contentType,
       textId: textId ?? this.textId,
       segmentIds: segmentIds ?? this.segmentIds,
+      inlineContent: inlineContent ?? this.inlineContent,
       title: title ?? this.title,
       subtaskId: subtaskId ?? this.subtaskId,
       isCompleted: isCompleted ?? this.isCompleted,
@@ -52,10 +162,14 @@ class PlanTextItem {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! PlanTextItem) return false;
-    if (other.textId != textId ||
+    if (other.contentType != contentType ||
+        other.textId != textId ||
         other.title != title ||
+        other.inlineContent != inlineContent ||
         other.subtaskId != subtaskId ||
-        other.isCompleted != isCompleted) return false;
+        other.isCompleted != isCompleted) {
+      return false;
+    }
     if (segmentIds == null && other.segmentIds == null) return true;
     if (segmentIds == null || other.segmentIds == null) return false;
     if (segmentIds!.length != other.segmentIds!.length) return false;
@@ -66,16 +180,26 @@ class PlanTextItem {
   }
 
   @override
-  int get hashCode => Object.hash(textId, Object.hashAll(segmentIds ?? []), title, subtaskId, isCompleted);
+  int get hashCode => Object.hash(
+        contentType,
+        textId,
+        Object.hashAll(segmentIds ?? const []),
+        inlineContent,
+        title,
+        subtaskId,
+        isCompleted,
+      );
 
   @override
   String toString() {
-    return 'PlanTextItem(textId: $textId, segmentIds: $segmentIds, title: $title, subtaskId: $subtaskId, isCompleted: $isCompleted)';
+    return 'PlanTextItem(contentType: $contentType, textId: $textId, '
+        'title: $title, subtaskId: $subtaskId, isCompleted: $isCompleted)';
   }
 }
 
-/// Context for navigation to reader screen
-/// Contains information about the navigation source and plan context for swipe navigation
+/// Context for navigation to reader / plan-text screens.
+/// Contains information about the navigation source and the linear list
+/// of plan subtasks for swipe / arrow navigation between them.
 class NavigationContext {
   final NavigationSource source;
   final String? planId;
@@ -93,21 +217,30 @@ class NavigationContext {
     this.currentTextIndex,
   });
 
-  /// Check if this navigation context supports swipe navigation
-  bool get canSwipe =>
+  /// Whether this context can navigate between plan items at all
+  /// (i.e. it has a non-empty list of items and a valid index).
+  bool get hasPlanItems =>
       source == NavigationSource.plan &&
       planTextItems != null &&
-      planTextItems!.length > 1;
+      planTextItems!.isNotEmpty &&
+      currentTextIndex != null &&
+      currentTextIndex! >= 0 &&
+      currentTextIndex! < planTextItems!.length;
+
+  /// Check if this navigation context supports swipe navigation
+  /// (more than one item to move between).
+  bool get canSwipe => hasPlanItems && planTextItems!.length > 1;
 
   /// Check if there is a next text in the plan
   bool get hasNextText =>
-      canSwipe &&
-      currentTextIndex != null &&
-      currentTextIndex! < planTextItems!.length - 1;
+      hasPlanItems && currentTextIndex! < planTextItems!.length - 1;
 
   /// Check if there is a previous text in the plan
-  bool get hasPreviousText =>
-      canSwipe && currentTextIndex != null && currentTextIndex! > 0;
+  bool get hasPreviousText => hasPlanItems && currentTextIndex! > 0;
+
+  /// Get the currently selected plan item, if any.
+  PlanTextItem? get currentItem =>
+      hasPlanItems ? planTextItems![currentTextIndex!] : null;
 
   /// Get the next text item in the plan
   PlanTextItem? get nextTextItem {
@@ -122,11 +255,7 @@ class NavigationContext {
   }
 
   /// Get the current text item's segment IDs for visibility control
-  List<String>? get currentSegmentIds {
-    if (planTextItems == null || currentTextIndex == null) return null;
-    if (currentTextIndex! < 0 || currentTextIndex! >= planTextItems!.length) return null;
-    return planTextItems![currentTextIndex!].segmentIds;
-  }
+  List<String>? get currentSegmentIds => currentItem?.segmentIds;
 
   NavigationContext copyWith({
     NavigationSource? source,
@@ -159,12 +288,12 @@ class NavigationContext {
 
   @override
   int get hashCode => Object.hash(
-    source,
-    planId,
-    dayNumber,
-    targetSegmentId,
-    currentTextIndex,
-  );
+        source,
+        planId,
+        dayNumber,
+        targetSegmentId,
+        currentTextIndex,
+      );
 
   @override
   String toString() {

--- a/lib/features/reader/presentation/widgets/reader_gestures/swipe_navigation_wrapper.dart
+++ b/lib/features/reader/presentation/widgets/reader_gestures/swipe_navigation_wrapper.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
-import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart';
@@ -66,20 +64,26 @@ class _SwipeNavigationWrapperState
               child: PlanNavigationBottomBar(
                 navigationContext: navigationContext,
                 fallbackTitle: widget.textDetail.title,
-                fallbackTitleFontFamily: getFontFamily(widget.textDetail.language),
-                onPreviousTap: canSwipe
-                    ? () => _navigate(
+                fallbackTitleFontFamily: getFontFamily(
+                  widget.textDetail.language,
+                ),
+                onPreviousTap:
+                    canSwipe
+                        ? () => _navigate(
                           navigationContext,
                           SwipeDirection.previous,
                         )
-                    : null,
-                onNextTap: canSwipe
-                    ? () => _navigate(navigationContext, SwipeDirection.next)
-                    : null,
-                onFinishedTap: navigationContext != null &&
-                        navigationContext.source == NavigationSource.plan
-                    ? _finishReading
-                    : null,
+                        : null,
+                onNextTap:
+                    canSwipe
+                        ? () =>
+                            _navigate(navigationContext, SwipeDirection.next)
+                        : null,
+                onFinishedTap:
+                    navigationContext != null &&
+                            navigationContext.source == NavigationSource.plan
+                        ? _finishReading
+                        : null,
               ),
             ),
         ],
@@ -103,6 +107,7 @@ class _SwipeNavigationWrapperState
 
     if (direction == SwipeDirection.next) {
       completeCurrentPlanSubtask(ref, currentContext);
+      invalidatePlanProviders(ref, currentContext);
     }
 
     // Clear UI state before navigation for clean transition
@@ -126,19 +131,7 @@ class _SwipeNavigationWrapperState
   void _finishReading() {
     final navContext = widget.params.navigationContext;
     completeCurrentPlanSubtask(ref, navContext);
-
-    if (navContext != null && navContext.source == NavigationSource.plan) {
-      final planId = navContext.planId;
-      final dayNumber = navContext.dayNumber;
-      if (planId != null && dayNumber != null) {
-        ref.invalidate(
-          userPlanDayContentFutureProvider(
-            PlanDaysParams(planId: planId, dayNumber: dayNumber),
-          ),
-        );
-        ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
-      }
-    }
+    invalidatePlanProviders(ref, navContext);
     if (mounted) context.pop();
   }
 }

--- a/lib/features/reader/presentation/widgets/reader_gestures/swipe_navigation_wrapper.dart
+++ b/lib/features/reader/presentation/widgets/reader_gestures/swipe_navigation_wrapper.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/core/extensions/context_ext.dart';
-import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_subtask_completion.dart';
 import 'package:flutter_pecha/features/reader/constants/reader_constants.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
 import 'package:flutter_pecha/features/reader/presentation/providers/reader_notifier.dart';
@@ -12,7 +13,13 @@ import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-/// Wrapper widget that handles swipe gestures for plan navigation
+/// Wraps the reader content with horizontal-swipe gestures and the shared
+/// plan navigation bottom bar.
+///
+/// Both prev/next gestures and bottom-bar arrows route through
+/// [PlanNavigator], which picks the correct screen for the next item's
+/// content type — so a SOURCE_REFERENCE → TEXT transition (or vice versa)
+/// happens transparently mid-sequence.
 class SwipeNavigationWrapper extends ConsumerStatefulWidget {
   final Widget child;
   final ReaderParams params;
@@ -34,219 +41,92 @@ class SwipeNavigationWrapper extends ConsumerStatefulWidget {
 
 class _SwipeNavigationWrapperState
     extends ConsumerState<SwipeNavigationWrapper> {
-  static final _logger = AppLogger('SwipeNavigationWrapper');
-  final NavigationService _navigationService = const NavigationService();
   bool _isNavigating = false;
 
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(readerNotifierProvider(widget.params));
     final navigationContext = state.navigationContext;
-    final localizations = context.l10n;
-    // Hide bottom navigation bar when segment action bar is visible
     final hideBottomNav = state.hasSelection && !state.isCommentaryOpen;
+    final showBottomBar = !hideBottomNav && !state.isCommentaryOpen;
 
-    // Show bottom bar for all readers (with or without navigation context)
-    final showBottomBar = !hideBottomNav;
-
-    // Determine if we should enable swipe and show full controls
     final canSwipe = navigationContext != null && navigationContext.canSwipe;
-    final isPlanNavigation =
-        navigationContext != null &&
-        navigationContext.source == NavigationSource.plan;
 
     return GestureDetector(
-      onHorizontalDragStart: canSwipe ? _onDragStart : null,
       onHorizontalDragEnd:
           canSwipe ? (details) => _onDragEnd(details, navigationContext) : null,
       child: Stack(
         children: [
           widget.child,
-          // Circular audio play button - positioned above SegmentActionBar
-          // if (!state.isCommentaryOpen)
-          //   AnimatedPositioned(
-          //     duration: const Duration(milliseconds: 300),
-          //     curve: Curves.easeInOut,
-          //     bottom: hideBottomNav ? 110 : 80,
-          //     left: MediaQuery.of(context).size.width / 2 - 28,
-          //     child: Material(
-          //       elevation: 4,
-          //       shape: const CircleBorder(),
-          //       color: Theme.of(context).cardColor,
-          //       child: InkWell(
-          //         onTap: () {
-          //           // show a comming soon snackbar
-          //           ScaffoldMessenger.of(context).showSnackBar(
-          //             SnackBar(
-          //               content: Text(localizations.comingSoonHeadline),
-          //               duration: Duration(seconds: 2),
-          //             ),
-          //           );
-          //         },
-          //         customBorder: const CircleBorder(),
-          //         child: Container(
-          //           width: 56,
-          //           height: 56,
-          //           padding: const EdgeInsets.all(8),
-          //           child: Icon(
-          //             Icons.play_arrow_rounded,
-          //             size: 32,
-          //             color: Theme.of(context).colorScheme.onSurface,
-          //           ),
-          //         ),
-          //       ),
-          //     ),
-          //   ),
-          // Bottom bar - always present but animated in/out
-          if (showBottomBar && !state.isCommentaryOpen)
-            _BottomBar(
-              textDetail: widget.textDetail,
-              navigationContext: navigationContext,
-              isPlanNavigation: isPlanNavigation,
-              isAppBarVisible: widget.isAppBarVisible,
-              onPreviousTap:
-                  canSwipe
-                      ? () => _navigateToAdjacentText(
-                        navigationContext,
-                        SwipeDirection.previous,
-                      )
-                      : null,
-              onNextTap:
-                  canSwipe
-                      ? () => _navigateToAdjacentText(
-                        navigationContext,
-                        SwipeDirection.next,
-                      )
-                      : null,
-              onFinishedTap: canSwipe ? _finishReading : null,
+          if (showBottomBar)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: PlanNavigationBottomBar(
+                navigationContext: navigationContext,
+                fallbackTitle: widget.textDetail.title,
+                fallbackTitleFontFamily: getFontFamily(widget.textDetail.language),
+                onPreviousTap: canSwipe
+                    ? () => _navigate(
+                          navigationContext,
+                          SwipeDirection.previous,
+                        )
+                    : null,
+                onNextTap: canSwipe
+                    ? () => _navigate(navigationContext, SwipeDirection.next)
+                    : null,
+                onFinishedTap: navigationContext != null &&
+                        navigationContext.source == NavigationSource.plan
+                    ? _finishReading
+                    : null,
+              ),
             ),
         ],
       ),
     );
   }
 
-  void _onDragStart(DragStartDetails details) {
-    // Track start position if needed for more complex gesture detection
-    // Currently using velocity-based navigation
-  }
-
   void _onDragEnd(DragEndDetails details, NavigationContext navigationContext) {
     if (_isNavigating) return;
 
     final velocity = details.primaryVelocity ?? 0;
-
-    // Check if swipe velocity exceeds threshold
-    if (velocity.abs() < ReaderConstants.swipeVelocityThreshold) {
-      return;
-    }
+    if (velocity.abs() < ReaderConstants.swipeVelocityThreshold) return;
 
     final direction =
         velocity > 0 ? SwipeDirection.previous : SwipeDirection.next;
-
-    // Check if navigation is possible
-    if (!_navigationService.canNavigate(navigationContext, direction)) {
-      return;
-    }
-
-    _navigateToAdjacentText(navigationContext, direction);
+    _navigate(navigationContext, direction);
   }
 
-  void _completeCurrentSubtask() {
-    final navContext = widget.params.navigationContext;
-    if (navContext == null || navContext.source != NavigationSource.plan) {
-      return;
-    }
-
-    final items = navContext.planTextItems;
-    final index = navContext.currentTextIndex;
-    if (items == null || index == null || index < 0 || index >= items.length) {
-      return;
-    }
-
-    final currentItem = items[index];
-    final subtaskId = currentItem.subtaskId;
-    if (subtaskId == null || subtaskId.isEmpty) return;
-    if (currentItem.isCompleted) return;
-
-    final planId = navContext.planId;
-    final dayNumber = navContext.dayNumber;
-
-    Future.microtask(() async {
-      try {
-        final result = await ref.read(
-          completeSubTaskFutureProvider(subtaskId).future,
-        );
-        result.fold(
-          (failure) =>
-              _logger.error('Failed to complete subtask: ${failure.message}'),
-          (_) {
-            _logger.info('Marked subtask $subtaskId as complete on navigation');
-            // Invalidate providers to refresh UI when user returns to plan screen
-            if (planId != null && dayNumber != null) {
-              ref.invalidate(
-                userPlanDayContentFutureProvider(
-                  PlanDaysParams(planId: planId, dayNumber: dayNumber),
-                ),
-              );
-              ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
-            }
-          },
-        );
-      } catch (e) {
-        _logger.error('Failed to complete subtask $subtaskId', e);
-      }
-    });
-  }
-
-  void _navigateToAdjacentText(
-    NavigationContext currentContext,
-    SwipeDirection direction,
-  ) {
+  void _navigate(NavigationContext currentContext, SwipeDirection direction) {
     if (_isNavigating) return;
 
-    final newContext = _navigationService.createNavigationContextForAdjacent(
-      currentContext,
-      direction,
-    );
-
-    if (newContext == null) return;
-
-    final adjacentText = _navigationService.getAdjacentText(
-      currentContext,
-      direction,
-    );
-    if (adjacentText == null) return;
-
     if (direction == SwipeDirection.next) {
-      _completeCurrentSubtask();
+      completeCurrentPlanSubtask(ref, currentContext);
     }
-
-    _isNavigating = true;
 
     // Clear UI state before navigation for clean transition
     final notifier = ref.read(readerNotifierProvider(widget.params).notifier);
     notifier.selectSegment(null);
     notifier.closeCommentary();
 
-    // Navigate to the new text
-    // Pass NavigationContext directly (it already contains targetSegmentId)
-    context.pushReplacement(
-      '/reader/${adjacentText.textId}',
-      extra: newContext,
+    final didNavigate = PlanNavigator.navigateAdjacent(
+      context,
+      currentContext,
+      direction,
     );
+    if (!didNavigate) return;
 
-    // Reset navigating flag after a short delay
+    _isNavigating = true;
     Future.delayed(const Duration(milliseconds: 500), () {
-      if (mounted) {
-        _isNavigating = false;
-      }
+      if (mounted) _isNavigating = false;
     });
   }
 
   void _finishReading() {
-    _completeCurrentSubtask();
-
     final navContext = widget.params.navigationContext;
+    completeCurrentPlanSubtask(ref, navContext);
+
     if (navContext != null && navContext.source == NavigationSource.plan) {
       final planId = navContext.planId;
       final dayNumber = navContext.dayNumber;
@@ -259,210 +139,6 @@ class _SwipeNavigationWrapperState
         ref.invalidate(userPlanDaysCompletionStatusProvider(planId));
       }
     }
-    if (mounted) {
-      context.pop();
-    }
-  }
-}
-
-/// Bottom bar - shows title only initially, expands to show full controls when tapped
-class _BottomBar extends StatelessWidget {
-  final NavigationContext? navigationContext;
-  final TextDetail textDetail;
-  final bool isPlanNavigation;
-  final bool isAppBarVisible;
-  final VoidCallback? onPreviousTap;
-  final VoidCallback? onNextTap;
-  final VoidCallback? onFinishedTap;
-
-  const _BottomBar({
-    required this.textDetail,
-    required this.navigationContext,
-    this.isPlanNavigation = false,
-    required this.isAppBarVisible,
-    required this.onPreviousTap,
-    required this.onNextTap,
-    this.onFinishedTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final canSwipe = navigationContext != null && navigationContext!.canSwipe;
-
-    return Positioned(
-      left: 0,
-      right: 0,
-      bottom: 0,
-      child: AnimatedSlide(
-        duration: const Duration(milliseconds: 500),
-        curve: Curves.easeInOut,
-        offset: isAppBarVisible ? Offset.zero : Offset.zero,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: BoxDecoration(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            border: Border(
-              top: BorderSide(color: Theme.of(context).dividerColor, width: 1),
-            ),
-          ),
-          child: SafeArea(
-            top: false,
-            child:
-                canSwipe
-                    ? _buildFullControls(context)
-                    : isPlanNavigation
-                    ? _buildSingleItemControls(context)
-                    : _buildMinimalTitle(context),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMinimalTitle(BuildContext context) {
-    return Center(
-      child: Text(
-        textDetail.title,
-        overflow: TextOverflow.ellipsis,
-        maxLines: 1,
-        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-          fontFamily: getFontFamily(textDetail.language),
-          fontWeight: FontWeight.bold,
-        ),
-        textAlign: TextAlign.center,
-      ),
-    );
-  }
-
-  Widget _buildSingleItemControls(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Expanded(
-          child: Text(
-            textDetail.title,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontFamily: getFontFamily(textDetail.language),
-              fontWeight: FontWeight.bold,
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ),
-        _NavigationButton(
-          icon: Icons.check,
-          isEnabled: true,
-          onTap: onFinishedTap ?? () => context.pop(),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildFullControls(BuildContext context) {
-    final hasPrevious = navigationContext!.hasPreviousText;
-    final hasNext = navigationContext!.hasNextText;
-    final progress = _getProgressText();
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        // Previous button
-        if (hasPrevious)
-          _NavigationButton(
-            icon: Icons.chevron_left,
-            isEnabled: hasPrevious,
-            onTap: hasPrevious ? onPreviousTap! : () => context.pop(),
-          ),
-        // Progress text
-        Expanded(
-          child: Column(
-            children: [
-              // text title
-              Text(
-                textDetail.title,
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-                style: Theme.of(
-                  context,
-                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              Text(
-                progress,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(
-                    context,
-                  ).textTheme.bodySmall?.color?.withAlpha(180),
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ],
-          ),
-        ),
-        // Next button
-        if (hasNext)
-          _NavigationButton(
-            icon: Icons.chevron_right,
-            isEnabled: hasNext,
-            onTap: hasNext ? onNextTap! : () => context.pop(),
-          ),
-
-        // if is last text, show checked icon to pop back to the plan screen
-        if (!hasNext)
-          _NavigationButton(
-            icon: Icons.check,
-            isEnabled: !hasNext,
-            onTap: onFinishedTap ?? () => context.pop(),
-          ),
-      ],
-    );
-  }
-
-  String _getProgressText() {
-    final items = navigationContext?.planTextItems;
-    final index = navigationContext?.currentTextIndex;
-    if (items == null || index == null) return '';
-    return '${index + 1} of ${items.length}';
-  }
-}
-
-/// Individual navigation button (left/right arrow)
-class _NavigationButton extends StatelessWidget {
-  final IconData icon;
-  final bool isEnabled;
-  final VoidCallback onTap;
-
-  const _NavigationButton({
-    required this.icon,
-    required this.isEnabled,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final color =
-        isEnabled
-            ? Theme.of(context).colorScheme.onSurface
-            : Theme.of(context).colorScheme.onSurface.withAlpha(80);
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(24),
-        child: Container(
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            border: Border.all(
-              color: color.withAlpha(isEnabled ? 100 : 50),
-              width: 1,
-            ),
-          ),
-          child: Icon(icon, size: 24, color: color),
-        ),
-      ),
-    );
+    if (mounted) context.pop();
   }
 }


### PR DESCRIPTION
# Navigation Refactor: After vs Before

```mermaid
flowchart LR

%% AFTER
subgraph AFTER
    A1["ActivityList each task"] --> B1["Build List PlanTextItem"]

    B1 --> C1["PlanSubtaskNavigation"]
    C1 --> D1["fromUserTasks"]
    C1 --> E1["fromPlanTasks"]
    C1 --> F1["Validate and convert"]

    F1 --> G1["PlanNavigator push"]
    G1 --> H1{"Content Type"}

    H1 -->|SOURCE_REFERENCE| I1["reader route"]
    H1 -->|TEXT| J1["plan-text route"]

    I1 --> K1["ReaderScreen"]
    J1 --> L1["PlanTextScreen"]

    K1 --> M1["BottomBar"]
    L1 --> M1

    M1 --> N1["prev | X of N | done"]
end

%% BEFORE
subgraph BEFORE
    A["ActivityList each task"] --> B["Open ReaderScreen only"]
    B --> C["Assumes SOURCE_REFERENCE"]

    D["TEXT content_type"] --> E["No path"]
    E --> F["Crash or empty reader"]

    G["SOURCE_REFERENCE"] --> B
end