### PR TITLE
Feat/special event notification

### DIFF
--- a/lib/core/storage/special_plan_started_at_store.dart
+++ b/lib/core/storage/special_plan_started_at_store.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_pecha/core/storage/storage_keys.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Synchronous-read store for special-plan `startedAt` dates.
+///
+/// The notification scheduler (`RoutineNotificationService`) is a non-Riverpod
+/// singleton invoked from background contexts, so it cannot await a
+/// SharedPreferences load each time it schedules. Instead, we cache the
+/// `SharedPreferences` instance once at startup via [init] and expose
+/// synchronous getters.
+///
+/// Source of truth for `startedAt` is the server's `UserPlansModel.startedAt`.
+/// We mirror it here so the day-N resolver works without going through the
+/// plans repository at schedule time.
+class SpecialPlanStartedAtStore {
+  SpecialPlanStartedAtStore._();
+
+  static SharedPreferences? _prefs;
+
+  /// Initialize the cached [SharedPreferences] instance. Safe to call multiple
+  /// times — second call is a no-op once primed. Call early in app startup
+  /// (before any notification scheduling).
+  static Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  static String _key(String planId) =>
+      '${StorageKeys.specialPlanStartedAtPrefix}$planId';
+
+  /// Reads the `startedAt` for [planId], or `null` if unknown.
+  /// Returns `null` when [init] has not run yet.
+  static DateTime? getStartedAt(String planId) {
+    final prefs = _prefs;
+    if (prefs == null) return null;
+    final raw = prefs.getString(_key(planId));
+    if (raw == null || raw.isEmpty) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  /// Persists [startedAt] for [planId]. Async because SharedPreferences write
+  /// goes to disk; the in-memory cache is updated synchronously by the plugin.
+  static Future<void> setStartedAt(String planId, DateTime startedAt) async {
+    final prefs = await _ensurePrefs();
+    await prefs.setString(_key(planId), startedAt.toIso8601String());
+    // ignore: avoid_print
+    print(
+      '[SP-STORE] setStartedAt planId=$planId startedAt=${startedAt.toIso8601String()}',
+    );
+  }
+
+  /// Removes the entry for [planId].
+  static Future<void> clear(String planId) async {
+    final prefs = await _ensurePrefs();
+    await prefs.remove(_key(planId));
+  }
+
+  /// Removes all special-plan startedAt entries AND day-1-shown flags.
+  /// Use on logout so a different user signing in starts fresh.
+  static Future<void> clearAll() async {
+    final prefs = await _ensurePrefs();
+    final keysToRemove = prefs
+        .getKeys()
+        .where(
+          (k) =>
+              k.startsWith(StorageKeys.specialPlanStartedAtPrefix) ||
+              k.startsWith(StorageKeys.specialPlanDay1ShownPrefix),
+        )
+        .toList();
+    for (final k in keysToRemove) {
+      await prefs.remove(k);
+    }
+  }
+
+  /// True if the Day 1 immediate-fire notification has already been shown for
+  /// [planId] given the [startedAt] date (date-only key).
+  static bool wasDay1Shown(String planId, DateTime startedAt) {
+    final prefs = _prefs;
+    if (prefs == null) return false;
+    return prefs.getBool(_day1Key(planId, startedAt)) ?? false;
+  }
+
+  /// Marks Day 1 as shown for [planId] on [startedAt]'s date.
+  static Future<void> markDay1Shown(String planId, DateTime startedAt) async {
+    final prefs = await _ensurePrefs();
+    final key = _day1Key(planId, startedAt);
+    await prefs.setBool(key, true);
+    // ignore: avoid_print
+    print('[SP-STORE] markDay1Shown key=$key value=true');
+  }
+
+  static String _day1Key(String planId, DateTime startedAt) {
+    final y = startedAt.year.toString().padLeft(4, '0');
+    final m = startedAt.month.toString().padLeft(2, '0');
+    final d = startedAt.day.toString().padLeft(2, '0');
+    return '${StorageKeys.specialPlanDay1ShownPrefix}${planId}_$y-$m-$d';
+  }
+
+  static Future<SharedPreferences> _ensurePrefs() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+}

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -56,6 +56,12 @@ class StorageKeys {
   static const String dailyReminderTime = 'daily_reminder_time';
   /// Daily reminder enabled flag
   static const String dailyReminderEnabled = 'daily_reminder_enabled';
+  /// Per-plan startedAt prefix for special-plan day-N notification series.
+  /// Full key: `special_plan_started_at_<planId>` → ISO8601 string.
+  static const String specialPlanStartedAtPrefix = 'special_plan_started_at_';
+  /// Per-plan idempotency flag prefix preventing duplicate Day 1 immediate
+  /// fires. Full key: `special_plan_day1_shown_<planId>_<yyyy-MM-dd>` → bool.
+  static const String specialPlanDay1ShownPrefix = 'special_plan_day1_shown_';
 
   // ========== FEATURES ==========
   /// Profile data JSON

--- a/lib/features/auth/presentation/providers/auth_notifier.dart
+++ b/lib/features/auth/presentation/providers/auth_notifier.dart
@@ -1,8 +1,10 @@
 // Riverpod provider and logic for authentication state.
 import 'dart:convert';
 
+import 'package:flutter_pecha/core/storage/special_plan_started_at_store.dart';
 import 'package:flutter_pecha/core/storage/storage_keys.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/notifications/data/services/routine_notification_service.dart';
 import 'package:flutter_pecha/core/utils/local_storage_service.dart';
 import 'package:flutter_pecha/features/auth/domain/entities/auth_credentials.dart';
 import 'package:flutter_pecha/features/auth/domain/usecases/clear_guest_mode_and_onboarding_usecase.dart';
@@ -323,6 +325,19 @@ class AuthNotifier extends StateNotifier<AuthState> {
     await ref
         .read(localStorageServiceProvider)
         .remove(StorageKeys.currentUserId);
+
+    // Reset special-plan day-N cache so a different user signing in does not
+    // inherit the prior user's day index or "day 1 already shown" flag.
+    await SpecialPlanStartedAtStore.clearAll();
+
+    // Cancel any pending special-plan one-shot notifications so the next user
+    // (or the same user after re-login) does not receive notifications keyed
+    // off the previous session's startedAt.
+    try {
+      await RoutineNotificationService().cancelAllSpecialPlanSchedules();
+    } catch (e) {
+      _logger.warning('Failed to cancel special-plan schedules on logout: $e');
+    }
 
     state = state.copyWith(isLoggedIn: false, isLoading: false, isGuest: false);
     _logger.info('User logged out, auth and user state cleared');

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -14,6 +14,8 @@ import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
 import 'package:flutter_pecha/features/home/presentation/providers/tags_provider.dart';
 import 'package:flutter_pecha/features/home/presentation/home_screen_constants.dart';
 import 'package:flutter_pecha/features/home/presentation/widgets/tag_card.dart';
+import 'package:flutter_pecha/features/notifications/application/special_plan_enrollment_hook.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
 import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -53,13 +55,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Future<void> _requestNotificationPermissionsIfNeeded() async {
+    _log.info('[SP-HOME] _requestNotificationPermissionsIfNeeded ENTER '
+        'hasRequested=$_hasRequestedPermissions');
     if (_hasRequestedPermissions) return;
     _hasRequestedPermissions = true;
 
     final notificationService = ref.read(notificationServiceProvider);
     if (notificationService == null) {
       _log.warning(
-        'NotificationService not initialized, skipping permission request',
+        '[SP-HOME] NotificationService not initialized, skipping permission request',
       );
       _navigateToPendingPlanIfNeeded();
       return;
@@ -69,20 +73,74 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       // Check if permissions are already granted
       final alreadyEnabled =
           await notificationService.areNotificationsEnabled();
+      _log.info('[SP-HOME] alreadyEnabled=$alreadyEnabled');
       if (!alreadyEnabled) {
-        _log.info('Requesting notification permissions...');
+        _log.info('[SP-HOME] requesting notification permissions...');
         final granted = await notificationService.requestPermission();
-        _log.info(granted
-            ? 'Notification permissions granted'
-            : 'Notification permissions denied');
+        _log.info('[SP-HOME] permission request result granted=$granted');
       }
     } catch (e) {
-      _log.warning('Error requesting notification permissions: $e');
+      _log.warning('[SP-HOME] error requesting notification permissions: $e');
     }
+
+    // Permission flow has run — fire any pending special-plan Day 1
+    // notifications now (e.g. user just enrolled in ITCC during onboarding
+    // after 09:00). Without permission, `_plugin.show()` silently no-ops, so
+    // this MUST run after the permission request above.
+    await _firePendingSpecialPlanDay1IfNeeded();
 
     // After the permission flow (dialog shown or already granted), check
     // whether onboarding left a plan waiting to be opened in Practice.
     _navigateToPendingPlanIfNeeded();
+  }
+
+  Future<void> _firePendingSpecialPlanDay1IfNeeded() async {
+    _log.info('[SP-HOME] _firePendingSpecialPlanDay1IfNeeded ENTER');
+    // Invalidate first — the provider may have been evaluated pre-login
+    // (no auth header) and cached a Forbidden failure. We need a fresh read.
+    _log.info('[SP-HOME] invalidating userPlansFutureProvider for fresh fetch');
+    ref.invalidate(userPlansFutureProvider);
+
+    const maxAttempts = 3;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      _log.info('[SP-HOME] fetch attempt $attempt/$maxAttempts');
+      try {
+        final userPlansAsync = await ref.read(userPlansFutureProvider.future);
+        final isFailure = userPlansAsync.isLeft();
+        _log.info('[SP-HOME] attempt $attempt resolved isFailure=$isFailure');
+        if (isFailure && attempt < maxAttempts) {
+          _log.warning(
+            '[SP-HOME] attempt $attempt failed — invalidating and retrying: '
+            '${userPlansAsync.fold((f) => f, (_) => "")}',
+          );
+          ref.invalidate(userPlansFutureProvider);
+          await Future.delayed(const Duration(milliseconds: 400));
+          continue;
+        }
+        await userPlansAsync.fold(
+          (failure) async {
+            _log.warning(
+              '[SP-HOME] giving up after $attempt attempts — fetch failed: $failure',
+            );
+          },
+          (response) async {
+            _log.info(
+              '[SP-HOME] user plans loaded count=${response.userPlans.length} '
+              'on attempt=$attempt, calling tryFirePendingSpecialPlanDay1Notifications',
+            );
+            await tryFirePendingSpecialPlanDay1Notifications(response.userPlans);
+          },
+        );
+        break;
+      } catch (e, st) {
+        _log.warning('[SP-HOME] attempt $attempt threw: $e\n$st');
+        if (attempt < maxAttempts) {
+          ref.invalidate(userPlansFutureProvider);
+          await Future.delayed(const Duration(milliseconds: 400));
+        }
+      }
+    }
+    _log.info('[SP-HOME] _firePendingSpecialPlanDay1IfNeeded EXIT');
   }
 
   /// Consumes [pendingOnboardingPlanProvider] and navigates to the Practice

--- a/lib/features/notifications/application/special_plan_bootstrap.dart
+++ b/lib/features/notifications/application/special_plan_bootstrap.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_pecha/core/storage/special_plan_started_at_store.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/notifications/data/special_plan_notifications.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/practice_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final _logger = AppLogger('SpecialPlanBootstrap');
+
+/// Eagerly-instantiated provider that mirrors `UserPlansModel.startedAt` for
+/// any plan ID in [kSpecialPlanNotifications] into [SpecialPlanStartedAtStore]
+/// each time `userPlansFutureProvider` resolves, then directly reschedules the
+/// per-day series via [RoutineNotificationService.rescheduleSpecialPlanSeries].
+///
+/// Why: the day-N notifications are deterministic one-shots keyed off
+/// `startedAt`. After uninstall+reinstall, login on a new device, or a
+/// timezone/clock change, those one-shots may be missing from the OS schedule.
+/// Rescheduling here — independent of the local Hive routine state — is
+/// idempotent (cancels first) and guarantees the next day's fire is registered
+/// even when `_loadRoutines` hasn't populated the routine block yet.
+final specialPlanBootstrapProvider = Provider<void>((ref) {
+  _logger.info('[SP-BOOT] specialPlanBootstrapProvider initialized — listening to userPlansFutureProvider');
+  ref.listen<AsyncValue<dynamic>>(userPlansFutureProvider, (previous, next) {
+    _logger.info('[SP-BOOT] userPlansFutureProvider state changed: ${next.runtimeType}');
+    next.whenData((either) async {
+      either.fold(
+        (failure) => _logger.warning(
+          '[SP-BOOT] userPlans fetch failed — cannot bootstrap: $failure',
+        ),
+        (response) async {
+          _logger.info(
+            '[SP-BOOT] userPlans loaded: ${response.userPlans.length} plans',
+          );
+          for (final plan in response.userPlans) {
+            if (!isSpecialPlan(plan.id)) continue;
+            await _bootstrapPlan(ref, plan);
+          }
+          _logger.info('[SP-BOOT] iteration done');
+        },
+      );
+    });
+  });
+});
+
+Future<void> _bootstrapPlan(Ref ref, UserPlansModel plan) async {
+  final cached = SpecialPlanStartedAtStore.getStartedAt(plan.id);
+  _logger.info(
+    '[SP-BOOT] special plan ${plan.id} cached=$cached '
+    'serverStartedAt=${plan.startedAt.toIso8601String()}',
+  );
+  if (cached?.toIso8601String() != plan.startedAt.toIso8601String()) {
+    await SpecialPlanStartedAtStore.setStartedAt(plan.id, plan.startedAt);
+    _logger.info(
+      '[SP-BOOT] wrote startedAt for ${plan.id} = ${plan.startedAt.toIso8601String()}',
+    );
+  } else {
+    _logger.info('[SP-BOOT] cache up-to-date for ${plan.id} — no write');
+  }
+
+  // Always reschedule (idempotent) so the OS schedule survives uninstall +
+  // reinstall and re-login, regardless of whether the routine-block Hive
+  // state has loaded yet.
+  try {
+    final notifService = ref.read(routineNotificationServiceProvider);
+    await notifService.rescheduleSpecialPlanSeries(
+      planId: plan.id,
+      planTitle: plan.title,
+      planImageUrl: plan.imageUrl,
+    );
+  } catch (e, st) {
+    _logger.error('[SP-BOOT] rescheduleSpecialPlanSeries failed for ${plan.id}', e, st);
+  }
+}

--- a/lib/features/notifications/application/special_plan_enrollment_hook.dart
+++ b/lib/features/notifications/application/special_plan_enrollment_hook.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_pecha/core/storage/special_plan_started_at_store.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/notifications/data/services/routine_notification_service.dart';
+import 'package:flutter_pecha/features/notifications/data/special_plan_notifications.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+
+final _logger = AppLogger('SpecialPlanEnrollmentHook');
+
+/// 09:00 — the routine block time used by event-enrollments. If the user
+/// enrolls before this time, the regular daily routine notification will
+/// serve as Day 1, so the immediate fire is skipped to avoid duplicates.
+const int kRoutineBlockHourThreshold = 9;
+
+/// Call after a user has been (newly or repeatedly) enrolled in [plan].
+/// Persists `plan.startedAt` (server truth) into [SpecialPlanStartedAtStore]
+/// so the routine notification scheduler can compute day-N at fire time.
+///
+/// Does NOT fire the immediate Day 1 notification — that requires the
+/// notification permission, which is only requested after the home screen
+/// mounts (post-onboarding). The actual fire happens via
+/// [tryFirePendingSpecialPlanDay1Notifications], called from the home screen
+/// once permission has been granted.
+Future<void> onSpecialPlanEnrolled(UserPlansModel plan) async {
+  _logger.info(
+    '[SP-HOOK] onSpecialPlanEnrolled called: planId=${plan.id} '
+    'title="${plan.title}" startedAt=${plan.startedAt.toIso8601String()} '
+    'startedAtLocal=${plan.startedAt.toLocal()}',
+  );
+  if (!isSpecialPlan(plan.id)) {
+    _logger.info('[SP-HOOK] planId=${plan.id} is NOT a special plan — skip');
+    return;
+  }
+
+  await SpecialPlanStartedAtStore.setStartedAt(plan.id, plan.startedAt);
+  _logger.info(
+    '[SP-HOOK] cached startedAt for ${plan.id} = ${plan.startedAt.toIso8601String()}',
+  );
+}
+
+/// Fires the Day 1 immediate notification for any [plans] whose:
+///   - id is in [kSpecialPlanNotifications],
+///   - startedAt date == today (local),
+///   - current local hour ≥ 09:00 (otherwise the scheduled 09:00 fire serves
+///     as Day 1, so skipping avoids duplicates),
+///   - and Day 1 has not already been shown today (idempotency flag).
+///
+/// Call this AFTER notification permission has been requested/granted, e.g.
+/// from `HomeScreen._requestNotificationPermissionsIfNeeded`. Without
+/// permission, `flutter_local_notifications.show()` silently no-ops on iOS
+/// and Android 13+ — so we cannot fire from inside the onboarding flow.
+Future<void> tryFirePendingSpecialPlanDay1Notifications(
+  Iterable<UserPlansModel> plans,
+) async {
+  final now = DateTime.now();
+  final planList = plans.toList();
+  _logger.info(
+    '[SP-DAY1-HOOK] tryFirePendingSpecialPlanDay1Notifications called '
+    'plans=${planList.length} now=$now (local) hour=${now.hour} '
+    'threshold=$kRoutineBlockHourThreshold',
+  );
+  for (final plan in planList) {
+    _logger.info(
+      '[SP-DAY1-HOOK] evaluating planId=${plan.id} title="${plan.title}" '
+      'startedAt=${plan.startedAt} startedAtLocal=${plan.startedAt.toLocal()}',
+    );
+    if (!isSpecialPlan(plan.id)) {
+      _logger.info('[SP-DAY1-HOOK] skip ${plan.id}: not a special plan');
+      continue;
+    }
+
+    final startedLocal = plan.startedAt.toLocal();
+    final isEnrollmentDay = DateTime(
+          startedLocal.year,
+          startedLocal.month,
+          startedLocal.day,
+        ) ==
+        DateTime(now.year, now.month, now.day);
+    _logger.info(
+      '[SP-DAY1-HOOK] enrollment-day check planId=${plan.id} '
+      'startedLocal=${startedLocal.year}-${startedLocal.month}-${startedLocal.day} '
+      'now=${now.year}-${now.month}-${now.day} isEnrollmentDay=$isEnrollmentDay',
+    );
+    if (!isEnrollmentDay) {
+      _logger.info(
+        '[SP-DAY1-HOOK] skip ${plan.id}: not enrollment day '
+        '(startedAt=${plan.startedAt}, now=$now)',
+      );
+      continue;
+    }
+
+    if (now.hour < kRoutineBlockHourThreshold) {
+      _logger.info(
+        '[SP-DAY1-HOOK] skip ${plan.id}: now hour=${now.hour} < $kRoutineBlockHourThreshold '
+        '— scheduled 09:00 routine fire will serve as Day 1',
+      );
+      continue;
+    }
+
+    // Ensure the cache has the startedAt — usually populated by
+    // [onSpecialPlanEnrolled] or the bootstrap listener, but be defensive.
+    final cached = SpecialPlanStartedAtStore.getStartedAt(plan.id);
+    _logger.info('[SP-DAY1-HOOK] cache lookup ${plan.id} cached=$cached');
+    if (cached == null) {
+      _logger.info('[SP-DAY1-HOOK] cache miss ${plan.id} — priming startedAt');
+      await SpecialPlanStartedAtStore.setStartedAt(plan.id, plan.startedAt);
+    }
+
+    _logger.info('[SP-DAY1-HOOK] firing Day 1 immediate for ${plan.id}');
+    final id = await RoutineNotificationService().showSpecialPlanDay1Immediate(
+      planId: plan.id,
+      planTitle: plan.title,
+      planImageUrl: plan.imageUrl,
+    );
+    _logger.info('[SP-DAY1-HOOK] Day 1 fire for ${plan.id} returned id=$id');
+  }
+  _logger.info('[SP-DAY1-HOOK] done iterating ${planList.length} plans');
+}

--- a/lib/features/notifications/data/channels/notification_channels.dart
+++ b/lib/features/notifications/data/channels/notification_channels.dart
@@ -39,12 +39,22 @@ class NotificationChannels {
         enableVibration: true,
       );
 
+  /// Action ID used for the Android action button on special-plan day-N
+  /// notifications. The tap handler treats this the same as a body tap.
+  static const String specialPlanActionId = 'special_plan_action';
+
   /// Full platform-specific NotificationDetails for routine block notifications.
+  ///
+  /// [androidActionButtonText] adds a single Android action button (e.g.
+  /// "START", "READ ON"). When `null`, no action button is rendered. iOS does
+  /// not render this label per product decision — body tap on iOS routes to
+  /// the same destination, preserving functionality.
   static NotificationDetails routineBlockDetails({
     String icon = 'ic_notification',
     StyleInformation? styleInformation,
     FilePathAndroidBitmap? largeIcon,
     DarwinNotificationDetails? iOSDetails,
+    String? androidActionButtonText,
   }) =>
       NotificationDetails(
         android: AndroidNotificationDetails(
@@ -59,6 +69,16 @@ class NotificationChannels {
           enableVibration: true,
           playSound: true,
           sound: routineAndroidSound,
+          actions: androidActionButtonText == null
+              ? null
+              : <AndroidNotificationAction>[
+                  AndroidNotificationAction(
+                    specialPlanActionId,
+                    androidActionButtonText,
+                    showsUserInterface: true,
+                    cancelNotification: true,
+                  ),
+                ],
         ),
         iOS: iOSDetails ?? DarwinNotificationDetails(
           sound: routineIosSoundFile,

--- a/lib/features/notifications/data/services/notification_service.dart
+++ b/lib/features/notifications/data/services/notification_service.dart
@@ -346,7 +346,15 @@ class NotificationService {
   }
 
   void _onNotificationTapped(NotificationResponse response) {
-    _logger.info('Notification tapped - ID: ${response.id}, Payload: ${response.payload}');
+    _logger.info(
+      'Notification tapped - ID: ${response.id}, '
+      'actionId: ${response.actionId}, Payload: ${response.payload}',
+    );
+
+    // Action button taps (e.g. special-plan day-N button) intentionally
+    // route the same as a body tap. The action button shares the
+    // notification's payload, so the existing parse-and-route logic below
+    // handles both cases without branching.
 
     if (_router == null || _container == null) {
       _logger.warning('Router/container not initialized, cannot navigate');

--- a/lib/features/notifications/data/services/routine_notification_service.dart
+++ b/lib/features/notifications/data/services/routine_notification_service.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_pecha/core/storage/special_plan_started_at_store.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/data/channels/notification_channels.dart';
 import 'package:flutter_pecha/features/notifications/data/services/notification_service.dart';
+import 'package:flutter_pecha/features/notifications/data/special_plan_notifications.dart';
 import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:timezone/timezone.dart' as tz;
@@ -102,6 +104,32 @@ class RoutineNotificationService {
     }
 
     try {
+      final firstItem = block.items.firstOrNull;
+
+      // Special-plan path: each day in the series has unique copy/button, so
+      // we cannot use a single `matchDateTimeComponents: time` repeating
+      // schedule (the OS would replay the same payload every day). Replace it
+      // with N deterministic one-shots, one per remaining day. The block's
+      // notificationId is cancelled to prevent duplicate fires from any
+      // previously-scheduled daily-repeat for the same block.
+      if (firstItem != null &&
+          firstItem.type == RoutineItemType.plan &&
+          isSpecialPlan(firstItem.id)) {
+        _logger.info(
+          '[SP-SCHEDULE] delegating to series scheduler for planId=${firstItem.id} '
+          'block=${block.id} notificationId=${block.notificationId}',
+        );
+        await _plugin.cancel(block.notificationId);
+        await rescheduleSpecialPlanSeries(
+          planId: firstItem.id,
+          planTitle: firstItem.title,
+          planImageUrl: firstItem.imageUrl,
+          blockHour: block.time.hour,
+          blockMinute: block.time.minute,
+        );
+        return NotificationResult.success(block.notificationId);
+      }
+
       final now = tz.TZDateTime.now(tz.local);
       var scheduledDate = tz.TZDateTime(
         tz.local,
@@ -121,20 +149,20 @@ class RoutineNotificationService {
         'tz=${tz.local.name}',
       );
 
-      final body = _getNotificationBody(block);
-      final firstItem = block.items.firstOrNull;
       final payload = firstItem != null
           ? jsonEncode({'itemId': firstItem.id, 'itemType': firstItem.type.name})
           : null;
 
-      // Add image support
+      final title = firstItem?.title ?? 'Time for your practice';
+      final body = _getNotificationBody(block);
+
       final androidStyle = await _buildBigPictureStyle(firstItem);
       final iosDetails = await _buildIOSNotificationDetails(firstItem);
       final largeIcon = await _getLargeIcon(firstItem);
 
       await _plugin.zonedSchedule(
         block.notificationId,
-        firstItem?.title ?? 'Time for your practice',
+        title,
         body,
         scheduledDate,
         NotificationChannels.routineBlockDetails(
@@ -169,6 +197,14 @@ class RoutineNotificationService {
     try {
       await _plugin.cancel(block.notificationId);
       _logger.info('Cancelled routine notification ID=${block.notificationId}');
+      // Special-plan blocks fan out into N one-shot schedules — cancel those
+      // too so disabling/removing the block stops the whole series.
+      final firstItem = block.items.firstOrNull;
+      if (firstItem != null &&
+          firstItem.type == RoutineItemType.plan &&
+          isSpecialPlan(firstItem.id)) {
+        await _cancelSpecialPlanSeriesForPlan(firstItem.id);
+      }
     } catch (e) {
       _logger.warning(
         'Failed to cancel notification ${block.notificationId}: $e',
@@ -240,6 +276,301 @@ class RoutineNotificationService {
     );
   }
 
+  /// Notification ID range reserved for one-shot special-plan immediate fires.
+  /// Sits below the routine-block hash range (1000-999999) and above the
+  /// flutter_local_notifications system reservation (0-99). 800 + dayIndex - 1
+  /// → range 800–807 for an 8-day series.
+  static const int _specialPlanOneShotIdBase = 800;
+
+  /// Notification ID range reserved for the daily 09:00 special-plan series.
+  /// Each plan in [kSpecialPlanNotifications] gets a contiguous slot of
+  /// [_specialPlanSeriesSlotSize] IDs starting at this base. ITCC (slot 0)
+  /// → 810..817. Future plans can claim slot 1 (820..827) etc.
+  static const int _specialPlanSeriesIdBase = 810;
+  static const int _specialPlanSeriesSlotSize = 10;
+
+  /// Returns a stable notification ID for [planId] day [dayIndex] (1-based).
+  /// Each special plan owns a 10-ID slot; the position inside [kSpecialPlanNotifications.keys]
+  /// determines the slot, so adding a new plan does not perturb existing IDs.
+  int _specialPlanSeriesNotifId(String planId, int dayIndex) {
+    final keys = kSpecialPlanNotifications.keys.toList();
+    final slot = keys.indexOf(planId);
+    if (slot < 0) {
+      throw ArgumentError('Plan $planId is not in kSpecialPlanNotifications');
+    }
+    return _specialPlanSeriesIdBase +
+        (slot * _specialPlanSeriesSlotSize) +
+        (dayIndex - 1);
+  }
+
+  /// Cancels every reserved one-shot ID for [planId]'s series (both immediate
+  /// 800-range and daily 810+-range). Used when the block is disabled or the
+  /// user logs out.
+  Future<void> _cancelSpecialPlanSeriesForPlan(String planId) async {
+    final entries = kSpecialPlanNotifications[planId];
+    if (entries == null) return;
+    _logger.info('[SP-SERIES] cancel series for planId=$planId days=${entries.length}');
+    for (var day = 1; day <= entries.length; day++) {
+      await _plugin.cancel(_specialPlanSeriesNotifId(planId, day));
+      await _plugin.cancel(_specialPlanOneShotIdBase + (day - 1));
+    }
+  }
+
+  /// Cancels every special-plan schedule across every plan. Called on logout
+  /// so a different user signing in does not inherit pending notifications.
+  Future<void> cancelAllSpecialPlanSchedules() async {
+    _logger.info(
+      '[SP-SERIES] cancelAllSpecialPlanSchedules — '
+      '${kSpecialPlanNotifications.length} plan(s)',
+    );
+    if (!_isReady) return;
+    for (final planId in kSpecialPlanNotifications.keys) {
+      await _cancelSpecialPlanSeriesForPlan(planId);
+    }
+  }
+
+  /// Reschedules the full N-day special-plan series for [planId] using the
+  /// server-truth `startedAt` from [SpecialPlanStartedAtStore]. For each day
+  /// 1..N where the 09:00 fire is still in the future, schedules a one-shot
+  /// `zonedSchedule` with that day's title/body/button baked in. Days already
+  /// in the past are skipped (no `matchDateTimeComponents` — these never
+  /// repeat). Always cancels prior series IDs first, so calling repeatedly is
+  /// idempotent.
+  ///
+  /// Required from caller:
+  ///   - cache must already have `startedAt` for [planId] (bootstrap listener
+  ///     or onSpecialPlanEnrolled writes it).
+  ///   - [planTitle] and [planImageUrl] are used for the notification image
+  ///     and large icon — pass values from [UserPlansModel] or [RoutineItem].
+  Future<void> rescheduleSpecialPlanSeries({
+    required String planId,
+    required String planTitle,
+    required String? planImageUrl,
+    int blockHour = kSpecialPlanFireHour,
+    int blockMinute = kSpecialPlanFireMinute,
+  }) async {
+    _logger.info(
+      '[SP-SERIES] rescheduleSpecialPlanSeries ENTER planId=$planId '
+      'fire=$blockHour:${blockMinute.toString().padLeft(2, '0')} _isReady=$_isReady',
+    );
+    if (!_isReady) {
+      _logger.warning('[SP-SERIES] notification service not ready — abort');
+      return;
+    }
+    final entries = kSpecialPlanNotifications[planId];
+    if (entries == null) {
+      _logger.warning('[SP-SERIES] planId=$planId not a special plan — abort');
+      return;
+    }
+    final startedAt = SpecialPlanStartedAtStore.getStartedAt(planId);
+    if (startedAt == null) {
+      _logger.warning(
+        '[SP-SERIES] no cached startedAt for $planId — abort. Bootstrap '
+        'listener should write it before this is called.',
+      );
+      return;
+    }
+
+    // Always wipe prior schedules first so we don't end up with duplicate
+    // fires from a previous (possibly incorrect) series.
+    await _cancelSpecialPlanSeriesForPlan(planId);
+
+    final startedLocal = startedAt.toLocal();
+    final pseudoItem = RoutineItem(
+      id: planId,
+      title: planTitle,
+      imageUrl: planImageUrl,
+      type: RoutineItemType.plan,
+    );
+    final iosDetails = await _buildIOSNotificationDetails(pseudoItem);
+    final largeIcon = await _getLargeIcon(pseudoItem);
+    final payload = jsonEncode({
+      'itemId': planId,
+      'itemType': RoutineItemType.plan.name,
+    });
+
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduledCount = 0;
+    var skippedPast = 0;
+
+    for (var day = 1; day <= entries.length; day++) {
+      final fireDate = tz.TZDateTime(
+        tz.local,
+        startedLocal.year,
+        startedLocal.month,
+        startedLocal.day + (day - 1),
+        blockHour,
+        blockMinute,
+      );
+
+      if (!fireDate.isAfter(now)) {
+        _logger.info(
+          '[SP-SERIES] day=$day fire=$fireDate is in the past — skip',
+        );
+        skippedPast++;
+        continue;
+      }
+
+      final dayContent = entries[day - 1];
+      final notifId = _specialPlanSeriesNotifId(planId, day);
+
+      // Build a fresh style per day so contentTitle/summaryText carry the
+      // day-N copy (Android style ignores the title/body args otherwise).
+      final androidStyle = await _buildBigPictureStyle(
+        pseudoItem,
+        overrideTitle: dayContent.title,
+        overrideBody: dayContent.body,
+      );
+
+      try {
+        await _plugin.zonedSchedule(
+          notifId,
+          dayContent.title,
+          dayContent.body,
+          fireDate,
+          NotificationChannels.routineBlockDetails(
+            styleInformation: androidStyle,
+            largeIcon: largeIcon,
+            iOSDetails: iosDetails,
+            androidActionButtonText: dayContent.buttonText,
+          ),
+          androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+          payload: payload,
+        );
+        scheduledCount++;
+        _logger.info(
+          '[SP-SERIES] scheduled day=$day id=$notifId fires=$fireDate '
+          'title="${dayContent.title}" button="${dayContent.buttonText}"',
+        );
+      } catch (e, st) {
+        _logger.error(
+          '[SP-SERIES] failed to schedule day=$day id=$notifId',
+          e,
+          st,
+        );
+      }
+    }
+
+    _logger.info(
+      '[SP-SERIES] rescheduleSpecialPlanSeries DONE planId=$planId '
+      'scheduled=$scheduledCount skippedPast=$skippedPast '
+      'totalDays=${entries.length}',
+    );
+  }
+
+  /// Fires an immediate (non-scheduled) one-shot notification with Day 1
+  /// content for [planId]. Idempotent: respects [SpecialPlanStartedAtStore]'s
+  /// `wasDay1Shown` flag — calling twice on the same day is a no-op. Requires
+  /// the startedAt to already be cached in the store (caller's responsibility).
+  ///
+  /// Returns the notification ID on success, or null when skipped.
+  Future<int?> showSpecialPlanDay1Immediate({
+    required String planId,
+    required String planTitle,
+    required String? planImageUrl,
+  }) async {
+    _logger.info(
+      '[SP-DAY1] showSpecialPlanDay1Immediate ENTER planId=$planId '
+      'title="$planTitle" imageUrl=$planImageUrl _isReady=$_isReady',
+    );
+    if (!_isReady) {
+      _logger.warning('[SP-DAY1] FAILED: NotificationService not initialized');
+      return null;
+    }
+
+    final startedAt = SpecialPlanStartedAtStore.getStartedAt(planId);
+    _logger.info('[SP-DAY1] cached startedAt=$startedAt');
+    if (startedAt == null) {
+      _logger.warning('[SP-DAY1] no cached startedAt for $planId — skip');
+      return null;
+    }
+
+    final wasShown = SpecialPlanStartedAtStore.wasDay1Shown(planId, startedAt);
+    _logger.info('[SP-DAY1] wasDay1Shown=$wasShown');
+    if (wasShown) {
+      _logger.info(
+        '[SP-DAY1] day1 already shown for $planId on '
+        '${startedAt.toIso8601String()} — skip (idempotent)',
+      );
+      return null;
+    }
+
+    final now = DateTime.now();
+    final dayContent = resolveSpecialPlanNotification(
+      planId: planId,
+      startedAt: startedAt,
+      now: now,
+    );
+    if (dayContent == null) {
+      _logger.info('[SP-DAY1] resolveSpecialPlanNotification returned null — skip');
+      return null;
+    }
+    final dayIndex = specialPlanDayIndex(
+      planId: planId,
+      startedAt: startedAt,
+      now: now,
+    );
+    _logger.info('[SP-DAY1] resolved dayIndex=$dayIndex title="${dayContent.title}"');
+    if (dayIndex != 1) {
+      _logger.info('[SP-DAY1] not currently day 1 (resolved=$dayIndex) — skip');
+      return null;
+    }
+
+    try {
+      // Build the same image-rich style as the daily routine notification,
+      // but with the day-N title/body baked into the style (otherwise Android
+      // would render the plan's static title + a generic summary).
+      final pseudoItem = RoutineItem(
+        id: planId,
+        title: planTitle,
+        imageUrl: planImageUrl,
+        type: RoutineItemType.plan,
+      );
+      final androidStyle = await _buildBigPictureStyle(
+        pseudoItem,
+        overrideTitle: dayContent.title,
+        overrideBody: dayContent.body,
+      );
+      final iosDetails = await _buildIOSNotificationDetails(pseudoItem);
+      final largeIcon = await _getLargeIcon(pseudoItem);
+
+      // dayIndex is non-null here (we early-returned when it was != 1).
+      final notifId = _specialPlanOneShotIdBase + (dayIndex! - 1);
+      final payload = jsonEncode({
+        'itemId': planId,
+        'itemType': RoutineItemType.plan.name,
+      });
+
+      _logger.info(
+        '[SP-DAY1] calling _plugin.show id=$notifId title="${dayContent.title}" '
+        'body="${dayContent.body}" button="${dayContent.buttonText}"',
+      );
+      await _plugin.show(
+        notifId,
+        dayContent.title,
+        dayContent.body,
+        NotificationChannels.routineBlockDetails(
+          styleInformation: androidStyle,
+          largeIcon: largeIcon,
+          iOSDetails: iosDetails,
+          androidActionButtonText: dayContent.buttonText,
+        ),
+        payload: payload,
+      );
+
+      await SpecialPlanStartedAtStore.markDay1Shown(planId, startedAt);
+
+      _logger.info(
+        '[SP-DAY1] SUCCESS id=$notifId planId=$planId '
+        'title="${dayContent.title}" markedDay1Shown=true',
+      );
+      return notifId;
+    } catch (e, st) {
+      _logger.error('[SP-DAY1] error showing day 1 for $planId', e, st);
+      return null;
+    }
+  }
+
   /// Cancel all routine block notifications.
   Future<void> cancelAllBlockNotifications(List<RoutineBlock> blocks) async {
     if (!_isReady) return;
@@ -270,12 +601,28 @@ class RoutineNotificationService {
   }
 
   /// Builds Android BigPictureStyle for rich image notifications.
-  Future<StyleInformation> _buildBigPictureStyle(RoutineItem? item) async {
+  ///
+  /// [overrideTitle]/[overrideBody] take precedence over [item]'s defaults —
+  /// pass the special-plan day-N copy here so Android renders that text inside
+  /// the style instead of the plan's static title and a generic summary.
+  Future<StyleInformation> _buildBigPictureStyle(
+    RoutineItem? item, {
+    String? overrideTitle,
+    String? overrideBody,
+  }) async {
+    final effectiveTitle = overrideTitle ?? item?.title ?? 'Time for your practice';
+    final effectiveBody = overrideBody ?? item?.title ?? 'Time for your practice';
+    _logger.info(
+      '[SP-STYLE] _buildBigPictureStyle title="$effectiveTitle" '
+      'body="$effectiveBody" imageUrl=${item?.imageUrl}',
+    );
+
     if (item == null || item.imageUrl == null || item.imageUrl!.isEmpty) {
+      _logger.info('[SP-STYLE] no image — using BigTextStyle');
       return BigTextStyleInformation(
-        item?.title ?? 'Time for your practice',
+        effectiveBody,
         htmlFormatBigText: true,
-        contentTitle: item?.title,
+        contentTitle: effectiveTitle,
         htmlFormatContentTitle: true,
       );
     }
@@ -283,23 +630,25 @@ class RoutineNotificationService {
     try {
       final imagePath = await _downloadAndCacheImage(item.imageUrl!);
       if (imagePath != null) {
+        _logger.info('[SP-STYLE] using BigPictureStyle imagePath=$imagePath');
         return BigPictureStyleInformation(
           FilePathAndroidBitmap(imagePath),
           largeIcon: await _getLargeIcon(item),
-          contentTitle: item.title,
-          summaryText: 'Time for your practice',
+          contentTitle: effectiveTitle,
+          summaryText: effectiveBody,
           htmlFormatContentTitle: true,
           htmlFormatSummaryText: true,
         );
       }
     } catch (e) {
-      _logger.warning('Failed to load image for notification: $e');
+      _logger.warning('[SP-STYLE] Failed to load image: $e');
     }
 
+    _logger.info('[SP-STYLE] image failed — falling back to BigTextStyle');
     return BigTextStyleInformation(
-      item.title,
+      effectiveBody,
       htmlFormatBigText: true,
-      contentTitle: item.title,
+      contentTitle: effectiveTitle,
       htmlFormatContentTitle: true,
     );
   }
@@ -315,6 +664,9 @@ class RoutineNotificationService {
           return DarwinNotificationDetails(
             attachments: [DarwinNotificationAttachment(imagePath)],
             threadIdentifier: 'routine_notifications',
+            presentAlert: true,
+            presentBadge: true,
+            presentSound: true,
           );
         }
       } catch (e) {
@@ -324,6 +676,9 @@ class RoutineNotificationService {
 
     return const DarwinNotificationDetails(
       threadIdentifier: 'routine_notifications',
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
     );
   }
 

--- a/lib/features/notifications/data/special_plan_notifications.dart
+++ b/lib/features/notifications/data/special_plan_notifications.dart
@@ -1,0 +1,162 @@
+/// Hard-coded per-day notification content for "special" plans whose daily
+/// routine notification should display different copy on each of the first N
+/// days after enrollment, after which the series ends and no further
+/// notifications fire for that plan.
+///
+/// Day index = `floor(today_local - startedAt_local) + 1`, where startedAt is
+/// the server-truth `UserPlansModel.startedAt`. Day 1 corresponds to index 0.
+///
+/// Add a new plan: insert another entry into [kSpecialPlanNotifications].
+/// Change copy: edit the relevant [DayNotification].
+/// No other code changes required.
+library;
+
+class DayNotification {
+  final String title;
+  final String body;
+
+  /// Optional Android action-button label (e.g. "START", "READ ON").
+  /// `null` → no action button. iOS never renders this label per product
+  /// decision (avoids upfront iOS category registration). Body tap on iOS
+  /// routes to the same destination, so functionality is preserved.
+  final String? buttonText;
+
+  const DayNotification({
+    required this.title,
+    required this.body,
+    this.buttonText,
+  });
+}
+
+/// ITCC "Abhidhamma in a Year" plan ID.
+/// Mirrors `kOnboardingEvents` in onboarding_preferences.dart.
+const String kItccPlanId = 'b42c9270-8bc9-4a98-b375-924a948ab18e';
+
+/// Daily fire time for the special-plan series (local time). Mirrors the
+/// 09:00 routine block the event-enrollment flow creates server-side.
+const int kSpecialPlanFireHour = 9;
+const int kSpecialPlanFireMinute = 0;
+
+const Map<String, List<DayNotification>> kSpecialPlanNotifications = {
+  kItccPlanId: <DayNotification>[
+    DayNotification(
+      title: 'Welcome to the course',
+      body:
+          "Your journey to Bodhgaya begins today. If you haven't already started, jump right in.",
+    ),
+    DayNotification(
+      title: 'Abhidhamma in a Year',
+      body:
+          "Welcome to day 2 of Abhidhamma in a Year. Today's reading is short — start here.",
+      buttonText: 'START',
+    ),
+    DayNotification(
+      title: "Today's tip",
+      body:
+          'Did you know, you can tap "Edit" on the Practice page to update your reminders?',
+    ),
+    DayNotification(
+      title: "Today's Pali word: kusula",
+      body: 'wholesome, as in kusula dhamma, wholesome phenomena.',
+      buttonText: 'START NOW',
+    ),
+    DayNotification(
+      title: 'A verse for today',
+      body:
+          '"They have gone to the state of arising together etc. with joy..." Continue in app.',
+      buttonText: 'READ ON',
+    ),
+    DayNotification(
+      title: 'Today: Intro to the Matrix',
+      body:
+          "In today's reading, you'll learn the most important Abhidhamma terms.",
+      buttonText: 'GOTO APP',
+    ),
+    DayNotification(
+      title: '196 days until Bodhgaya 🪷',
+      body:
+          'Every day of preparation brings the chanting closer. Open today\'s session.',
+    ),
+    DayNotification(
+      title: "You're almost there",
+      body:
+          "One more session to go in Part One. The path continues — open today's reading.",
+    ),
+  ],
+};
+
+/// True if [planId] has a special-plan series configured.
+bool isSpecialPlan(String planId) =>
+    kSpecialPlanNotifications.containsKey(planId);
+
+int _daysSince(DateTime startedAt, DateTime now) {
+  final startLocal = startedAt.toLocal();
+  final nowLocal = now.toLocal();
+  final start = DateTime(startLocal.year, startLocal.month, startLocal.day);
+  final today = DateTime(nowLocal.year, nowLocal.month, nowLocal.day);
+  final days = today.difference(start).inDays;
+  // ignore: avoid_print
+  print(
+    '[SP-RESOLVER] _daysSince startedAt=$startedAt (local=$startLocal) '
+    'now=$now (local=$nowLocal) -> days=$days',
+  );
+  return days;
+}
+
+/// Returns the day-N notification content for [planId] given [startedAt],
+/// or `null` if [planId] is not a special plan, [startedAt] is in the future,
+/// or the series has ended.
+DayNotification? resolveSpecialPlanNotification({
+  required String planId,
+  required DateTime startedAt,
+  required DateTime now,
+}) {
+  final entries = kSpecialPlanNotifications[planId];
+  if (entries == null) {
+    // ignore: avoid_print
+    print('[SP-RESOLVER] resolveSpecialPlanNotification: planId=$planId is NOT a special plan');
+    return null;
+  }
+  final index = _daysSince(startedAt, now);
+  if (index < 0 || index >= entries.length) {
+    // ignore: avoid_print
+    print(
+      '[SP-RESOLVER] resolveSpecialPlanNotification: index=$index out of range '
+      '[0..${entries.length - 1}] for planId=$planId -> null',
+    );
+    return null;
+  }
+  final entry = entries[index];
+  // ignore: avoid_print
+  print(
+    '[SP-RESOLVER] resolveSpecialPlanNotification: planId=$planId day=${index + 1} '
+    'title="${entry.title}" button="${entry.buttonText}"',
+  );
+  return entry;
+}
+
+/// True if the special-plan series for [planId] has ended (used to suppress
+/// the daily routine notification after the last day).
+bool isSpecialPlanSeriesEnded({
+  required String planId,
+  required DateTime startedAt,
+  required DateTime now,
+}) {
+  final entries = kSpecialPlanNotifications[planId];
+  if (entries == null) return false;
+  return _daysSince(startedAt, now) >= entries.length;
+}
+
+/// 1-based day index for [planId] given [startedAt]. Returns null if not a
+/// special plan, before-start, or past series length.
+int? specialPlanDayIndex({
+  required String planId,
+  required DateTime startedAt,
+  required DateTime now,
+}) {
+  final entries = kSpecialPlanNotifications[planId];
+  if (entries == null) return null;
+  final daysSince = _daysSince(startedAt, now);
+  if (daysSince < 0 || daysSince >= entries.length) return null;
+  return daysSince + 1;
+}

--- a/lib/features/onboarding/application/event_enrollment_service.dart
+++ b/lib/features/onboarding/application/event_enrollment_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/notifications/application/special_plan_enrollment_hook.dart';
 import 'package:flutter_pecha/features/plans/data/models/response/user_plan_list_response_model.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/features/plans/domain/usecases/user_plans_usecases.dart';
@@ -52,16 +53,36 @@ class EventEnrollmentService {
   /// Throws a descriptive [Exception] if a critical step fails and the UI
   /// should surface an error to the user.
   Future<List<UserPlansModel>> enrollInEvents(List<String> planIds) async {
+    _logger.info('[SP-ENROLL] enrollInEvents START planIds=$planIds');
     for (final planId in planIds) {
+      _logger.info('[SP-ENROLL] subscribing $planId');
       await _subscribeToPlan(planId);
+      _logger.info('[SP-ENROLL] adding routine block for $planId');
       await _addToRoutine(planId);
+    }
+
+    // Fetch the user's enrolled plans BEFORE persisting the routine so the
+    // special-plan startedAt cache is primed by the time
+    // [RoutineNotificationService.scheduleBlockNotification] is called inside
+    // [_persistRoutineLocallyAndScheduleNotifications]. Otherwise the first
+    // schedule on enrollment day would fall back to default routine content.
+    _logger.info('[SP-ENROLL] fetching enrolled plans');
+    final enrolledPlans = await _fetchEnrolledPlans(planIds);
+    _logger.info(
+      '[SP-ENROLL] fetched ${enrolledPlans.length} enrolled plans: '
+      '${enrolledPlans.map((p) => "${p.id}@${p.startedAt.toIso8601String()}").join(", ")}',
+    );
+    for (final plan in enrolledPlans) {
+      await onSpecialPlanEnrolled(plan);
     }
 
     // Mirror the practice-tab edit-routine save flow: persist the final
     // server routine to Hive and schedule device-local notifications.
+    _logger.info('[SP-ENROLL] persisting routine + scheduling notifications');
     await _persistRoutineLocallyAndScheduleNotifications();
 
-    return _fetchEnrolledPlans(planIds);
+    _logger.info('[SP-ENROLL] enrollInEvents DONE returning ${enrolledPlans.length} plans');
+    return enrolledPlans;
   }
 
   // ─── Step 1: Subscribe ───

--- a/lib/features/onboarding/domain/entities/onboarding_preferences.dart
+++ b/lib/features/onboarding/domain/entities/onboarding_preferences.dart
@@ -23,9 +23,9 @@ class OnboardingEventPlan {
 const kOnboardingEvents = <OnboardingEventPlan>[
   OnboardingEventPlan(
     planId: 'b42c9270-8bc9-4a98-b375-924a948ab18e',
-    eventLabel: 'ITCC',
+    eventLabel: 'ITCC Bodhgaya · Dec 2026',
     planName: 'Abhidhamma in a Year',
-    description: 'Daily Abhidhamma study over 8 days',
+    description: '200 days prep for the International Tipitaka Chanting Ceremony',
     totalDays: 8,
   ),
 ];

--- a/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
@@ -106,7 +106,7 @@ class _OnboardingScreenEventState extends ConsumerState<OnboardingScreenEvent> {
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        'Check to enroll',
+                        'Optional · Tap to enroll',
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w400,
@@ -307,7 +307,7 @@ class _ReminderNote extends StatelessWidget {
         const SizedBox(width: 6),
         Expanded(
           child: Text(
-            'We\'ll send you a daily reminder at 9:00 AM. (Change anytime.)',
+            'Selected events will be added to your practice with a 9:00 AM daily reminder.',
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w400,

--- a/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen_event.dart
@@ -25,7 +25,7 @@ class OnboardingScreenEvent extends ConsumerStatefulWidget {
 }
 
 class _OnboardingScreenEventState extends ConsumerState<OnboardingScreenEvent> {
-  /// Plan IDs currently checked by the user. All events are checked by default.
+  /// Plan IDs currently checked by the user. Empty by default — opt-in.
   late Set<String> _checkedPlanIds;
 
   bool _isLoading = false;
@@ -34,7 +34,7 @@ class _OnboardingScreenEventState extends ConsumerState<OnboardingScreenEvent> {
   @override
   void initState() {
     super.initState();
-    _checkedPlanIds = {for (final e in kOnboardingEvents) e.planId};
+    _checkedPlanIds = <String>{};
   }
 
   void _toggleEvent(String planId) {
@@ -106,7 +106,7 @@ class _OnboardingScreenEventState extends ConsumerState<OnboardingScreenEvent> {
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        'Optional · Uncheck to skip',
+                        'Check to enroll',
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w400,
@@ -307,7 +307,7 @@ class _ReminderNote extends StatelessWidget {
         const SizedBox(width: 6),
         Expanded(
           child: Text(
-            'Selected events will be added to your practice with a 9:00 AM daily reminder.',
+            'We\'ll send you a daily reminder at 9:00 AM. (Change anytime.)',
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w400,

--- a/lib/features/plans/presentation/plan_info.dart
+++ b/lib/features/plans/presentation/plan_info.dart
@@ -216,7 +216,10 @@ class _PlanInfoState extends ConsumerState<PlanInfo> {
   }
 
   Future<void> _handleEnroll(BuildContext context) async {
-    // TODO: Implement enrollment
+    // TODO: Implement enrollment. After a successful subscribe + fetching the
+    // resulting UserPlansModel, call `onSpecialPlanEnrolled(plan)` from
+    // `lib/features/notifications/application/special_plan_enrollment_hook.dart`
+    // so special-plan day-N notifications (e.g. ITCC) trigger here too.
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Enrollment coming soon!')));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,8 +9,10 @@ import 'package:flutter_pecha/core/config/router/app_router.dart';
 import 'package:flutter_pecha/core/network/connectivity_service.dart';
 import 'package:flutter_pecha/core/l10n/l10n.dart';
 import 'package:flutter_pecha/core/services/service_providers.dart';
+import 'package:flutter_pecha/core/storage/special_plan_started_at_store.dart';
 import 'package:flutter_pecha/core/theme/theme_notifier.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/notifications/application/special_plan_bootstrap.dart';
 import 'package:flutter_pecha/features/notifications/data/services/notification_service.dart';
 import 'package:flutter_pecha/features/practice/data/datasource/routine_local_storage.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/practice_providers.dart';
@@ -80,6 +82,14 @@ void main() async {
     _logger.warning('Error initializing notification service: $e');
   }
 
+  // Prime the special-plan startedAt cache so the notification scheduler can
+  // read it synchronously when scheduling daily routine blocks.
+  try {
+    await SpecialPlanStartedAtStore.init();
+  } catch (e) {
+    _logger.warning('Error initializing special plan store: $e');
+  }
+
   // Initialize routine local storage (persistent user data, not cache)
   final routineStorage = RoutineLocalStorage();
   try {
@@ -115,6 +125,10 @@ class MyApp extends ConsumerWidget {
     // Initialize services in background via providers
     ref.watch(audioHandlerProvider);
     ref.watch(notificationServiceProvider);
+    // Listener that mirrors UserPlansModel.startedAt into
+    // SpecialPlanStartedAtStore whenever userPlansFutureProvider resolves.
+    // Must be watched here so the listener stays alive for the app lifetime.
+    ref.watch(specialPlanBootstrapProvider);
     NotificationService.setRouter(router);
     NotificationService().consumeLaunchNotification();
 

--- a/test/features/notifications/special_plan_notifications_test.dart
+++ b/test/features/notifications/special_plan_notifications_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_pecha/features/notifications/data/special_plan_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('special_plan_notifications', () {
+    final startedAt = DateTime(2026, 1, 1, 9, 0); // Day 1 = 2026-01-01
+
+    group('isSpecialPlan', () {
+      test('returns true for ITCC plan id', () {
+        expect(isSpecialPlan(kItccPlanId), isTrue);
+      });
+
+      test('returns false for unknown plan id', () {
+        expect(isSpecialPlan('non-existent-plan-id'), isFalse);
+      });
+    });
+
+    group('resolveSpecialPlanNotification', () {
+      test('returns day-1 content on enrollment day', () {
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: startedAt,
+          now: DateTime(2026, 1, 1, 14, 0),
+        );
+        expect(result, isNotNull);
+        expect(result!.title, 'Welcome to the course');
+        expect(result.buttonText, isNull);
+      });
+
+      test('returns day-2 content one day after enrollment', () {
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: startedAt,
+          now: DateTime(2026, 1, 2, 9, 1),
+        );
+        expect(result, isNotNull);
+        expect(result!.title, 'Abhidhamma in a Year');
+        expect(result.buttonText, 'START');
+      });
+
+      test('returns day-8 content 7 days after enrollment', () {
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: startedAt,
+          now: DateTime(2026, 1, 8, 9, 0),
+        );
+        expect(result, isNotNull);
+        expect(result!.title, "You're almost there");
+      });
+
+      test('returns null on day 9 (series ended)', () {
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: startedAt,
+          now: DateTime(2026, 1, 9, 9, 0),
+        );
+        expect(result, isNull);
+      });
+
+      test('returns null when now is before startedAt (clock skew)', () {
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: startedAt,
+          now: DateTime(2025, 12, 31, 23, 59),
+        );
+        expect(result, isNull);
+      });
+
+      test('returns null for non-special plan', () {
+        final result = resolveSpecialPlanNotification(
+          planId: 'unknown-id',
+          startedAt: startedAt,
+          now: DateTime(2026, 1, 1),
+        );
+        expect(result, isNull);
+      });
+
+      test('day rollover uses calendar date, not 24h elapsed', () {
+        // Enrolled at 23:59 on Jan 1; "now" is 00:01 on Jan 2 — only 2 minutes
+        // elapsed but it's a new calendar day → Day 2 content.
+        final lateNight = DateTime(2026, 1, 1, 23, 59);
+        final earlyMorning = DateTime(2026, 1, 2, 0, 1);
+        final result = resolveSpecialPlanNotification(
+          planId: kItccPlanId,
+          startedAt: lateNight,
+          now: earlyMorning,
+        );
+        expect(result, isNotNull);
+        expect(result!.title, 'Abhidhamma in a Year');
+      });
+    });
+
+    group('isSpecialPlanSeriesEnded', () {
+      test('false on enrollment day', () {
+        expect(
+          isSpecialPlanSeriesEnded(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 1, 9, 0),
+          ),
+          isFalse,
+        );
+      });
+
+      test('false on day 8', () {
+        expect(
+          isSpecialPlanSeriesEnded(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 8, 9, 0),
+          ),
+          isFalse,
+        );
+      });
+
+      test('true on day 9', () {
+        expect(
+          isSpecialPlanSeriesEnded(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 9, 0, 1),
+          ),
+          isTrue,
+        );
+      });
+
+      test('false for non-special plan regardless of time', () {
+        expect(
+          isSpecialPlanSeriesEnded(
+            planId: 'unknown',
+            startedAt: startedAt,
+            now: DateTime(2030, 1, 1),
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('specialPlanDayIndex', () {
+      test('returns 1 on enrollment day', () {
+        expect(
+          specialPlanDayIndex(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 1, 23, 0),
+          ),
+          1,
+        );
+      });
+
+      test('returns 5 on day 5', () {
+        expect(
+          specialPlanDayIndex(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 5, 9, 0),
+          ),
+          5,
+        );
+      });
+
+      test('returns null after series ends', () {
+        expect(
+          specialPlanDayIndex(
+            planId: kItccPlanId,
+            startedAt: startedAt,
+            now: DateTime(2026, 1, 9, 9, 0),
+          ),
+          isNull,
+        );
+      });
+    });
+
+    group('kSpecialPlanNotifications shape', () {
+      test('ITCC has exactly 8 days', () {
+        expect(kSpecialPlanNotifications[kItccPlanId]!.length, 8);
+      });
+
+      test('every entry has non-empty title and body', () {
+        for (final list in kSpecialPlanNotifications.values) {
+          for (final entry in list) {
+            expect(entry.title, isNotEmpty);
+            expect(entry.body, isNotEmpty);
+          }
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
feat(notifications): deterministic per-day series for special plans                                                                                                           
                                                                                                                                                                              
  Replace the single daily-repeating routine notification with N one-shot                                                                                                       
  schedules (one per day) for plans in kSpecialPlanNotifications. Each day
  fires with its own title/body/button instead of replaying the same                                                                                                            
  payload. Non-special plans keep the existing daily-repeat behavior                                                                                                            
  unchanged.                                                                                                                                                                    
                                                                                                                                                                                
  - Add rescheduleSpecialPlanSeries: cancels prior schedules and registers                                                                                                      
    one zonedSchedule per remaining day at 09:00 (idempotent).                                                                                                                  
  - Add cancelAllSpecialPlanSchedules / _cancelSpecialPlanSeriesForPlan;                                                                                                        
    reserve notification IDs 810+ per plan slot.                                                                                                                                
  - scheduleBlockNotification + cancelBlockNotification now delegate to                                                                                                         
    the series scheduler when the first item is a special plan.                                                                                                                 
  - Bootstrap listener reschedules the series directly after caching                                                                                                            
    startedAt, so uninstall+reinstall and re-login restore the schedule                                                                                                         
    even before Hive routine blocks load.                                                                                                                                       
  - Logout cancels all pending special-plan schedules so a different user                                                                                                       
    does not inherit them. 