### PR TITLE
fix: enhance CachedNetworkImageWidget and optimize PlanListScreen with image precaching

### DIFF
--- a/lib/core/widgets/cached_network_image_widget.dart
+++ b/lib/core/widgets/cached_network_image_widget.dart
@@ -10,7 +10,15 @@ bool _isNetworkUrl(String url) {
       (uri.scheme == 'http' || uri.scheme == 'https');
 }
 
-class CachedNetworkImageWidget extends StatelessWidget {
+/// Strips the query string and fragment so presigned URLs (e.g. S3 with
+/// rotating signatures) resolve to the same cache entry across sessions.
+String _stableCacheKey(String url) {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return url;
+  return uri.replace(query: '', fragment: '').toString();
+}
+
+class CachedNetworkImageWidget extends StatefulWidget {
   /// Remote http(s) URL, or a bundled asset path starting with `assets/`.
   final String? imageUrl;
 
@@ -27,6 +35,14 @@ class CachedNetworkImageWidget extends StatelessWidget {
   final Duration? fadeInDuration;
   final VoidCallback? onImageLoaded;
 
+  /// Explicit decode width in physical pixels. When null and [width] is set,
+  /// it is auto-derived from `width * devicePixelRatio`.
+  final int? memCacheWidth;
+
+  /// Explicit decode height in physical pixels. When null and [height] is set,
+  /// it is auto-derived from `height * devicePixelRatio`.
+  final int? memCacheHeight;
+
   const CachedNetworkImageWidget({
     super.key,
     this.imageUrl,
@@ -41,77 +57,100 @@ class CachedNetworkImageWidget extends StatelessWidget {
     this.placeholderFadeInDuration,
     this.fadeInDuration,
     this.onImageLoaded,
+    this.memCacheWidth,
+    this.memCacheHeight,
   });
 
   @override
+  State<CachedNetworkImageWidget> createState() =>
+      _CachedNetworkImageWidgetState();
+}
+
+class _CachedNetworkImageWidgetState extends State<CachedNetworkImageWidget> {
+  bool _didPrecache = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didPrecache) return;
+    final url = widget.imageUrl?.trim();
+    if (url == null || url.isEmpty || !_isNetworkUrl(url)) return;
+    _didPrecache = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      precacheImage(
+        CachedNetworkImageProvider(url, cacheKey: _stableCacheKey(url)),
+        context,
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final trimmed = imageUrl?.trim();
+    final trimmed = widget.imageUrl?.trim();
     final url = (trimmed != null && trimmed.isNotEmpty) ? trimmed : null;
 
     Widget imageWidget;
 
     if (url != null && _isAssetPath(url)) {
       imageWidget = _buildAssetImage(url, context);
-      if (onImageLoaded != null) {
+      if (widget.onImageLoaded != null) {
         imageWidget = _ImageLoadedNotifier(
-          onImageLoaded: onImageLoaded!,
+          onImageLoaded: widget.onImageLoaded!,
           imageUrl: url,
           useAssetImage: true,
           child: imageWidget,
         );
       }
     } else if (url != null && _isNetworkUrl(url)) {
+      final dpr = MediaQuery.of(context).devicePixelRatio;
+      final memW = widget.memCacheWidth ??
+          (widget.width != null ? (widget.width! * dpr).round() : null);
+      final memH = widget.memCacheHeight ??
+          (widget.height != null ? (widget.height! * dpr).round() : null);
+
       imageWidget = CachedNetworkImage(
         imageUrl: url,
-        width: width,
-        height: height,
-        fit: fit,
-        fadeInDuration: fadeInDuration ?? const Duration(milliseconds: 200),
-        placeholderFadeInDuration: placeholderFadeInDuration ?? Duration.zero,
-        placeholder:
-            placeholder != null
-                ? (context, url) => placeholder!
-                : (context, url) => Container(
-                    width: width,
-                    height: height,
-                    color: Colors.grey.shade200,
-                    child: const Center(
-                      child: SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    ),
-                  ),
-        errorWidget:
-            errorWidget != null
-                ? (context, url, error) => errorWidget!
-                : (context, url, error) =>
-                    fallbackAsset != null
-                        ? _buildAssetImage(fallbackAsset!, context)
-                        : _buildErrorWidget(context),
+        cacheKey: _stableCacheKey(url),
+        width: widget.width,
+        height: widget.height,
+        fit: widget.fit,
+        memCacheWidth: memW,
+        memCacheHeight: memH,
+        maxWidthDiskCache: memW,
+        maxHeightDiskCache: memH,
+        fadeInDuration:
+            widget.fadeInDuration ?? const Duration(milliseconds: 200),
+        placeholderFadeInDuration:
+            widget.placeholderFadeInDuration ?? Duration.zero,
+        placeholder: widget.placeholder != null
+            ? (context, url) => widget.placeholder!
+            : (context, url) => _buildLoadingPlaceholder(),
+        errorWidget: widget.errorWidget != null
+            ? (context, url, error) => widget.errorWidget!
+            : (context, url, error) => widget.fallbackAsset != null
+                ? _buildAssetImage(widget.fallbackAsset!, context)
+                : _buildErrorWidget(context),
       );
 
-      if (onImageLoaded != null) {
+      if (widget.onImageLoaded != null) {
         imageWidget = _ImageLoadedNotifier(
-          onImageLoaded: onImageLoaded!,
+          onImageLoaded: widget.onImageLoaded!,
           imageUrl: url,
           useAssetImage: false,
           child: imageWidget,
         );
       }
     } else if (url != null) {
-      // Non-http URL and not an asset path — treat as missing.
-      imageWidget =
-          fallbackAsset != null
-              ? _buildAssetImage(fallbackAsset!, context)
-              : _buildErrorWidget(context);
-    } else if (fallbackAsset != null) {
-      imageWidget = _buildAssetImage(fallbackAsset!, context);
-      if (onImageLoaded != null) {
+      imageWidget = widget.fallbackAsset != null
+          ? _buildAssetImage(widget.fallbackAsset!, context)
+          : _buildErrorWidget(context);
+    } else if (widget.fallbackAsset != null) {
+      imageWidget = _buildAssetImage(widget.fallbackAsset!, context);
+      if (widget.onImageLoaded != null) {
         imageWidget = _ImageLoadedNotifier(
-          onImageLoaded: onImageLoaded!,
-          imageUrl: fallbackAsset!,
+          onImageLoaded: widget.onImageLoaded!,
+          imageUrl: widget.fallbackAsset!,
           useAssetImage: true,
           child: imageWidget,
         );
@@ -120,33 +159,50 @@ class CachedNetworkImageWidget extends StatelessWidget {
       imageWidget = _buildErrorWidget(context);
     }
 
-    if (borderRadius != null) {
-      imageWidget = ClipRRect(borderRadius: borderRadius!, child: imageWidget);
+    if (widget.borderRadius != null) {
+      imageWidget = ClipRRect(
+        borderRadius: widget.borderRadius!,
+        child: imageWidget,
+      );
     }
 
-    if (heroTag != null && heroTag!.isNotEmpty) {
-      imageWidget = Hero(tag: heroTag!, child: imageWidget);
+    if (widget.heroTag != null && widget.heroTag!.isNotEmpty) {
+      imageWidget = Hero(tag: widget.heroTag!, child: imageWidget);
     }
 
     return imageWidget;
   }
 
+  Widget _buildLoadingPlaceholder() {
+    return Container(
+      width: widget.width,
+      height: widget.height,
+      color: Colors.grey.shade200,
+      child: const Center(
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+
   Widget _buildAssetImage(String assetPath, BuildContext context) {
     return Image.asset(
       assetPath,
-      width: width,
-      height: height,
-      fit: fit,
-      errorBuilder:
-          (context, error, stackTrace) =>
-              errorWidget ?? _buildErrorWidget(context),
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      errorBuilder: (context, error, stackTrace) =>
+          widget.errorWidget ?? _buildErrorWidget(context),
     );
   }
 
   Widget _buildErrorWidget(BuildContext context) {
     return Container(
-      width: width,
-      height: height,
+      width: widget.width,
+      height: widget.height,
       color: Colors.grey.shade300,
       child: const Center(
         child: Icon(Icons.broken_image, size: 48, color: Colors.grey),
@@ -184,10 +240,12 @@ class _ImageLoadedNotifierState extends State<_ImageLoadedNotifier> {
   }
 
   void _setupImageListener() {
-    final ImageProvider imageProvider =
-        widget.useAssetImage
-            ? AssetImage(widget.imageUrl)
-            : CachedNetworkImageProvider(widget.imageUrl);
+    final ImageProvider imageProvider = widget.useAssetImage
+        ? AssetImage(widget.imageUrl)
+        : CachedNetworkImageProvider(
+            widget.imageUrl,
+            cacheKey: _stableCacheKey(widget.imageUrl),
+          );
     _imageStream = imageProvider.resolve(const ImageConfiguration());
     _imageStreamListener = ImageStreamListener(
       (ImageInfo image, bool synchronousCall) {
@@ -196,16 +254,16 @@ class _ImageLoadedNotifierState extends State<_ImageLoadedNotifier> {
           widget.onImageLoaded();
         }
       },
-      onError: (exception, stackTrace) {
-        // Don't call callback on error
-      },
+      onError: (exception, stackTrace) {},
     );
     _imageStream?.addListener(_imageStreamListener!);
   }
 
   @override
   void dispose() {
-    _imageStream?.removeListener(_imageStreamListener!);
+    if (_imageStreamListener != null) {
+      _imageStream?.removeListener(_imageStreamListener!);
+    }
     super.dispose();
   }
 
@@ -217,6 +275,6 @@ class _ImageLoadedNotifierState extends State<_ImageLoadedNotifier> {
 
 extension CachedNetworkImageProviderExtension on String {
   ImageProvider get cachedNetworkImageProvider {
-    return CachedNetworkImageProvider(this);
+    return CachedNetworkImageProvider(this, cacheKey: _stableCacheKey(this));
   }
 }

--- a/lib/core/widgets/cached_network_image_widget.dart
+++ b/lib/core/widgets/cached_network_image_widget.dart
@@ -10,6 +10,14 @@ bool _isNetworkUrl(String url) {
       (uri.scheme == 'http' || uri.scheme == 'https');
 }
 
+/// Converts a logical dimension to physical pixels for cache sizing. Returns
+/// null when the dimension is null, non-finite (e.g. `double.infinity`), or
+/// non-positive — in those cases the framework should decode at natural size.
+int? _toCachePx(double? logical, double dpr) {
+  if (logical == null || !logical.isFinite || logical <= 0) return null;
+  return (logical * dpr).round();
+}
+
 /// Strips the query string and fragment so presigned URLs (e.g. S3 with
 /// rotating signatures) resolve to the same cache entry across sessions.
 String _stableCacheKey(String url) {
@@ -104,10 +112,8 @@ class _CachedNetworkImageWidgetState extends State<CachedNetworkImageWidget> {
       }
     } else if (url != null && _isNetworkUrl(url)) {
       final dpr = MediaQuery.of(context).devicePixelRatio;
-      final memW = widget.memCacheWidth ??
-          (widget.width != null ? (widget.width! * dpr).round() : null);
-      final memH = widget.memCacheHeight ??
-          (widget.height != null ? (widget.height! * dpr).round() : null);
+      final memW = widget.memCacheWidth ?? _toCachePx(widget.width, dpr);
+      final memH = widget.memCacheHeight ?? _toCachePx(widget.height, dpr);
 
       imageWidget = CachedNetworkImage(
         imageUrl: url,

--- a/lib/core/widgets/cached_network_image_widget.dart
+++ b/lib/core/widgets/cached_network_image_widget.dart
@@ -66,11 +66,23 @@ class CachedNetworkImageWidget extends StatelessWidget {
         width: width,
         height: height,
         fit: fit,
+        fadeInDuration: fadeInDuration ?? const Duration(milliseconds: 200),
+        placeholderFadeInDuration: placeholderFadeInDuration ?? Duration.zero,
         placeholder:
             placeholder != null
                 ? (context, url) => placeholder!
-                : (context, url) =>
-                    const Center(child: CircularProgressIndicator()),
+                : (context, url) => Container(
+                    width: width,
+                    height: height,
+                    color: Colors.grey.shade200,
+                    child: const Center(
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  ),
         errorWidget:
             errorWidget != null
                 ? (context, url, error) => errorWidget!

--- a/lib/features/home/presentation/screens/plan_list_screen.dart
+++ b/lib/features/home/presentation/screens/plan_list_screen.dart
@@ -1,9 +1,9 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/config/router/app_routes.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
 import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
@@ -146,8 +146,6 @@ class PlanListScreen extends ConsumerWidget {
             delegate: SliverChildBuilderDelegate(
               (context, index) => _PlanListItem(plan: sorted[index + 1]),
               childCount: sorted.length - 1,
-              addAutomaticKeepAlives: false,
-              addRepaintBoundaries: true,
             ),
           ),
         ),
@@ -157,31 +155,13 @@ class PlanListScreen extends ConsumerWidget {
   }
 }
 
-class _FeaturedPlanCard extends ConsumerStatefulWidget {
+class _FeaturedPlanCard extends ConsumerWidget {
   final Plan plan;
 
   const _FeaturedPlanCard({required this.plan});
 
   @override
-  ConsumerState<_FeaturedPlanCard> createState() => _FeaturedPlanCardState();
-}
-
-class _FeaturedPlanCardState extends ConsumerState<_FeaturedPlanCard> {
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (widget.plan.coverImageUrl != null &&
-        widget.plan.coverImageUrl!.isNotEmpty) {
-      precacheImage(
-        CachedNetworkImageProvider(widget.plan.coverImageUrl!),
-        context,
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final plan = widget.plan;
+  Widget build(BuildContext context, WidgetRef ref) {
     final locale = ref.watch(localeProvider);
     final lineHeight = getLineHeight(locale.languageCode);
     final titleFontSize = locale.languageCode == 'bo' ? 22.0 : 18.0;
@@ -301,31 +281,13 @@ class _FeaturedPlanCardState extends ConsumerState<_FeaturedPlanCard> {
   }
 }
 
-class _PlanListItem extends ConsumerStatefulWidget {
+class _PlanListItem extends ConsumerWidget {
   final Plan plan;
 
   const _PlanListItem({required this.plan});
 
   @override
-  ConsumerState<_PlanListItem> createState() => _PlanListItemState();
-}
-
-class _PlanListItemState extends ConsumerState<_PlanListItem> {
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (widget.plan.coverImageUrl != null &&
-        widget.plan.coverImageUrl!.isNotEmpty) {
-      precacheImage(
-        CachedNetworkImageProvider(widget.plan.coverImageUrl!),
-        context,
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final plan = widget.plan;
+  Widget build(BuildContext context, WidgetRef ref) {
     final locale = ref.watch(localeProvider);
     final lineHeight = getLineHeight(locale.languageCode);
     final titleFontSize = locale.languageCode == 'bo' ? 18.0 : 16.0;
@@ -356,6 +318,8 @@ class _PlanListItemState extends ConsumerState<_PlanListItem> {
                 placeholderIconSize: 24,
                 placeholderAlphaMin: 0.3,
                 placeholderAlphaMax: 0.5,
+                width: 86,
+                height: 86,
               ),
             ),
             const SizedBox(width: 12),
@@ -414,26 +378,28 @@ class _PlanCoverImage extends StatelessWidget {
   final double placeholderIconSize;
   final double placeholderAlphaMin;
   final double placeholderAlphaMax;
+  final double? width;
+  final double? height;
 
   const _PlanCoverImage({
     required this.imageUrl,
     required this.placeholderIconSize,
     required this.placeholderAlphaMin,
     required this.placeholderAlphaMax,
+    this.width,
+    this.height,
   });
 
   @override
   Widget build(BuildContext context) {
     if (imageUrl != null && imageUrl!.isNotEmpty) {
-      return Image.network(
-        imageUrl!,
+      return CachedNetworkImageWidget(
+        imageUrl: imageUrl,
+        width: width,
+        height: height,
         fit: BoxFit.cover,
-        errorBuilder:
-            (context, error, stackTrace) => _buildPlaceholder(context),
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
-          return _buildPlaceholder(context);
-        },
+        placeholder: _buildPlaceholder(context),
+        errorWidget: _buildPlaceholder(context),
       );
     }
     return _buildPlaceholder(context);

--- a/lib/features/home/presentation/screens/plan_list_screen.dart
+++ b/lib/features/home/presentation/screens/plan_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/config/router/app_routes.dart';
@@ -145,6 +146,8 @@ class PlanListScreen extends ConsumerWidget {
             delegate: SliverChildBuilderDelegate(
               (context, index) => _PlanListItem(plan: sorted[index + 1]),
               childCount: sorted.length - 1,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: true,
             ),
           ),
         ),
@@ -154,13 +157,31 @@ class PlanListScreen extends ConsumerWidget {
   }
 }
 
-class _FeaturedPlanCard extends ConsumerWidget {
+class _FeaturedPlanCard extends ConsumerStatefulWidget {
   final Plan plan;
 
   const _FeaturedPlanCard({required this.plan});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_FeaturedPlanCard> createState() => _FeaturedPlanCardState();
+}
+
+class _FeaturedPlanCardState extends ConsumerState<_FeaturedPlanCard> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (widget.plan.coverImageUrl != null &&
+        widget.plan.coverImageUrl!.isNotEmpty) {
+      precacheImage(
+        CachedNetworkImageProvider(widget.plan.coverImageUrl!),
+        context,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final plan = widget.plan;
     final locale = ref.watch(localeProvider);
     final lineHeight = getLineHeight(locale.languageCode);
     final titleFontSize = locale.languageCode == 'bo' ? 22.0 : 18.0;
@@ -280,13 +301,31 @@ class _FeaturedPlanCard extends ConsumerWidget {
   }
 }
 
-class _PlanListItem extends ConsumerWidget {
+class _PlanListItem extends ConsumerStatefulWidget {
   final Plan plan;
 
   const _PlanListItem({required this.plan});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_PlanListItem> createState() => _PlanListItemState();
+}
+
+class _PlanListItemState extends ConsumerState<_PlanListItem> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (widget.plan.coverImageUrl != null &&
+        widget.plan.coverImageUrl!.isNotEmpty) {
+      precacheImage(
+        CachedNetworkImageProvider(widget.plan.coverImageUrl!),
+        context,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final plan = widget.plan;
     final locale = ref.watch(localeProvider);
     final lineHeight = getLineHeight(locale.languageCode);
     final titleFontSize = locale.languageCode == 'bo' ? 18.0 : 16.0;

--- a/lib/features/home/presentation/widgets/plan_list_view.dart
+++ b/lib/features/home/presentation/widgets/plan_list_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
@@ -292,15 +293,11 @@ class PlanCoverImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (imageUrl != null && imageUrl!.isNotEmpty) {
-      return Image.network(
-        imageUrl!,
+      return CachedNetworkImageWidget(
+        imageUrl: imageUrl,
         fit: BoxFit.cover,
-        errorBuilder:
-            (context, error, stackTrace) => _buildPlaceholder(context),
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
-          return _buildPlaceholder(context);
-        },
+        placeholder: _buildPlaceholder(context),
+        errorWidget: _buildPlaceholder(context),
       );
     }
     return _buildPlaceholder(context);

--- a/lib/features/home/presentation/widgets/tag_card.dart
+++ b/lib/features/home/presentation/widgets/tag_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class TagCard extends ConsumerWidget {
@@ -89,16 +90,11 @@ class TagCard extends ConsumerWidget {
           },
         );
       }
-      return Image.network(
-        imageUrl!,
+      return CachedNetworkImageWidget(
+        imageUrl: imageUrl,
         fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) {
-          return _buildPlaceholder(context);
-        },
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
-          return _buildPlaceholder(context);
-        },
+        placeholder: _buildPlaceholder(context),
+        errorWidget: _buildPlaceholder(context),
       );
     }
     return _buildPlaceholder(context);

--- a/lib/features/home/presentation/widgets/tag_card.dart
+++ b/lib/features/home/presentation/widgets/tag_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -81,29 +82,15 @@ class TagCard extends ConsumerWidget {
   }
 
   Widget _buildBackgroundImage(BuildContext context) {
-    if (imageUrl != null && imageUrl!.isNotEmpty) {
-      if (imageUrl!.startsWith('assets/')) {
-        return Image.asset(
-          imageUrl!,
-          fit: BoxFit.cover,
-          errorBuilder: (context, error, stackTrace) {
-            return _buildPlaceholder(context);
-          },
-        );
-      }
-      return Image.network(
-        imageUrl!,
-        fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) {
-          return _buildPlaceholder(context);
-        },
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
-          return _buildPlaceholder(context);
-        },
-      );
+    if (imageUrl == null || imageUrl!.isEmpty) {
+      return _buildPlaceholder(context);
     }
-    return _buildPlaceholder(context);
+    return CachedNetworkImageWidget(
+      imageUrl: imageUrl,
+      fit: BoxFit.cover,
+      placeholder: _buildPlaceholder(context),
+      errorWidget: _buildPlaceholder(context),
+    );
   }
 
   Widget _buildPlaceholder(BuildContext context) {


### PR DESCRIPTION
- Images are preloaded using `precacheImage()` when each list item is created
- As you scroll, Flutter builds items slightly before they become visible, triggering the preload
- Once preloaded, images display instantly from cache when they come into view
- This happens automatically as you scroll - no manual intervention needed

- Images load ahead of time as you scroll
- Smoother scrolling experience
- No more waiting for images to load as they appear
- Cached images display instantly