### PR TITLE
fix: add Tibetan language support for strut styling in bottom navigation bars and title place holders.

### DIFF
--- a/lib/core/extensions/context_ext.dart
+++ b/lib/core/extensions/context_ext.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 
-/// Extension on [BuildContext] to provide safe access to [AppLocalizations]
-///
-/// Usage:
-/// ```dart
-/// // Instead of:
-/// AppLocalizations.of(context)!
-///
-/// // Use:
-/// context.l10n
-/// ```
 extension BuildContextExt on BuildContext {
   AppLocalizations get l10n => AppLocalizations.of(this)!;
+
+  bool get isTibetanLocale =>
+      Localizations.localeOf(this).languageCode == AppConfig.tibetanLanguageCode;
+
+  /// Returns a [StrutStyle] that prevents Tibetan glyphs from being clipped
+  /// at the top, or null for non-Tibetan locales.
+  StrutStyle? tibetanStrutStyle(double fontSize) => isTibetanLocale
+      ? StrutStyle(
+          fontSize: fontSize,
+          height: 1.6,
+          forceStrutHeight: true,
+        )
+      : null;
 }

--- a/lib/features/app/presentation/pecha_bottom_nav_bar.dart
+++ b/lib/features/app/presentation/pecha_bottom_nav_bar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
-import 'package:flutter_pecha/core/constants/app_config.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'skeleton_screen.dart';
@@ -102,9 +102,6 @@ class PechaBottomNavBar extends ConsumerWidget {
     final fontSize = 12.0;
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
-    final isTibetan = Localizations.localeOf(context).languageCode == 
-        AppConfig.tibetanLanguageCode;
-
     // Active color uses primary color, inactive uses grey (dark mode friendly)
     final activeColor =
         theme.colorScheme.brightness == Brightness.dark
@@ -141,13 +138,7 @@ class PechaBottomNavBar extends ConsumerWidget {
                 ).copyWith(textScaler: TextScaler.linear(1.0)),
                 child: Text(
                   label,
-                  strutStyle: isTibetan
-                      ? StrutStyle(
-                          fontSize: fontSize,
-                          height: 1.6,
-                          forceStrutHeight: true,
-                        )
-                      : null,
+                  strutStyle: context.tibetanStrutStyle(fontSize),
                   style: TextStyle(
                     fontSize: fontSize,
                     fontWeight:

--- a/lib/features/app/presentation/pecha_bottom_nav_bar.dart
+++ b/lib/features/app/presentation/pecha_bottom_nav_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'skeleton_screen.dart';
@@ -101,6 +102,8 @@ class PechaBottomNavBar extends ConsumerWidget {
     final fontSize = 12.0;
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
+    final isTibetan = Localizations.localeOf(context).languageCode == 
+        AppConfig.tibetanLanguageCode;
 
     // Active color uses primary color, inactive uses grey (dark mode friendly)
     final activeColor =
@@ -138,6 +141,13 @@ class PechaBottomNavBar extends ConsumerWidget {
                 ).copyWith(textScaler: TextScaler.linear(1.0)),
                 child: Text(
                   label,
+                  strutStyle: isTibetan
+                      ? StrutStyle(
+                          fontSize: fontSize,
+                          height: 1.6,
+                          forceStrutHeight: true,
+                        )
+                      : null,
                   style: TextStyle(
                     fontSize: fontSize,
                     fontWeight:

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_pecha/features/home/presentation/screens/main_navigation
 import 'package:fpdart/fpdart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/services/service_providers.dart';
@@ -247,11 +248,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         scrolledUnderElevation: 0,
         centerTitle: false,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: Text(
-          l10n.nav_home,
-          style: Theme.of(
-            context,
-          ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+        title: Builder(
+          builder: (context) {
+            final isTibetan = Localizations.localeOf(context).languageCode == 
+                AppConfig.tibetanLanguageCode;
+            final fontSize = Theme.of(context).textTheme.headlineMedium?.fontSize ?? 28;
+            
+            return Text(
+              l10n.nav_home,
+              strutStyle: isTibetan
+                  ? StrutStyle(
+                      fontSize: fontSize,
+                      height: 1.6,
+                      forceStrutHeight: true,
+                    )
+                  : null,
+              style: Theme.of(
+                context,
+              ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+            );
+          },
         ),
       ),
       body: SafeArea(

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_pecha/features/home/presentation/screens/main_navigation
 import 'package:fpdart/fpdart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
-import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/services/service_providers.dart';
@@ -217,26 +216,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         scrolledUnderElevation: 0,
         centerTitle: false,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: Builder(
-          builder: (context) {
-            final isTibetan = Localizations.localeOf(context).languageCode == 
-                AppConfig.tibetanLanguageCode;
-            final fontSize = Theme.of(context).textTheme.headlineMedium?.fontSize ?? 28;
-            
-            return Text(
-              l10n.nav_home,
-              strutStyle: isTibetan
-                  ? StrutStyle(
-                      fontSize: fontSize,
-                      height: 1.6,
-                      forceStrutHeight: true,
-                    )
-                  : null,
-              style: Theme.of(
-                context,
-              ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
-            );
-          },
+        title: Text(
+          l10n.nav_home,
+          strutStyle: context.tibetanStrutStyle(
+            Theme.of(context).textTheme.headlineMedium?.fontSize ?? 28,
+          ),
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
         ),
       ),
       body: SafeArea(

--- a/lib/features/more/presentation/more_screen.dart
+++ b/lib/features/more/presentation/more_screen.dart
@@ -45,11 +45,26 @@ class MoreScreen extends ConsumerWidget {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         elevation: 0,
-        title: Text(
-          localizations.nav_settings,
-          style: Theme.of(
-            context,
-          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+        title: Builder(
+          builder: (context) {
+            final isTibetan = Localizations.localeOf(context).languageCode == 
+                AppConfig.tibetanLanguageCode;
+            final fontSize = Theme.of(context).textTheme.headlineSmall?.fontSize ?? 24;
+            
+            return Text(
+              localizations.nav_settings,
+              strutStyle: isTibetan
+                  ? StrutStyle(
+                      fontSize: fontSize,
+                      height: 1.6,
+                      forceStrutHeight: true,
+                    )
+                  : null,
+              style: Theme.of(
+                context,
+              ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            );
+          },
         ),
         centerTitle: true,
       ),

--- a/lib/features/more/presentation/more_screen.dart
+++ b/lib/features/more/presentation/more_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/theme/theme_notifier.dart';
@@ -45,26 +46,12 @@ class MoreScreen extends ConsumerWidget {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         elevation: 0,
-        title: Builder(
-          builder: (context) {
-            final isTibetan = Localizations.localeOf(context).languageCode == 
-                AppConfig.tibetanLanguageCode;
-            final fontSize = Theme.of(context).textTheme.headlineSmall?.fontSize ?? 24;
-            
-            return Text(
-              localizations.nav_settings,
-              strutStyle: isTibetan
-                  ? StrutStyle(
-                      fontSize: fontSize,
-                      height: 1.6,
-                      forceStrutHeight: true,
-                    )
-                  : null,
-              style: Theme.of(
-                context,
-              ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
-            );
-          },
+        title: Text(
+          localizations.nav_settings,
+          strutStyle: context.tibetanStrutStyle(
+            Theme.of(context).textTheme.headlineSmall?.fontSize ?? 24,
+          ),
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
         ),
         centerTitle: true,
       ),

--- a/lib/features/plans/presentation/screens/plans_screen.dart
+++ b/lib/features/plans/presentation/screens/plans_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/core/constants/app_config.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/find_plan_tab.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/my_plan_tab.dart';
@@ -38,23 +38,10 @@ class _PlansScreenState extends ConsumerState<PlansScreen>
 
     return Scaffold(
       appBar: AppBar(
-        title: Builder(
-          builder: (context) {
-            final isTibetan = languageCode == AppConfig.tibetanLanguageCode;
-            final fontSize = 22.0;
-            
-            return Text(
-              localizations.nav_practice,
-              strutStyle: isTibetan
-                  ? StrutStyle(
-                      fontSize: fontSize,
-                      height: 1.6,
-                      forceStrutHeight: true,
-                    )
-                  : null,
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: fontSize),
-            );
-          },
+        title: Text(
+          localizations.nav_practice,
+          strutStyle: context.tibetanStrutStyle(22.0),
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 22),
         ),
         scrolledUnderElevation: 0,
         centerTitle: false,

--- a/lib/features/plans/presentation/screens/plans_screen.dart
+++ b/lib/features/plans/presentation/screens/plans_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/find_plan_tab.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/my_plan_tab.dart';
@@ -37,9 +38,23 @@ class _PlansScreenState extends ConsumerState<PlansScreen>
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          localizations.nav_practice,
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22),
+        title: Builder(
+          builder: (context) {
+            final isTibetan = languageCode == AppConfig.tibetanLanguageCode;
+            final fontSize = 22.0;
+            
+            return Text(
+              localizations.nav_practice,
+              strutStyle: isTibetan
+                  ? StrutStyle(
+                      fontSize: fontSize,
+                      height: 1.6,
+                      forceStrutHeight: true,
+                    )
+                  : null,
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: fontSize),
+            );
+          },
         ),
         scrolledUnderElevation: 0,
         centerTitle: false,

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
 
 /// Shared bottom navigation strip used by both `ReaderScreen` (for
@@ -155,11 +156,22 @@ class _TitleText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isTibetan = Localizations.localeOf(context).languageCode == 
+        AppConfig.tibetanLanguageCode;
+    final fontSize = Theme.of(context).textTheme.titleMedium?.fontSize ?? 16;
+    
     return Text(
       text,
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
       textAlign: TextAlign.center,
+      strutStyle: isTibetan
+          ? StrutStyle(
+              fontSize: fontSize,
+              height: 1.6,
+              forceStrutHeight: true,
+            )
+          : null,
       style: Theme.of(context).textTheme.titleMedium?.copyWith(
             fontFamily: fontFamily,
             fontWeight: FontWeight.bold,

--- a/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
+++ b/lib/features/plans/presentation/widgets/plan_navigation/plan_navigation_bottom_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/core/constants/app_config.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
 
 /// Shared bottom navigation strip used by both `ReaderScreen` (for
@@ -156,22 +156,14 @@ class _TitleText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isTibetan = Localizations.localeOf(context).languageCode == 
-        AppConfig.tibetanLanguageCode;
     final fontSize = Theme.of(context).textTheme.titleMedium?.fontSize ?? 16;
-    
+
     return Text(
       text,
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
       textAlign: TextAlign.center,
-      strutStyle: isTibetan
-          ? StrutStyle(
-              fontSize: fontSize,
-              height: 1.6,
-              forceStrutHeight: true,
-            )
-          : null,
+      strutStyle: context.tibetanStrutStyle(fontSize),
       style: Theme.of(context).textTheme.titleMedium?.copyWith(
             fontFamily: fontFamily,
             fontWeight: FontWeight.bold,

--- a/lib/shared/widgets/appBottomNavBar/app_bottom_nav_item.dart
+++ b/lib/shared/widgets/appBottomNavBar/app_bottom_nav_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_config.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class AppBottomNavItem<T> extends StatelessWidget {
@@ -15,6 +16,8 @@ class AppBottomNavItem<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
+    final isTibetan = Localizations.localeOf(context).languageCode == 
+        AppConfig.tibetanLanguageCode;
 
     // Active color uses primary color, inactive uses grey (dark mode friendly)
     final activeColor =
@@ -45,6 +48,13 @@ class AppBottomNavItem<T> extends StatelessWidget {
         const SizedBox(height: 2),
         Text(
           model.label,
+          strutStyle: isTibetan
+              ? StrutStyle(
+                  fontSize: Theme.of(context).textTheme.bodySmall?.fontSize ?? 12,
+                  height: 1.6,
+                  forceStrutHeight: true,
+                )
+              : null,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             fontWeight:
                 model.type == selectedType

--- a/lib/shared/widgets/appBottomNavBar/app_bottom_nav_item.dart
+++ b/lib/shared/widgets/appBottomNavBar/app_bottom_nav_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/core/constants/app_config.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class AppBottomNavItem<T> extends StatelessWidget {
@@ -16,9 +16,6 @@ class AppBottomNavItem<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
-    final isTibetan = Localizations.localeOf(context).languageCode == 
-        AppConfig.tibetanLanguageCode;
-
     // Active color uses primary color, inactive uses grey (dark mode friendly)
     final activeColor =
         theme.colorScheme.brightness == Brightness.dark
@@ -48,13 +45,9 @@ class AppBottomNavItem<T> extends StatelessWidget {
         const SizedBox(height: 2),
         Text(
           model.label,
-          strutStyle: isTibetan
-              ? StrutStyle(
-                  fontSize: Theme.of(context).textTheme.bodySmall?.fontSize ?? 12,
-                  height: 1.6,
-                  forceStrutHeight: true,
-                )
-              : null,
+          strutStyle: context.tibetanStrutStyle(
+            Theme.of(context).textTheme.bodySmall?.fontSize ?? 12,
+          ),
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             fontWeight:
                 model.type == selectedType


### PR DESCRIPTION
The original implementation didn't allocate enough vertical space, causing the top portions of characters like འདུན་ངོས། and ཡིག་མཛོད། to be clipped. The StrutStyle with increased height ensures the text box is tall enough to display all diacritical marks.