### PR TITLE
Fix/plan enroll issue

### DIFF
--- a/lib/core/storage/plan_metadata_store.dart
+++ b/lib/core/storage/plan_metadata_store.dart
@@ -6,17 +6,25 @@ final _logger = AppLogger('PlanMetadataStore');
 
 /// Enrollment metadata for a single plan.
 class PlanMetadata {
-  final DateTime startedAt;
+  /// Day-1 anchor of the plan. Equals `plan.startDate ?? plan.startedAt`.
+  /// For fixed-date plans this is the plan's scheduled start (e.g. May 13).
+  /// For flexible plans this is when the user enrolled.
+  ///
+  /// All notification day-numbering is computed against this anchor.
+  final DateTime effectiveStartDate;
   final int totalDays;
 
-  const PlanMetadata({required this.startedAt, required this.totalDays});
+  const PlanMetadata({
+    required this.effectiveStartDate,
+    required this.totalDays,
+  });
 
   @override
   String toString() =>
-      'PlanMetadata(startedAt: ${startedAt.toIso8601String()}, totalDays: $totalDays)';
+      'PlanMetadata(effectiveStartDate: ${effectiveStartDate.toIso8601String()}, totalDays: $totalDays)';
 }
 
-/// Synchronous-read store for enrolled plan metadata (startedAt + totalDays).
+/// Synchronous-read store for enrolled plan metadata (effectiveStartDate + totalDays).
 ///
 /// The notification scheduler is a non-Riverpod singleton invoked from
 /// background contexts, so it cannot await SharedPreferences each time.
@@ -41,34 +49,45 @@ class PlanMetadataStore {
     final prefs = _prefs;
     if (prefs == null) return null;
 
-    final rawDate = prefs.getString(_startedAtKey(planId));
+    final rawDate = prefs.getString(_anchorKey(planId));
     final totalDays = prefs.getInt(_totalDaysKey(planId));
     if (rawDate == null || totalDays == null) return null;
 
-    final startedAt = DateTime.tryParse(rawDate);
-    if (startedAt == null) {
-      _logger.warning('Failed to parse startedAt for $planId: "$rawDate"');
+    final effectiveStartDate = DateTime.tryParse(rawDate);
+    if (effectiveStartDate == null) {
+      _logger.warning(
+        '[NOTIF-META] failed to parse effectiveStartDate for $planId: "$rawDate"',
+      );
       return null;
     }
-    return PlanMetadata(startedAt: startedAt, totalDays: totalDays);
+    return PlanMetadata(
+      effectiveStartDate: effectiveStartDate,
+      totalDays: totalDays,
+    );
   }
 
-  /// Persists [startedAt] and [totalDays] for [planId].
+  /// Persists [effectiveStartDate] (plan day-1 anchor) and [totalDays] for [planId].
   static Future<void> setMetadata(
     String planId, {
-    required DateTime startedAt,
+    required DateTime effectiveStartDate,
     required int totalDays,
   }) async {
     final prefs = await _ensurePrefs();
-    await prefs.setString(_startedAtKey(planId), startedAt.toIso8601String());
+    await prefs.setString(
+      _anchorKey(planId),
+      effectiveStartDate.toIso8601String(),
+    );
     await prefs.setInt(_totalDaysKey(planId), totalDays);
+    _logger.info(
+      '[NOTIF-META] stored $planId anchor=${effectiveStartDate.toIso8601String()} totalDays=$totalDays',
+    );
   }
 
   /// Removes all metadata and shown flags for [planId]. Call when the user
   /// removes the plan from their routine so a re-enrol starts fresh.
   static Future<void> clear(String planId) async {
     final prefs = await _ensurePrefs();
-    await prefs.remove(_startedAtKey(planId));
+    await prefs.remove(_anchorKey(planId));
     await prefs.remove(_totalDaysKey(planId));
     for (final key in prefs.getKeys().where(_isShownFlagForPlan(planId)).toList()) {
       await prefs.remove(key);
@@ -116,7 +135,10 @@ class PlanMetadataStore {
 
   // ─── Private helpers ──────────────────────────────────────────────────────
 
-  static String _startedAtKey(String planId) =>
+  // Storage key is kept as `planStartedAtPrefix` for backwards compatibility
+  // with previously stored values. Semantically it now holds the plan day-1
+  // anchor (effectiveStartDate), not the user's enrollment timestamp.
+  static String _anchorKey(String planId) =>
       '${StorageKeys.planStartedAtPrefix}$planId';
 
   static String _totalDaysKey(String planId) =>

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -16,6 +16,7 @@ import 'package:flutter_pecha/features/home/presentation/home_screen_constants.d
 import 'package:flutter_pecha/features/home/presentation/widgets/tag_card.dart';
 import 'package:flutter_pecha/features/notifications/application/plan_enrollment_hook.dart';
 import 'package:flutter_pecha/features/notifications/application/special_plan_enrollment_hook.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/routine_provider.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
 import 'package:flutter_pecha/shared/utils/helper_functions.dart';
@@ -164,9 +165,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     // Push plan details FIRST while HomeScreen is still mounted.
     // Switching the tab index BEFORE the push would unmount HomeScreen,
     // making the subsequent context.push a no-op.
+    final anchor = plan.effectiveStartDate;
+    final selectedDay = PlanUtils.dayNumberFor(
+      anchor,
+      DateTime.now(),
+      plan.totalDays,
+    ).clamp(1, plan.totalDays);
+    _log.info(
+      '[ENROLL-NAV] onboarding open ${plan.id} '
+      'anchor=${anchor.toIso8601String()} '
+      'startDate=${plan.startDate?.toIso8601String()} '
+      'startedAt=${plan.startedAt.toIso8601String()} '
+      'selectedDay=$selectedDay/${plan.totalDays}',
+    );
     context.push(
       '/practice/details',
-      extra: {'plan': plan, 'selectedDay': 1, 'startDate': plan.startedAt},
+      extra: {'plan': plan, 'selectedDay': selectedDay, 'startDate': anchor},
     );
 
     // Switch bottom-nav to Practice so popping back from plan details

--- a/lib/features/home/presentation/screens/plan_list_screen.dart
+++ b/lib/features/home/presentation/screens/plan_list_screen.dart
@@ -331,8 +331,9 @@ class _PlanListItem extends ConsumerWidget {
                       if (isFlexible && !isEnrolled)
                         RoutineItemChip(label: context.l10n.start_now)
                       else if (!isFlexible &&
-                          (!isEnrolled ||
-                              DateTime.now().isBefore(plan.startDate!)))
+                          DateTime.now().isBefore(
+                            DateUtils.dateOnly(plan.startDate!),
+                          ))
                         RoutineItemChip(
                           label: context.l10n.plan_starts_on(
                             DateFormat(
@@ -494,9 +495,14 @@ _EnrolledPlanInfo? _getEnrolledInfo(WidgetRef ref, String planId) {
 }
 
 bool _showFeaturedChipRow(bool isEnrolled, bool isFlexible, Plan plan) {
-  if (!isEnrolled) return true;
-  if (isFlexible) return false;
-  return DateTime.now().isBefore(plan.startDate!);
+  if (isFlexible) {
+    // Flexible plans show "Start now" chip only before enrollment.
+    return !isEnrolled;
+  }
+  // Fixed-date plans show "Starts <date>" only while the plan hasn't
+  // started yet — independent of enrollment status. Once today is on
+  // or after the plan start date, the chip is hidden.
+  return DateTime.now().isBefore(DateUtils.dateOnly(plan.startDate!));
 }
 
 class _EnrolledBadge extends StatelessWidget {

--- a/lib/features/notifications/application/plan_enrollment_hook.dart
+++ b/lib/features/notifications/application/plan_enrollment_hook.dart
@@ -13,27 +13,39 @@ final _logger = AppLogger('PlanEnrollmentHook');
 const int kPlanBlockHour = 9;
 const int kPlanBlockMinute = 0;
 
-/// Caches [plan.startedAt] and [plan.totalDays] into [PlanMetadataStore]
-/// so the notification scheduler can compute fire dates synchronously.
+/// Caches the plan's day-1 anchor (`plan.effectiveStartDate`) and totalDays
+/// into [PlanMetadataStore] so the notification scheduler can compute fire
+/// dates synchronously.
+///
+/// For fixed-date plans, `effectiveStartDate == plan.startDate` (plan's
+/// scheduled start), NOT the user's enrollment time. This ensures users who
+/// join late see the correct day-N notification (e.g. "Day 5 of N") instead
+/// of being treated as Day 1.
 ///
 /// Skips special plans — those are handled by [onSpecialPlanEnrolled].
 Future<void> onPlanEnrolled(UserPlansModel plan) async {
   if (isSpecialPlan(plan.id)) return;
+  final anchor = plan.effectiveStartDate;
   await PlanMetadataStore.setMetadata(
     plan.id,
-    startedAt: plan.startedAt,
+    effectiveStartDate: anchor,
     totalDays: plan.totalDays,
   );
-  _logger.info('Cached metadata for ${plan.id}: startedAt=${plan.startedAt.toIso8601String()} totalDays=${plan.totalDays}');
+  _logger.info(
+    '[ENROLL-NOTIF] cached ${plan.id} anchor=${anchor.toIso8601String()} '
+    'startDate=${plan.startDate?.toIso8601String()} '
+    'startedAt=${plan.startedAt.toIso8601String()} totalDays=${plan.totalDays}',
+  );
 }
 
 /// Fires an immediate notification for any [plans] where today's scheduled
 /// block time has already passed and the notification has not yet been shown.
 ///
 /// Handles all three cases:
-///   - **startedAt == today**: Day 1 immediate if block time has passed.
-///   - **startedAt in the past**: Day-N immediate if block time has passed.
-///   - **startedAt in the future**: skip — scheduled one-shot handles it.
+///   - **anchor == today**: Day 1 immediate if block time has passed.
+///   - **anchor in the past**: Day-N immediate based on plan day-number.
+///   - **anchor in the future** (early enrollment): skip — scheduled
+///     one-shot handles it on the plan's actual start date.
 ///
 /// [routineBlocks] provides the actual block time per plan, so we never fire
 /// early (e.g. a 10:30 plan is not fired at 09:15).
@@ -48,7 +60,7 @@ Future<void> tryFirePendingPlanDayNotifications(
   // handled by `tryFirePendingSpecialPlanNotifications` and are unaffected.
   if (!AppFeatureFlags.kSchedulePlanNotifications) {
     _logger.info(
-      'tryFirePendingPlanDayNotifications: skipped — kSchedulePlanNotifications=false',
+      '[ENROLL-NOTIF] tryFirePending: skipped — kSchedulePlanNotifications=false',
     );
     return;
   }
@@ -60,15 +72,22 @@ Future<void> tryFirePendingPlanDayNotifications(
   for (final plan in plans) {
     if (isSpecialPlan(plan.id)) continue;
 
-    final startedLocal = plan.startedAt.toLocal();
-    final startedDay = DateTime(
-      startedLocal.year,
-      startedLocal.month,
-      startedLocal.day,
+    final anchorLocal = plan.effectiveStartDate.toLocal();
+    final anchorDay = DateTime(
+      anchorLocal.year,
+      anchorLocal.month,
+      anchorLocal.day,
     );
 
-    // Plan hasn't started yet.
-    if (startedDay.isAfter(today)) continue;
+    // Plan hasn't started yet (early enrollment) — scheduled one-shot
+    // will fire on day 1.
+    if (anchorDay.isAfter(today)) {
+      _logger.info(
+        '[ENROLL-NOTIF] tryFirePending skip ${plan.id}: anchor in future '
+        '(${anchorDay.toIso8601String()} > ${today.toIso8601String()})',
+      );
+      continue;
+    }
 
     // Look up the actual scheduled time from the routine block.
     final matchingBlock = routineBlocks.cast<RoutineBlock?>().firstWhere(
@@ -85,12 +104,15 @@ Future<void> tryFirePendingPlanDayNotifications(
 
     if (!blockTimePassed) continue;
 
-    final daysSince = today.difference(startedDay).inDays;
+    final daysSince = today.difference(anchorDay).inDays;
     final todayDayNumber = daysSince + 1;
 
     if (todayDayNumber > plan.totalDays) continue;
     if (PlanMetadataStore.wasImmediateShownOn(plan.id, today)) continue;
 
+    _logger.info(
+      '[ENROLL-NOTIF] tryFirePending firing ${plan.id} day=$todayDayNumber/${plan.totalDays}',
+    );
     final id = await RoutineNotificationService().showPlanDayImmediate(
       planId: plan.id,
       planTitle: plan.title,
@@ -104,6 +126,8 @@ Future<void> tryFirePendingPlanDayNotifications(
   }
 
   if (firedCount > 0) {
-    _logger.info('Fired $firedCount immediate plan day notifications');
+    _logger.info(
+      '[ENROLL-NOTIF] tryFirePending: fired $firedCount immediate plan-day notifications',
+    );
   }
 }

--- a/lib/features/notifications/application/plan_notification_bootstrap.dart
+++ b/lib/features/notifications/application/plan_notification_bootstrap.dart
@@ -23,7 +23,7 @@ final planNotificationBootstrapProvider = Provider<void>((ref) {
   ref.listen<AsyncValue<dynamic>>(userPlansFutureProvider, (_, next) {
     next.whenData((either) {
       either.fold(
-        (failure) => _logger.warning('userPlans fetch failed: $failure'),
+        (failure) => _logger.warning('[ENROLL-NOTIF] userPlans fetch failed: $failure'),
         (response) async {
           for (final plan in response.userPlans) {
             if (!isSpecialPlan(plan.id)) await _bootstrap(ref, plan);
@@ -54,22 +54,27 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
   if (matchingBlockOrNull == null) {
     // Plan was removed from the routine — clear stale metadata so
     // re-enrolment is treated as fresh.
-    _logger.info('${plan.id} not in routine — clearing cached metadata');
+    _logger.info('[ENROLL-NOTIF] ${plan.id} not in routine — clearing cached metadata');
     await PlanMetadataStore.clear(plan.id);
     return;
   }
 
   // Keep the cached metadata in sync with server truth.
+  final anchor = plan.effectiveStartDate;
   final cached = PlanMetadataStore.getMetadata(plan.id);
   final isUpToDate =
-      cached?.startedAt.toIso8601String() == plan.startedAt.toIso8601String() &&
+      cached?.effectiveStartDate.toIso8601String() == anchor.toIso8601String() &&
       cached?.totalDays == plan.totalDays;
 
   if (!isUpToDate) {
-    _logger.info('${plan.id} metadata changed — updating cache');
+    _logger.info(
+      '[ENROLL-NOTIF] ${plan.id} metadata changed — updating cache '
+      '(cached=${cached?.toString()}, anchor=${anchor.toIso8601String()}, '
+      'startDate=${plan.startDate?.toIso8601String()}, startedAt=${plan.startedAt.toIso8601String()})',
+    );
     await PlanMetadataStore.setMetadata(
       plan.id,
-      startedAt: plan.startedAt,
+      effectiveStartDate: anchor,
       totalDays: plan.totalDays,
     );
   }
@@ -85,6 +90,6 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
       blockMinute: matchingBlockOrNull.time.minute,
     );
   } catch (e, st) {
-    _logger.error('Failed to reschedule ${plan.id}', e, st);
+    _logger.error('[ENROLL-NOTIF] Failed to reschedule ${plan.id}', e, st);
   }
 }

--- a/lib/features/notifications/application/special_plan_bootstrap.dart
+++ b/lib/features/notifications/application/special_plan_bootstrap.dart
@@ -37,6 +37,13 @@ final specialPlanBootstrapProvider = Provider<void>((ref) {
 });
 
 Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
+  _logger.info(
+    '[ENROLL-NOTIF-SP] bootstrap ${plan.id} '
+    'startDate=${plan.startDate?.toIso8601String()} '
+    'startedAt=${plan.startedAt.toIso8601String()} '
+    'effective=${plan.effectiveStartDate.toIso8601String()}',
+  );
+
   // Determine whether the plan is in the user's current local routine.
   final routineBlocks = ref.read(routineProvider).blocks;
 
@@ -44,7 +51,12 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
   // before routineProvider has loaded its Hive data. An empty routine is
   // ambiguous (might mean "not yet loaded"), so skip the cleanup to avoid
   // incorrectly wiping metadata; the next bootstrap fire will catch up.
-  if (routineBlocks.isEmpty) return;
+  if (routineBlocks.isEmpty) {
+    _logger.info(
+      '[ENROLL-NOTIF-SP] bootstrap ${plan.id} — routine empty/not loaded yet, skip',
+    );
+    return;
+  }
 
   final inRoutine = routineBlocks.any(
     (block) => block.items.any(
@@ -60,11 +72,21 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
     return;
   }
 
-  // Keep the cached startedAt in sync with server truth.
+  // Keep the cached anchor in sync with server truth. We store the plan's
+  // day-1 anchor (effectiveStartDate = startDate ?? startedAt) so that late
+  // joiners see the correct day-N notification (e.g. "Day 6" content), not
+  // Day 1 from their enrollment time.
+  final anchor = plan.effectiveStartDate;
   final cached = SpecialPlanStartedAtStore.getStartedAt(plan.id);
-  if (cached?.toIso8601String() != plan.startedAt.toIso8601String()) {
-    _logger.info('${plan.id} startedAt changed — updating cache');
-    await SpecialPlanStartedAtStore.setStartedAt(plan.id, plan.startedAt);
+  if (cached?.toIso8601String() != anchor.toIso8601String()) {
+    _logger.info(
+      '[ENROLL-NOTIF-SP] ${plan.id} anchor changed — updating cache '
+      '(cached=${cached?.toIso8601String()}, '
+      'anchor=${anchor.toIso8601String()}, '
+      'startDate=${plan.startDate?.toIso8601String()}, '
+      'startedAt=${plan.startedAt.toIso8601String()})',
+    );
+    await SpecialPlanStartedAtStore.setStartedAt(plan.id, anchor);
   }
 
   // Find the matching routine block to use its scheduled time.
@@ -76,6 +98,10 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
 
   // Reschedule is idempotent: cancels prior IDs first, then rebuilds the
   // future one-shot series. Survives reinstall and re-login.
+  _logger.info(
+    '[ENROLL-NOTIF-SP] bootstrap ${plan.id} — reschedule with '
+    'block=${matchingBlock.time.hour}:${matchingBlock.time.minute.toString().padLeft(2, '0')}',
+  );
   try {
     await ref.read(routineNotificationServiceProvider).rescheduleSpecialPlanSeries(
       planId: plan.id,
@@ -85,6 +111,6 @@ Future<void> _bootstrap(Ref ref, UserPlansModel plan) async {
       blockMinute: matchingBlock.time.minute,
     );
   } catch (e, st) {
-    _logger.error('Failed to reschedule ${plan.id}', e, st);
+    _logger.error('[ENROLL-NOTIF-SP] reschedule failed for ${plan.id}', e, st);
   }
 }

--- a/lib/features/notifications/application/special_plan_enrollment_hook.dart
+++ b/lib/features/notifications/application/special_plan_enrollment_hook.dart
@@ -12,8 +12,9 @@ final _logger = AppLogger('SpecialPlanEnrollmentHook');
 /// an immediate to avoid duplicates.
 const int kRoutineBlockHourThreshold = 9;
 
-/// Caches [plan.startedAt] (server truth) into [SpecialPlanStartedAtStore]
-/// so the notification scheduler can compute the correct day-N at fire time.
+/// Caches the plan's day-1 anchor ([plan.effectiveStartDate]) into
+/// [SpecialPlanStartedAtStore] so the notification scheduler can compute
+/// the correct day-N at fire time.
 ///
 /// Does NOT fire an immediate notification. Permission is only requested after
 /// HomeScreen mounts; the actual fire happens via [tryFirePendingSpecialPlanNotifications].
@@ -23,19 +24,23 @@ Future<void> onSpecialPlanEnrolled(UserPlansModel plan) async {
   final anchor = plan.effectiveStartDate;
   await SpecialPlanStartedAtStore.setStartedAt(plan.id, anchor);
   _logger.info(
-    '[SP-HOOK] cached anchor for ${plan.id} = ${anchor.toIso8601String()} '
-    '(startDate=${plan.startDate?.toIso8601String()}, startedAt=${plan.startedAt.toIso8601String()})',
+    '[ENROLL-NOTIF-SP] cached ${plan.id} anchor=${anchor.toIso8601String()} '
+    'startDate=${plan.startDate?.toIso8601String()} '
+    'startedAt=${plan.startedAt.toIso8601String()}',
   );
 }
 
 /// Fires an immediate notification for any [plans] whose series is active
-/// today and whose scheduled block time (09:00) has already passed.
+/// today and whose scheduled block time has already passed.
 ///
-/// Handles all three cases:
-///   - **Day 1 / new enrol**: startedAt == today, past 09:00 → fire Day 1.
-///   - **Delete + re-enrol**: startedAt is in the past, still within series,
-///     past 09:00 → fire the current day's content.
-///   - **Start date in the future**: skip — scheduled one-shot handles it.
+/// Handles:
+///   - **Day 1 / new enrol**: anchor == today, past block time → fire Day 1.
+///   - **Late enrollment**: anchor in past, today is day-N within series →
+///     fire Day-N (e.g. user joined on day 5 → fire Day 5 notification).
+///   - **Delete + re-enrol**: anchor in past, still within series → fire
+///     current day.
+///   - **Anchor in the future** (early enrol): skip — scheduled one-shot
+///     handles it on the plan's actual day 1.
 ///
 /// Idempotent: uses a per-date flag so repeated calls on the same day are
 /// no-ops even if the user opens the app multiple times.
@@ -52,35 +57,50 @@ Future<void> tryFirePendingSpecialPlanNotifications(
     if (!isSpecialPlan(plan.id)) continue;
 
     final anchorLocal = plan.effectiveStartDate.toLocal();
-    final isPlanDay1 =
-        DateTime(anchorLocal.year, anchorLocal.month, anchorLocal.day) ==
-        DateTime(now.year, now.month, now.day);
+    final anchorDay = DateTime(
+      anchorLocal.year,
+      anchorLocal.month,
+      anchorLocal.day,
+    );
 
-    if (!isPlanDay1) {
+    // Plan hasn't started yet (early enrollment) — the scheduled one-shot
+    // will fire on the plan's actual day 1.
+    if (anchorDay.isAfter(today)) {
+      _logger.info(
+        '[ENROLL-NOTIF-SP] skip ${plan.id}: anchor in future '
+        '(${anchorDay.toIso8601String()} > ${today.toIso8601String()})',
+      );
       continue;
     }
 
-    // Before 09:00 the scheduled one-shot handles the notification.
+    // Today is on or after day 1 — figure out which day-N we're on so we
+    // can fire the right immediate.
+    final daysSince = today.difference(anchorDay).inDays;
+    final dayNumber = daysSince + 1;
+
+    // Before the block time the scheduled one-shot handles the notification.
     if (now.hour < kRoutineBlockHourThreshold) {
       _logger.info(
-        'skip ${plan.id}: before block time (${now.hour}h < ${kRoutineBlockHourThreshold}h)',
+        '[ENROLL-NOTIF-SP] skip ${plan.id}: before block time '
+        '(${now.hour}h < ${kRoutineBlockHourThreshold}h) day=$dayNumber',
       );
       continue;
     }
 
     // Idempotency: already shown today?
     if (SpecialPlanStartedAtStore.wasShownOn(plan.id, today)) {
-      _logger.info('skip ${plan.id}: already shown today');
+      _logger.info(
+        '[ENROLL-NOTIF-SP] skip ${plan.id}: already shown today day=$dayNumber',
+      );
       continue;
     }
 
-    // Ensure the cache has the startedAt — usually populated by
+    // Ensure the cache has the anchor — usually populated by
     // [onSpecialPlanEnrolled] or the bootstrap listener, but be defensive.
     final cached = SpecialPlanStartedAtStore.getStartedAt(plan.id);
-    _logger.info('[SP-DAY1-HOOK] cache lookup ${plan.id} cached=$cached');
     if (cached == null) {
       _logger.info(
-        '[SP-DAY1-HOOK] cache miss ${plan.id} — priming effectiveStartDate',
+        '[ENROLL-NOTIF-SP] cache miss ${plan.id} — priming effectiveStartDate=${plan.effectiveStartDate.toIso8601String()}',
       );
       await SpecialPlanStartedAtStore.setStartedAt(
         plan.id,
@@ -88,7 +108,9 @@ Future<void> tryFirePendingSpecialPlanNotifications(
       );
     }
 
-    // _logger.info('Firing day ${daysSince + 1} immediate for ${plan.id}');
+    _logger.info(
+      '[ENROLL-NOTIF-SP] firing ${plan.id} day=$dayNumber anchor=${anchorDay.toIso8601String()}',
+    );
     await RoutineNotificationService().showSpecialPlanCurrentDayImmediate(
       planId: plan.id,
       planTitle: plan.title,

--- a/lib/features/notifications/data/services/routine_notification_service.dart
+++ b/lib/features/notifications/data/services/routine_notification_service.dart
@@ -126,6 +126,11 @@ class RoutineNotificationService {
           return NotificationResult.success(block.notificationId);
         }
 
+        _logger.info(
+          '[SP-CHECK] planId=${firstItem.id} title="${firstItem.title}" '
+          'NOT in kSpecialPlanNotifications — falling through to general-plan path',
+        );
+
         final metadata = PlanMetadataStore.getMetadata(firstItem.id);
         if (metadata != null) {
           await reschedulePlanDurationSeries(

--- a/lib/features/notifications/data/services/routine_notification_service.dart
+++ b/lib/features/notifications/data/services/routine_notification_service.dart
@@ -335,13 +335,19 @@ class RoutineNotificationService {
     }
     final startedAt = SpecialPlanStartedAtStore.getStartedAt(planId);
     if (startedAt == null) {
-      _logger.warning('rescheduleSpecialPlanSeries: no cached startedAt for $planId');
+      _logger.warning('[NOTIF-SCHEDULE-SP] no cached startedAt for $planId');
       return;
     }
 
     await _cancelSpecialPlanSeries(planId);
 
     final startedLocal = startedAt.toLocal();
+    _logger.info(
+      '[NOTIF-SCHEDULE-SP] $planId begin — cachedAnchor=${startedAt.toIso8601String()} '
+      'startedLocal=${startedLocal.toIso8601String()} '
+      'block=$blockHour:${blockMinute.toString().padLeft(2, '0')} '
+      'entries=${entries.length}',
+    );
     final pseudoItem = RoutineItem(
       id: planId,
       title: planTitle,
@@ -368,10 +374,25 @@ class RoutineNotificationService {
       blockMinute,
     );
 
+    _logger.info(
+      '[NOTIF-SCHEDULE-SP] $planId seriesStart=${seriesStart.toIso8601String()} '
+      'now=${now.toIso8601String()}',
+    );
+
     var scheduledCount = 0;
+    var skippedPast = 0;
     for (var day = 1; day <= entries.length; day++) {
       final fireDate = seriesStart.add(Duration(days: day - 1));
-      if (!fireDate.isAfter(now)) continue; // past — skip
+      if (!fireDate.isAfter(now)) {
+        skippedPast++;
+        _logger.info(
+          '[NOTIF-SCHEDULE-SP] $planId day=$day fireDate=${fireDate.toIso8601String()} — PAST, skipping',
+        );
+        continue;
+      }
+      _logger.info(
+        '[NOTIF-SCHEDULE-SP] $planId day=$day fireDate=${fireDate.toIso8601String()} — scheduling',
+      );
 
       final dayContent = entries[day - 1];
       final notifId = _specialPlanSeriesNotifId(planId, day);
@@ -403,8 +424,8 @@ class RoutineNotificationService {
     }
 
     _logger.info(
-      'rescheduleSpecialPlanSeries: $planId — $scheduledCount future days scheduled '
-      '(${entries.length - scheduledCount} in the past)',
+      '[NOTIF-SCHEDULE-SP] $planId DONE — scheduled=$scheduledCount past=$skippedPast '
+      'total=${entries.length}',
     );
 
     // Immediate catch-up: if today's scheduled fire has already passed and
@@ -439,12 +460,34 @@ class RoutineNotificationService {
       startedLocal.day,
     );
     final daysSince = today.difference(startedDay).inDays;
+    _logger.info(
+      '[NOTIF-SCHEDULE-SP] $planId overdue check — '
+      'today=${today.toIso8601String()} startedDay=${startedDay.toIso8601String()} '
+      'daysSince=$daysSince entries=${entries.length}',
+    );
 
-    if (daysSince < 0 || daysSince >= entries.length) return; // outside series
-    if (SpecialPlanStartedAtStore.wasShownOn(planId, today)) return; // already shown
+    if (daysSince < 0 || daysSince >= entries.length) {
+      _logger.info(
+        '[NOTIF-SCHEDULE-SP] $planId overdue: outside series — skip',
+      );
+      return;
+    }
+    if (SpecialPlanStartedAtStore.wasShownOn(planId, today)) {
+      _logger.info('[NOTIF-SCHEDULE-SP] $planId overdue: already shown today — skip');
+      return;
+    }
 
     final todayFireTz = seriesStart.add(Duration(days: daysSince));
-    if (todayFireTz.isAfter(tz.TZDateTime.now(tz.local))) return; // not yet due
+    if (todayFireTz.isAfter(tz.TZDateTime.now(tz.local))) {
+      _logger.info(
+        '[NOTIF-SCHEDULE-SP] $planId overdue: not yet due '
+        '(fireAt=${todayFireTz.toIso8601String()}) — skip',
+      );
+      return;
+    }
+    _logger.info(
+      '[NOTIF-SCHEDULE-SP] $planId overdue: firing immediate day=${daysSince + 1}',
+    );
 
     await showSpecialPlanCurrentDayImmediate(
       planId: planId,
@@ -477,21 +520,38 @@ class RoutineNotificationService {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
 
-    if (SpecialPlanStartedAtStore.wasShownOn(planId, today)) return null;
+    if (SpecialPlanStartedAtStore.wasShownOn(planId, today)) {
+      _logger.info(
+        '[ENROLL-NOTIF-SP] showImmediate $planId — already shown today, skip',
+      );
+      return null;
+    }
 
     final dayContent = resolveSpecialPlanNotification(
       planId: planId,
       startedAt: startedAt,
       now: now,
     );
-    if (dayContent == null) return null;
+    if (dayContent == null) {
+      _logger.warning(
+        '[ENROLL-NOTIF-SP] showImmediate $planId — no day content resolved '
+        '(anchor=${startedAt.toIso8601String()} now=${now.toIso8601String()})',
+      );
+      return null;
+    }
 
     final dayIndex = specialPlanDayIndex(
       planId: planId,
       startedAt: startedAt,
       now: now,
     );
-    if (dayIndex == null) return null;
+    if (dayIndex == null) {
+      _logger.warning('[ENROLL-NOTIF-SP] showImmediate $planId — dayIndex null');
+      return null;
+    }
+    _logger.info(
+      '[ENROLL-NOTIF-SP] showImmediate $planId day=$dayIndex title="${dayContent.title}"',
+    );
 
     // Guard: if permission is not yet granted, _plugin.show() silently no-ops
     // on Android 13+ and iOS. Do NOT mark wasShownOn in that case — the
@@ -633,7 +693,11 @@ class RoutineNotificationService {
 
     await _cancelPlanDurationSeries(planId);
 
-    final startedLocal = metadata.startedAt.toLocal();
+    // Anchor day-numbering to the plan's day-1 (effectiveStartDate).
+    // For fixed-date plans where the user joined late, this is the plan's
+    // scheduled start, NOT the user's enrollment timestamp — so they see
+    // the correct day-N notification (e.g. "Day 5 of 10") instead of Day 1.
+    final startedLocal = metadata.effectiveStartDate.toLocal();
     final nowTz = tz.TZDateTime.now(tz.local);
     final pseudoItem = RoutineItem(
       id: planId,
@@ -692,12 +756,15 @@ class RoutineNotificationService {
     }
 
     _logger.info(
-      'reschedulePlanDurationSeries: $planId — $scheduledCount future days scheduled '
-      'of ${metadata.totalDays} total',
+      '[NOTIF-SCHEDULE] $planId — anchor=${startedLocal.toIso8601String()} '
+      'block=$blockHour:${blockMinute.toString().padLeft(2, '0')} '
+      '$scheduledCount future days scheduled of ${metadata.totalDays} total',
     );
 
     // Immediate catch-up: fire today's notification if the block time has
-    // already passed and it hasn't been shown yet.
+    // already passed and it hasn't been shown yet. Day-N is computed from
+    // the plan anchor (effectiveStartDate) so late joiners see the correct
+    // day number.
     final nowLocal = DateTime.now();
     final today = DateTime(nowLocal.year, nowLocal.month, nowLocal.day);
     final startedDay = DateTime(startedLocal.year, startedLocal.month, startedLocal.day);
@@ -718,7 +785,7 @@ class RoutineNotificationService {
         );
         if (id != null) {
           await PlanMetadataStore.markImmediateShownOn(planId, today);
-          _logger.info('reschedulePlanDurationSeries: fired immediate day=$todayDayNumber for $planId id=$id');
+          _logger.info('[NOTIF-SCHEDULE] fired immediate day=$todayDayNumber for $planId id=$id');
         }
       }
     }

--- a/lib/features/notifications/data/special_plan_notifications.dart
+++ b/lib/features/notifications/data/special_plan_notifications.dart
@@ -35,6 +35,7 @@ class DayNotification {
 /// ITCC "Abhidhamma in a Year" plan ID.
 /// Mirrors `kOnboardingEvents` in onboarding_preferences.dart.
 const String kItccPlanId = 'b42c9270-8bc9-4a98-b375-924a948ab18e';
+const String kItccPlan7to37Id = '509657b5-7af5-45de-b22d-0ea2fe094424';
 
 /// Daily fire time for the special-plan series (local time). Mirrors the
 /// 09:00 routine block the event-enrollment flow creates server-side.
@@ -75,6 +76,38 @@ const Map<String, List<DayNotification>> kSpecialPlanNotifications = {
       body:
           "Today marks a significant step: finishing part 1 - and tomorrow, you'll begin part 2.",
       buttonText: 'GOTO APP',
+    ),
+  ],
+  kItccPlan7to37Id: <DayNotification>[
+    DayNotification(
+      title: 'Welcome to ITCC: Days 7-37',
+      body:
+          'Today we begin Cittuppādakaṇḍaṃ, the Chapter on the Arising of Consciousness and look at the mind when something wholesome arises.',
+      buttonText: 'Read Now',
+    ),
+    DayNotification(
+      title: 'A verse for today',
+      body:
+          '"Whatever at that time is mindfulness, recollection, the holding, the not floating away, the not forgetting — this at that time is the power of mindfulness."',
+      buttonText: 'Start Session',
+    ),
+    DayNotification(
+      title: "Today's Pali word: Khandha",
+      body:
+          '"Khanda" means heap or aggregate. Today\'s verses analyze a mind-moment via four immaterial aggregates — feeling, perception, formations, and consciousness — and the material one, form.',
+      buttonText: 'Open App',
+    ),
+    DayNotification(
+      title: 'The path in every moment',
+      body:
+          'Right view, thought, effort, mindfulness, concentration — the five path-factors are present in every wholesome mind.',
+      buttonText: 'Begin',
+    ),
+    DayNotification(
+      title: "Question for today's session",
+      body:
+          'Of these five types of wholesome mind — with joy or equanimity, with knowledge or without, spontaneous or prompted — which feels closest to this moment?',
+      buttonText: 'Start Reading',
     ),
   ],
 };

--- a/lib/features/plans/data/models/plans_model.dart
+++ b/lib/features/plans/data/models/plans_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/plans/data/models/author/author_dto_model.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
 import 'package:flutter_pecha/features/plans/domain/entities/plan.dart'
     as domain;
 
@@ -98,13 +99,8 @@ class PlansModel {
                   json['author'] as Map<String, dynamic>,
                 )
                 : null,
-        startDate:
-            json['start_date'] != null
-                ? DateTime.tryParse(json['start_date'] as String)
-                : null,
+        startDate: PlanUtils.parseCalendarDate(json['start_date'] as String?),
         displayOrder: json['display_order'] as int?,
-        // TEMP TEST — remove before merging
-        // startDate: _testStartDate(),
       );
     } catch (e) {
       _logger.error('Error in PlansModel.fromJson', e);

--- a/lib/features/plans/data/models/user/user_plans_model.dart
+++ b/lib/features/plans/data/models/user/user_plans_model.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
+
 class UserPlansModel {
   final String id;
   final String title;
@@ -40,12 +42,7 @@ class UserPlansModel {
       totalDays: json['total_days'] as int,
       tags:
           json['tags'] != null ? List<String>.from(json['tags'] as List) : null,
-      startDate:
-          json['start_date'] != null
-              ? DateTime.tryParse(json['start_date'] as String)
-              : null,
-      // TEMP TEST — remove before merging
-      // startDate: _testStartDate(),
+      startDate: PlanUtils.parseCalendarDate(json['start_date'] as String?),
     );
   }
 

--- a/lib/features/plans/data/utils/plan_utils.dart
+++ b/lib/features/plans/data/utils/plan_utils.dart
@@ -1,4 +1,33 @@
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+
+final _logger = AppLogger('PlanUtils');
+
 class PlanUtils {
+  /// Parses a backend calendar-date string (e.g. `2026-05-14T00:00:00.000Z`)
+  /// into a local-midnight DateTime preserving the calendar day.
+  ///
+  /// Backend sends plan start dates as UTC midnight, but these represent
+  /// **calendar dates**, not instants. A naive `.toLocal()` shifts the day
+  /// in negative-offset zones (e.g. May 14 UTC midnight → May 13 20:00 in
+  /// Toronto), producing off-by-one day-N calculations. This helper extracts
+  /// the UTC year/month/day and rebuilds at local midnight so the calendar
+  /// day is preserved everywhere downstream.
+  static DateTime? parseCalendarDate(String? iso) {
+    if (iso == null) return null;
+    final parsed = DateTime.tryParse(iso);
+    if (parsed == null) {
+      _logger.warning('[CAL-DATE] failed to parse: $iso');
+      return null;
+    }
+    final utc = parsed.toUtc();
+    final normalized = DateTime(utc.year, utc.month, utc.day);
+    _logger.info(
+      '[CAL-DATE] raw=$iso utc=${utc.toIso8601String()} '
+      'localMidnight=${normalized.toIso8601String()}',
+    );
+    return normalized;
+  }
+
   static int calculateSelectedDay(DateTime startedAt, int totalDays) {
     final today = DateTime.now();
     final localStartedAt = startedAt.toLocal();
@@ -25,20 +54,54 @@ class PlanUtils {
     return 1;
   }
 
-  /// Counts past scheduled days (before today) that the user has not completed.
-  /// Excludes today — the user still has time to finish it.
+  /// Returns the plan day-number (1-based) for [forDate], using
+  /// [planStartDate] as the anchor for Day 1. Clamped to `[1, totalDays]`.
+  /// Returns 0 if [forDate] is before the plan started.
+  static int dayNumberFor(
+    DateTime planStartDate,
+    DateTime forDate,
+    int totalDays,
+  ) {
+    final start = planStartDate.toLocal();
+    final target = forDate.toLocal();
+    final normalizedStart = DateTime(start.year, start.month, start.day);
+    final normalizedTarget = DateTime(target.year, target.month, target.day);
+    if (normalizedTarget.isBefore(normalizedStart)) return 0;
+    final diff = normalizedTarget.difference(normalizedStart).inDays + 1;
+    if (diff > totalDays) return totalDays;
+    return diff;
+  }
+
+  /// Counts past scheduled days the user has not completed.
+  ///
+  /// Skips days before [userJoinDate] — those happened before the user
+  /// enrolled and can never count as missed. Excludes today — user still
+  /// has time to finish it.
+  ///
+  /// [planStartDate]: Day 1 anchor (= `plan.startDate ?? plan.startedAt`).
+  /// [userJoinDate]: when the user actually enrolled (= `plan.startedAt`).
   static int calculateMissedDays(
-    DateTime startedAt,
+    DateTime planStartDate,
+    DateTime userJoinDate,
     int totalDays,
     Map<int, bool> completionStatus,
   ) {
-    final todayDayNumber = calculateSelectedDay(startedAt, totalDays);
+    final todayDayNumber = dayNumberFor(planStartDate, DateTime.now(), totalDays);
+    final joinDayNumberRaw = dayNumberFor(planStartDate, userJoinDate, totalDays);
+    // Clamp join day to >= 1: if the user enrolled before the plan started,
+    // treat their effective first day as Day 1.
+    final joinDayNumber = joinDayNumberRaw < 1 ? 1 : joinDayNumberRaw;
+
     int missedCount = 0;
-    for (int day = 1; day < todayDayNumber; day++) {
-      if (completionStatus[day] != true) {
-        missedCount++;
-      }
+    for (int day = joinDayNumber; day < todayDayNumber; day++) {
+      if (completionStatus[day] != true) missedCount++;
     }
+
+    _logger.info(
+      '[ENROLL-MISSED] planStart=${planStartDate.toIso8601String()} '
+      'userJoin=${userJoinDate.toIso8601String()} '
+      'todayDay=$todayDayNumber joinDay=$joinDayNumber missed=$missedCount',
+    );
     return missedCount;
   }
 }

--- a/lib/features/plans/presentation/widgets/plan_preview/plan_preview_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_preview/plan_preview_details.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
 import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
 import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
 import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
 import 'package:flutter_pecha/features/plans/data/models/plan_days_model.dart';
@@ -30,8 +32,38 @@ class PlanPreviewDetails extends ConsumerStatefulWidget {
   ConsumerState<PlanPreviewDetails> createState() => _PlanPreviewDetailsState();
 }
 
+final _logger = AppLogger('PlanPreviewDetails');
+
 class _PlanPreviewDetailsState extends ConsumerState<PlanPreviewDetails> {
-  int selectedDay = 1;
+  late int selectedDay;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedDay = _defaultSelectedDay();
+  }
+
+  /// For fixed-date plans that have already started, default the carousel
+  /// to today's plan day so an unenrolled visitor sees they'd be joining
+  /// mid-stream. Before the start date (or for flexible plans without a
+  /// start date), default to Day 1. After the plan has ended, clamp to the
+  /// final day.
+  int _defaultSelectedDay() {
+    final startDate = widget.plan.startDate;
+    if (startDate == null) return 1;
+    final day = PlanUtils.dayNumberFor(
+      startDate,
+      DateTime.now(),
+      widget.plan.totalDays,
+    );
+    final selected = day < 1 ? 1 : day;
+    _logger.info(
+      '[ENROLL-DAY] preview ${widget.plan.id} '
+      'startDate=${startDate.toIso8601String()} '
+      'totalDays=${widget.plan.totalDays} default=$selected',
+    );
+    return selected;
+  }
 
   bool _isPlanInRoutine(RoutineData routineData) {
     return routineData.blocks.any(

--- a/lib/features/plans/presentation/widgets/plan_track/missed_days_badge.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/missed_days_badge.dart
@@ -3,13 +3,19 @@ import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
 
 class MissedDaysBadge extends StatelessWidget {
-  final DateTime startDate;
+  /// Day-1 anchor of the plan (= `plan.startDate ?? plan.startedAt`).
+  final DateTime planStartDate;
+
+  /// When the user actually enrolled (= `plan.startedAt`). Used to skip
+  /// days before enrollment when counting missed days.
+  final DateTime userJoinDate;
   final int totalDays;
   final Map<int, bool> completionStatus;
 
   const MissedDaysBadge({
     super.key,
-    required this.startDate,
+    required this.planStartDate,
+    required this.userJoinDate,
     required this.totalDays,
     required this.completionStatus,
   });
@@ -17,7 +23,8 @@ class MissedDaysBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final missedDays = PlanUtils.calculateMissedDays(
-      startDate,
+      planStartDate,
+      userJoinDate,
       totalDays,
       completionStatus,
     );

--- a/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
@@ -332,7 +332,8 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
         ),
         if (completionStatus != null)
           MissedDaysBadge(
-            startDate: widget.startDate,
+            planStartDate: widget.startDate,
+            userJoinDate: widget.plan.startedAt,
             totalDays: widget.plan.totalDays,
             completionStatus: completionStatus,
           ),

--- a/lib/features/practice/presentation/widgets/routine_filled_state.dart
+++ b/lib/features/practice/presentation/widgets/routine_filled_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/data/models/notification_nav.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
@@ -10,6 +11,8 @@ import 'package:flutter_pecha/features/reader/data/models/navigation_context.dar
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+
+final _logger = AppLogger('RoutineFilledState');
 
 class RoutineFilledState extends ConsumerWidget {
   final RoutineData routineData;
@@ -52,10 +55,17 @@ class RoutineFilledState extends ConsumerWidget {
             return; // plans not loaded yet — wait for next build
           }
           ref.read(pendingNotificationNavProvider.notifier).state = null;
-          final startDate = userPlan.startedAt;
+          final startDate = userPlan.effectiveStartDate;
           final daysSince =
               DateTime.now().difference(DateUtils.dateOnly(startDate)).inDays;
           final selectedDay = (daysSince + 1).clamp(1, userPlan.totalDays);
+          _logger.info(
+            '[ENROLL-NAV] deep-link open ${userPlan.id} '
+            'anchor=${startDate.toIso8601String()} '
+            'startDate=${userPlan.startDate?.toIso8601String()} '
+            'startedAt=${userPlan.startedAt.toIso8601String()} '
+            'selectedDay=$selectedDay/${userPlan.totalDays}',
+          );
           context.push(
             '/practice/details',
             extra: {
@@ -203,10 +213,16 @@ class _RoutineBlockSection extends ConsumerWidget {
 
     final startDate =
         userPlan.startDate ?? item.enrolledAt ?? userPlan.startedAt;
-    debugPrint(':::::::::::::::: $startDate');
     final daysSinceEnrollment =
         DateTime.now().difference(DateUtils.dateOnly(startDate)).inDays;
     final selectedDay = (daysSinceEnrollment + 1).clamp(1, userPlan.totalDays);
+    _logger.info(
+      '[ENROLL-NAV] open plan ${userPlan.id} '
+      'anchor=${startDate.toIso8601String()} '
+      'startDate=${userPlan.startDate?.toIso8601String()} '
+      'startedAt=${userPlan.startedAt.toIso8601String()} '
+      'selectedDay=$selectedDay/${userPlan.totalDays}',
+    );
 
     context.push(
       '/practice/details',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -977,26 +977,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1526,10 +1526,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
 Add plan 509657b5-7af5-45de-b22d-0ea2fe094424 to kSpecialPlanNotifications                                                                                                    
  with 5 days of custom day-N copy. Routes through the special-plan branch
  which bypasses kSchedulePlanNotifications=false. Fire time uses the user's                                                                                                    
  routine block time (no onboarding auto-enrollment).     