### PR TITLE
feat: migrate select session to practice items flow

### DIFF
--- a/lib/features/plans/presentation/widgets/plan_preview/plan_preview_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_preview/plan_preview_details.dart
@@ -74,6 +74,19 @@ class _PlanPreviewDetailsState extends ConsumerState<PlanPreviewDetails> {
     );
   }
 
+  /// True when the plan has a fixed start date that is strictly after today's
+  /// local calendar date. The backend blocks enrolling in future-dated plans,
+  /// so the bottom "Add to Routine" button is hidden in that case to avoid a
+  /// guaranteed-failure tap and the downstream "Plan not found" snackbar in
+  /// the routine screen. Flexible plans (`startDate == null`) are unaffected.
+  bool _isFuturePlan() {
+    final startDate = widget.plan.startDate;
+    if (startDate == null) return false;
+    final today = DateUtils.dateOnly(DateTime.now());
+    final start = DateUtils.dateOnly(startDate.toLocal());
+    return start.isAfter(today);
+  }
+
   void _handleAddToRoutine() {
     final isGuest = ref.read(authProvider).isGuest;
     if (isGuest) {
@@ -89,6 +102,7 @@ class _PlanPreviewDetailsState extends ConsumerState<PlanPreviewDetails> {
     final authState = ref.watch(authProvider);
     final isGuest = authState.isGuest;
     final alreadyInRoutine = _isCurrentlyInRoutine();
+    final isFuturePlan = _isFuturePlan();
 
     return Scaffold(
       appBar: _buildAppBar(context, alreadyInRoutine),
@@ -106,7 +120,8 @@ class _PlanPreviewDetailsState extends ConsumerState<PlanPreviewDetails> {
               ),
             ),
           ),
-          if (!alreadyInRoutine) _buildBottomButton(context, isGuest),
+          if (!alreadyInRoutine && !isFuturePlan)
+            _buildBottomButton(context, isGuest),
         ],
       ),
     );

--- a/lib/features/practice/data/datasource/practice_items_remote_datasource.dart
+++ b/lib/features/practice/data/datasource/practice_items_remote_datasource.dart
@@ -1,0 +1,59 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_pecha/core/error/exceptions.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/practice/data/models/practice_item_model.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+
+class PracticeItemsRemoteDatasource {
+  final Dio _dio;
+  final _logger = AppLogger('PracticeItemsRemoteDatasource');
+
+  PracticeItemsRemoteDatasource({required Dio dio}) : _dio = dio;
+
+  /// Endpoint: GET /practice/items
+  /// Returns a paginated list of practice-addable items (plans + series).
+  Future<PracticeItemsResponseModel> fetchPracticeItems({
+    required PracticeItemsTab tab,
+    required String language,
+    required int page,
+    required int pageSize,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '/practice/items',
+        queryParameters: {
+          'tab': tab.toQueryValue(),
+          'language': language,
+          'page': page,
+          'page_size': pageSize,
+        },
+      );
+
+      final data = response.data;
+      if (data is! Map<String, dynamic>) {
+        _logger.error('Unexpected /practice/items payload type: ${data.runtimeType}');
+        throw const ServerException('Invalid response from /practice/items');
+      }
+      return PracticeItemsResponseModel.fromJson(data);
+    } on DioException catch (e) {
+      _logger.error('Dio error in fetchPracticeItems', e);
+      throw _dioToException(e, 'Failed to load practice items');
+    }
+  }
+
+  Exception _dioToException(DioException e, String label) {
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.sendTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
+      return const NetworkException('Connection timeout');
+    }
+    if (e.type == DioExceptionType.connectionError) {
+      return const NetworkException('No internet connection');
+    }
+    final status = e.response?.statusCode;
+    if (status == 401) return const AuthenticationException('Unauthorized');
+    if (status == 404) return const NotFoundException('Practice items not found');
+    if (status == 429) return const RateLimitException('Too many requests');
+    return ServerException('$label: ${status ?? 'unknown error'}');
+  }
+}

--- a/lib/features/practice/data/models/practice_item_model.dart
+++ b/lib/features/practice/data/models/practice_item_model.dart
@@ -1,0 +1,94 @@
+/// Wire-level type discriminator for the `/practice/items` response.
+enum PracticeItemType {
+  plan,
+  series,
+  unknown;
+
+  static PracticeItemType fromJson(String? value) => switch (value) {
+    'plan' => PracticeItemType.plan,
+    'series' => PracticeItemType.series,
+    _ => PracticeItemType.unknown,
+  };
+}
+
+/// One row of `GET /practice/items`. The backend returns a single item shape
+/// discriminated by [type]: a `plan` row has plan fields at the top level,
+/// while a `series` row carries series metadata + nested plans.
+///
+/// Parsing keeps the raw JSON around so the repository can lazily convert to
+/// the right domain entity ([PlansModel] / [SeriesModel]) based on [type].
+class PracticeItemModel {
+  final String id;
+  final PracticeItemType type;
+  final Map<String, dynamic> raw;
+
+  const PracticeItemModel({
+    required this.id,
+    required this.type,
+    required this.raw,
+  });
+
+  factory PracticeItemModel.fromJson(Map<String, dynamic> json) {
+    return PracticeItemModel(
+      id: (json['id'] as String?) ?? '',
+      type: PracticeItemType.fromJson(json['type'] as String?),
+      raw: json,
+    );
+  }
+}
+
+/// Page metadata for `GET /practice/items`.
+class PracticePaginationModel {
+  final int page;
+  final int pageSize;
+  final int total;
+  final int totalPages;
+
+  const PracticePaginationModel({
+    required this.page,
+    required this.pageSize,
+    required this.total,
+    required this.totalPages,
+  });
+
+  factory PracticePaginationModel.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return const PracticePaginationModel(
+        page: 1,
+        pageSize: 0,
+        total: 0,
+        totalPages: 1,
+      );
+    }
+    return PracticePaginationModel(
+      page: (json['page'] as num?)?.toInt() ?? 1,
+      pageSize: (json['page_size'] as num?)?.toInt() ?? 0,
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      totalPages: (json['total_pages'] as num?)?.toInt() ?? 1,
+    );
+  }
+}
+
+/// Full response envelope for `GET /practice/items`.
+class PracticeItemsResponseModel {
+  final List<PracticeItemModel> items;
+  final PracticePaginationModel pagination;
+
+  const PracticeItemsResponseModel({
+    required this.items,
+    required this.pagination,
+  });
+
+  factory PracticeItemsResponseModel.fromJson(Map<String, dynamic> json) {
+    final rawItems = (json['items'] as List<dynamic>?) ?? const [];
+    return PracticeItemsResponseModel(
+      items: rawItems
+          .whereType<Map<String, dynamic>>()
+          .map(PracticeItemModel.fromJson)
+          .toList(),
+      pagination: PracticePaginationModel.fromJson(
+        json['pagination'] as Map<String, dynamic>?,
+      ),
+    );
+  }
+}

--- a/lib/features/practice/data/models/session_selection.dart
+++ b/lib/features/practice/data/models/session_selection.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
 import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
 import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 
@@ -20,4 +21,19 @@ class RecitationSessionSelection extends SessionSelection {
   final RecitationModel recitation;
 
   const RecitationSessionSelection(this.recitation);
+}
+
+/// Represents a series selection from the session picker.
+///
+/// The full [series] entity is carried (not just the id) so the consumer can
+/// display the series name in transient UI (snackbars/loaders) without an
+/// extra fetch. Enrollment + plan injection are handled downstream by
+/// reusing the existing `seriesEnrollmentProvider` + `enrollSeriesId`
+/// handoff to `EditRoutineScreen`.
+class SeriesSessionSelection extends SessionSelection {
+  final Series series;
+
+  const SeriesSessionSelection(this.series);
+
+  String get seriesId => series.id;
 }

--- a/lib/features/practice/data/repositories/practice_items_repository_impl.dart
+++ b/lib/features/practice/data/repositories/practice_items_repository_impl.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_pecha/core/error/exceptions.dart';
+import 'package:flutter_pecha/core/error/failures.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/home/data/models/series_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/plans_model.dart';
+import 'package:flutter_pecha/features/practice/data/datasource/practice_items_remote_datasource.dart';
+import 'package:flutter_pecha/features/practice/data/models/practice_item_model.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_item.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_page.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+import 'package:flutter_pecha/features/practice/domain/repositories/practice_items_repository.dart';
+import 'package:fpdart/fpdart.dart';
+
+class PracticeItemsRepositoryImpl implements PracticeItemsRepository {
+  final PracticeItemsRemoteDatasource _datasource;
+  final _logger = AppLogger('PracticeItemsRepositoryImpl');
+
+  PracticeItemsRepositoryImpl({required PracticeItemsRemoteDatasource datasource})
+    : _datasource = datasource;
+
+  @override
+  Future<Either<Failure, PracticeItemsPage>> getPracticeItems({
+    required PracticeItemsTab tab,
+    required String language,
+    required int page,
+    required int pageSize,
+  }) async {
+    try {
+      final response = await _datasource.fetchPracticeItems(
+        tab: tab,
+        language: language,
+        page: page,
+        pageSize: pageSize,
+      );
+
+      final items = <PracticeItem>[];
+      for (final raw in response.items) {
+        final entity = _toEntity(raw, language);
+        if (entity != null) items.add(entity);
+      }
+
+      return Right(
+        PracticeItemsPage(
+          items: items,
+          page: response.pagination.page,
+          pageSize: response.pagination.pageSize,
+          total: response.pagination.total,
+          totalPages: response.pagination.totalPages,
+        ),
+      );
+    } catch (e, st) {
+      _logger.error('Failed to fetch /practice/items', e, st);
+      return Left(_toFailure(e));
+    }
+  }
+
+  /// Converts a raw API row to its domain entity. Unknown types are dropped
+  /// (returns null) so the UI never has to render a discriminator it cannot
+  /// reason about.
+  PracticeItem? _toEntity(PracticeItemModel model, String language) {
+    switch (model.type) {
+      case PracticeItemType.plan:
+        try {
+          final plan = PlansModel.fromJson(model.raw).toEntity();
+          return PracticePlanItem(plan);
+        } catch (e) {
+          _logger.warning('Skipping malformed plan item ${model.id}: $e');
+          return null;
+        }
+      case PracticeItemType.series:
+        try {
+          // `/practice/items` exposes the series cover under `image_url`,
+          // while [SeriesModel] (shared with `/series`) reads `image`. Bridge
+          // here so series items render their cover without modifying the
+          // shared model.
+          final normalized = Map<String, dynamic>.from(model.raw);
+          normalized['image'] ??= normalized['image_url'];
+          final series = SeriesModel.fromJson(normalized).toEntity(language);
+          return PracticeSeriesItem(series);
+        } catch (e) {
+          _logger.warning('Skipping malformed series item ${model.id}: $e');
+          return null;
+        }
+      case PracticeItemType.unknown:
+        _logger.warning('Skipping practice item ${model.id} with unknown type');
+        return null;
+    }
+  }
+
+  Failure _toFailure(Object e) {
+    if (e is NetworkException) return NetworkFailure(e.message);
+    if (e is AuthenticationException) return AuthenticationFailure(e.message);
+    if (e is NotFoundException) return NotFoundFailure(e.message);
+    if (e is RateLimitException) return RateLimitFailure(e.message);
+    if (e is ServerException) return ServerFailure(e.message);
+    return const ServerFailure(
+      'An unexpected error occurred. Please try again.',
+    );
+  }
+}

--- a/lib/features/practice/domain/entities/practice_item.dart
+++ b/lib/features/practice/domain/entities/practice_item.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
+
+/// Domain-level item shown in the practice picker. Either a standalone [Plan]
+/// or a [Series]. Callers branch on the subtype rather than a discriminator
+/// string so unknown server `type` values are filtered out upstream.
+sealed class PracticeItem {
+  /// Shared id used for routine duplicate-detection and enrolled-series
+  /// filtering across plan and series rows.
+  String get id;
+}
+
+class PracticePlanItem implements PracticeItem {
+  final Plan plan;
+  const PracticePlanItem(this.plan);
+
+  @override
+  String get id => plan.id;
+}
+
+class PracticeSeriesItem implements PracticeItem {
+  final Series series;
+  const PracticeSeriesItem(this.series);
+
+  @override
+  String get id => series.id;
+}

--- a/lib/features/practice/domain/entities/practice_items_page.dart
+++ b/lib/features/practice/domain/entities/practice_items_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_pecha/features/practice/domain/entities/practice_item.dart';
+
+/// One page of practice items returned by `GET /practice/items`.
+///
+/// Uses 1-based page indexing to match the backend contract; `hasMore` is
+/// derived from `page < totalPages` so callers do not have to reason about
+/// the underlying numbers.
+class PracticeItemsPage {
+  final List<PracticeItem> items;
+  final int page;
+  final int pageSize;
+  final int total;
+  final int totalPages;
+
+  const PracticeItemsPage({
+    required this.items,
+    required this.page,
+    required this.pageSize,
+    required this.total,
+    required this.totalPages,
+  });
+
+  bool get hasMore => page < totalPages;
+}

--- a/lib/features/practice/domain/entities/practice_items_tab.dart
+++ b/lib/features/practice/domain/entities/practice_items_tab.dart
@@ -1,0 +1,15 @@
+/// Domain-level tab filter for `GET /practice/items`.
+///
+/// Kept in the domain layer so use-cases/repositories don't depend on data
+/// implementation files.
+enum PracticeItemsTab {
+  all,
+  series,
+  plans;
+
+  String toQueryValue() => switch (this) {
+    PracticeItemsTab.all => 'all',
+    PracticeItemsTab.series => 'series',
+    PracticeItemsTab.plans => 'plans',
+  };
+}

--- a/lib/features/practice/domain/repositories/practice_items_repository.dart
+++ b/lib/features/practice/domain/repositories/practice_items_repository.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_pecha/core/error/failures.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_page.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+import 'package:fpdart/fpdart.dart';
+
+/// Domain contract for `GET /practice/items`.
+abstract class PracticeItemsRepository {
+  /// Fetches a single page of practice items filtered by [tab] and
+  /// localized by [language]. Page indexing is 1-based to mirror the API.
+  Future<Either<Failure, PracticeItemsPage>> getPracticeItems({
+    required PracticeItemsTab tab,
+    required String language,
+    required int page,
+    required int pageSize,
+  });
+}

--- a/lib/features/practice/domain/usecases/get_practice_items_usecase.dart
+++ b/lib/features/practice/domain/usecases/get_practice_items_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_pecha/core/error/failures.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_page.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+import 'package:flutter_pecha/features/practice/domain/repositories/practice_items_repository.dart';
+import 'package:fpdart/fpdart.dart';
+
+/// Fetches one page of practice items, filtered by [tab] and [language].
+class GetPracticeItemsUseCase {
+  final PracticeItemsRepository _repository;
+  const GetPracticeItemsUseCase(this._repository);
+
+  Future<Either<Failure, PracticeItemsPage>> call({
+    required PracticeItemsTab tab,
+    required String language,
+    required int page,
+    required int pageSize,
+  }) {
+    return _repository.getPracticeItems(
+      tab: tab,
+      language: language,
+      page: page,
+      pageSize: pageSize,
+    );
+  }
+}

--- a/lib/features/practice/practice.dart
+++ b/lib/features/practice/practice.dart
@@ -10,10 +10,14 @@ library;
 export 'domain/entities/routine.dart';
 export 'domain/entities/practice_session.dart';
 export 'domain/entities/practice_progress.dart';
+export 'domain/entities/practice_item.dart';
+export 'domain/entities/practice_items_page.dart';
+export 'domain/entities/practice_items_tab.dart';
 
 // Domain - Repositories
 export 'domain/repositories/practice_repository.dart';
 export 'domain/repositories/routine_api_repository.dart';
+export 'domain/repositories/practice_items_repository.dart';
 
 // Domain - Use Cases (local storage)
 export 'domain/usecases/get_routines_usecase.dart';
@@ -22,11 +26,13 @@ export 'domain/usecases/complete_practice_usecase.dart';
 
 // Domain - Use Cases (remote API)
 export 'domain/usecases/routine_api_usecases.dart';
+export 'domain/usecases/get_practice_items_usecase.dart';
 
 // Data - Models
 export 'data/models/routine_model.dart';
 export 'data/models/routine_api_models.dart';
 export 'data/models/session_selection.dart';
+export 'data/models/practice_item_model.dart';
 
 // Data - Services
 export 'package:flutter_pecha/features/notifications/data/services/routine_notification_service.dart';
@@ -37,12 +43,14 @@ export 'data/utils/routine_api_mapper.dart';
 
 // Data - Datasources
 export 'data/datasource/routine_local_storage.dart';
+export 'data/datasource/practice_items_remote_datasource.dart';
 
 // Presentation - Providers
 export 'presentation/providers/practice_providers.dart';
 export 'presentation/providers/use_case_providers.dart';
 export 'presentation/providers/routine_api_providers.dart';
 export 'presentation/providers/routine_provider.dart';
+export 'presentation/providers/practice_items_paginated_provider.dart';
 
 // Presentation - Screens
 export 'presentation/screens/practice_screen.dart';

--- a/lib/features/practice/presentation/providers/practice_items_paginated_provider.dart
+++ b/lib/features/practice/presentation/providers/practice_items_paginated_provider.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/di/core_providers.dart';
+import 'package:flutter_pecha/core/utils/app_logger.dart';
+import 'package:flutter_pecha/features/practice/data/datasource/practice_items_remote_datasource.dart';
+import 'package:flutter_pecha/features/practice/data/repositories/practice_items_repository_impl.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_item.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+import 'package:flutter_pecha/features/practice/domain/repositories/practice_items_repository.dart';
+import 'package:flutter_pecha/features/practice/domain/usecases/get_practice_items_usecase.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final _logger = AppLogger('PracticeItemsNotifier');
+
+/// Default page size for the practice picker. Matches the existing
+/// find-plans `_limit` so list behavior feels identical end-to-end.
+const int _defaultPageSize = 20;
+
+// ─── DI providers ───
+
+final practiceItemsRemoteDatasourceProvider =
+    Provider<PracticeItemsRemoteDatasource>((ref) {
+      return PracticeItemsRemoteDatasource(dio: ref.watch(dioProvider));
+    });
+
+final practiceItemsRepositoryProvider = Provider<PracticeItemsRepository>((
+  ref,
+) {
+  return PracticeItemsRepositoryImpl(
+    datasource: ref.watch(practiceItemsRemoteDatasourceProvider),
+  );
+});
+
+final getPracticeItemsUseCaseProvider = Provider<GetPracticeItemsUseCase>((
+  ref,
+) {
+  return GetPracticeItemsUseCase(ref.watch(practiceItemsRepositoryProvider));
+});
+
+// ─── State ───
+
+/// Immutable view-state for the paginated practice items list.
+class PracticeItemsState {
+  final List<PracticeItem> items;
+  final bool isLoading;
+  final bool isLoadingMore;
+  final String? error;
+  final bool hasMore;
+
+  /// 1-based; `0` means "nothing fetched yet".
+  final int page;
+
+  const PracticeItemsState({
+    this.items = const [],
+    this.isLoading = false,
+    this.isLoadingMore = false,
+    this.error,
+    this.hasMore = true,
+    this.page = 0,
+  });
+
+  PracticeItemsState copyWith({
+    List<PracticeItem>? items,
+    bool? isLoading,
+    bool? isLoadingMore,
+    String? error,
+    bool? hasMore,
+    int? page,
+  }) {
+    return PracticeItemsState(
+      items: items ?? this.items,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      // Pass `error` explicitly so callers can clear it by passing null.
+      error: error,
+      hasMore: hasMore ?? this.hasMore,
+      page: page ?? this.page,
+    );
+  }
+}
+
+/// Page-based paginated notifier for `GET /practice/items`.
+///
+/// Mirrors the public surface of `FindPlansNotifier` (`loadInitial`,
+/// `loadMore`, `retry`, `refresh`) so the UI can swap providers without
+/// behavioral churn — only the underlying pagination math changes from
+/// `skip/limit` to `page/total_pages`.
+class PracticeItemsNotifier extends StateNotifier<PracticeItemsState> {
+  final GetPracticeItemsUseCase _useCase;
+  final PracticeItemsTab _tab;
+  final String _languageCode;
+
+  PracticeItemsNotifier({
+    required GetPracticeItemsUseCase useCase,
+    required PracticeItemsTab tab,
+    required String languageCode,
+  }) : _useCase = useCase,
+       _tab = tab,
+       _languageCode = languageCode,
+       super(const PracticeItemsState()) {
+    loadInitial();
+  }
+
+  Future<void> loadInitial() async {
+    if (state.isLoading) return;
+    state = state.copyWith(isLoading: true);
+
+    final result = await _useCase(
+      tab: _tab,
+      language: _languageCode,
+      page: 1,
+      pageSize: _defaultPageSize,
+    );
+
+    if (!mounted) return;
+    result.fold(
+      (failure) {
+        _logger.error('Initial load failed: ${failure.message}');
+        state = state.copyWith(isLoading: false, error: failure.message);
+      },
+      (page) {
+        state = PracticeItemsState(
+          items: page.items,
+          isLoading: false,
+          isLoadingMore: false,
+          hasMore: page.hasMore,
+          page: page.page,
+        );
+      },
+    );
+  }
+
+  Future<void> loadMore() async {
+    if (state.isLoadingMore || state.isLoading || !state.hasMore) return;
+
+    state = state.copyWith(isLoadingMore: true);
+    final nextPage = state.page + 1;
+
+    final result = await _useCase(
+      tab: _tab,
+      language: _languageCode,
+      page: nextPage,
+      pageSize: _defaultPageSize,
+    );
+
+    if (!mounted) return;
+    result.fold(
+      (failure) {
+        _logger.error('Load more failed: ${failure.message}');
+        state = state.copyWith(
+          isLoadingMore: false,
+          error: failure.message,
+        );
+      },
+      (page) {
+        state = state.copyWith(
+          items: [...state.items, ...page.items],
+          isLoadingMore: false,
+          hasMore: page.hasMore,
+          page: page.page,
+        );
+      },
+    );
+  }
+
+  void retry() {
+    if (state.items.isEmpty) {
+      loadInitial();
+    } else {
+      loadMore();
+    }
+  }
+
+  Future<void> refresh() async {
+    state = const PracticeItemsState();
+    await loadInitial();
+  }
+}
+
+/// Family keyed by the tab so the screen can have independent providers
+/// per tab if needed. Default usage in the picker is `PracticeItemsTab.all`.
+final practiceItemsPaginatedProvider = StateNotifierProvider.autoDispose
+    .family<PracticeItemsNotifier, PracticeItemsState, PracticeItemsTab>((
+      ref,
+      tab,
+    ) {
+      final locale = ref.watch(localeProvider);
+      return PracticeItemsNotifier(
+        useCase: ref.watch(getPracticeItemsUseCaseProvider),
+        tab: tab,
+        languageCode: locale.languageCode,
+      );
+    });

--- a/lib/features/practice/presentation/screens/edit_routine_screen.dart
+++ b/lib/features/practice/presentation/screens/edit_routine_screen.dart
@@ -58,8 +58,10 @@ class EditRoutineScreen extends ConsumerStatefulWidget {
   final Plan? initialPlan;
 
   /// When provided, after hydration the screen fetches all currently-active
-  /// plans from the given series and injects them into the routine at the
-  /// default 8:00 AM block. Backend filters out future plans by start date.
+  /// plans from the given series and injects them into the routine, reusing
+  /// any existing empty block or creating a new one at the user's current
+  /// local time (with the standard 10-minute gap). Backend filters out future
+  /// plans by start date.
   final String? enrollSeriesId;
 
   const EditRoutineScreen({
@@ -82,12 +84,6 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
 
   /// Guard so series-enrollment prefill runs exactly once after hydration.
   bool _seriesEnrollmentHydrated = false;
-
-  /// Default time used when prefilling a routine block from series enrollment.
-  static const TimeOfDay _seriesEnrollDefaultTime = TimeOfDay(
-    hour: 8,
-    minute: 0,
-  );
 
   /// Sequential queue so API calls never overlap or race.
   Future<void> _opQueue = Future.value();
@@ -136,6 +132,43 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     }
   }
 
+  /// Resolves where to place auto-injected items (plan deep-link or series
+  /// enrollment prefill). Prefers the earliest existing empty block, re-timed
+  /// to the user's current local time (with the standard 10-minute gap from
+  /// other blocks). Falls back to a brand-new block at the current local
+  /// time, and finally to `_blocks.first` if no valid slot is available.
+  ///
+  /// Mutates `block.time` and reorders `_blocks` (via `_sortBlocks`), so the
+  /// caller must wrap this in `setState` when called outside the build phase.
+  ({_EditableBlock target, bool isNewBlock}) _resolveInjectionTarget() {
+    _sortBlocks();
+
+    for (final block in _blocks) {
+      if (block.items.isEmpty) {
+        final otherTimes = _blocks
+            .where((b) => !identical(b, block))
+            .map((b) => b.time)
+            .toList();
+        final adjusted = adjustTimeForMinimumGap(TimeOfDay.now(), otherTimes);
+        if (adjusted != null) {
+          block.time = adjusted;
+        }
+        return (target: block, isNewBlock: false);
+      }
+    }
+
+    final allTimes = _blocks.map((b) => b.time).toList();
+    final adjusted = adjustTimeForMinimumGap(TimeOfDay.now(), allTimes);
+    if (adjusted == null) {
+      return (target: _blocks.first, isNewBlock: false);
+    }
+    final newBlock = _EditableBlock(
+      time: adjusted,
+      notificationEnabled: true,
+    );
+    return (target: newBlock, isNewBlock: true);
+  }
+
   void _injectInitialPlan(Plan plan) {
     final alreadyExists = _blocks.any(
       (b) => b.items.any(
@@ -152,28 +185,11 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
       enrolledAt: DateTime.now(),
     );
 
-    // If we have exactly one empty default block, add the plan there
-    if (_blocks.length == 1 && _blocks.first.items.isEmpty) {
-      _blocks.first.items.add(newItem);
-      return;
+    final resolved = _resolveInjectionTarget();
+    resolved.target.items.add(newItem);
+    if (resolved.isNewBlock) {
+      _blocks.add(resolved.target);
     }
-
-    // Otherwise create a new time block at the user's current local time
-    final otherTimes = _blocks.map((b) => b.time).toList();
-    final adjusted = adjustTimeForMinimumGap(TimeOfDay.now(), otherTimes);
-    if (adjusted == null) {
-      // Fallback: add to the first block if no time slot available
-      _blocks.first.items.add(newItem);
-      return;
-    }
-
-    _blocks.add(
-      _EditableBlock(
-        time: adjusted,
-        notificationEnabled: true,
-        items: [newItem],
-      ),
-    );
     _sortBlocks();
   }
 
@@ -233,53 +249,14 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     );
   }
 
-  /// Adds [plans] into the routine at the default 8:00 AM block.
-  ///
-  /// Behavior:
-  /// - If the only block is the empty 12:00 PM default, it is replaced with
-  ///   an 8:00 AM block instead of adding another one.
-  /// - If a block at exactly 8:00 AM already exists, plans are appended there.
-  /// - Otherwise a new block is created; the time is shifted if 8:00 AM would
-  ///   collide with an existing block (using the same min-gap rules).
-  /// - Plans that already exist in any block (by id + plan type) are skipped.
+  /// Adds [plans] into the routine, reusing the earliest empty block (re-timed
+  /// to the user's current local time) or creating a new block at that time
+  /// with the standard 10-minute gap. Plans that already exist in any block
+  /// (by id + plan type) are skipped.
   ///
   /// Returns the affected block (to drive a follow-up server sync) or null
-  /// if there is nothing new to inject.
+  /// if every plan was already present.
   _EditableBlock? _injectSeriesUserPlans(List<UserPlansModel> plans) {
-    final _EditableBlock targetBlock;
-    bool replaceDefault = false;
-    bool isNewBlock = false;
-
-    if (_blocks.length == 1 && _blocks.first.items.isEmpty) {
-      targetBlock = _EditableBlock(
-        time: _seriesEnrollDefaultTime,
-        notificationEnabled: true,
-      );
-      replaceDefault = true;
-    } else {
-      _EditableBlock? existing;
-      for (final b in _blocks) {
-        if (b.time == _seriesEnrollDefaultTime) {
-          existing = b;
-          break;
-        }
-      }
-      if (existing != null) {
-        targetBlock = existing;
-      } else {
-        final otherTimes = _blocks.map((b) => b.time).toList();
-        final adjusted = adjustTimeForMinimumGap(
-          _seriesEnrollDefaultTime,
-          otherTimes,
-        );
-        targetBlock = _EditableBlock(
-          time: adjusted ?? _seriesEnrollDefaultTime,
-          notificationEnabled: true,
-        );
-        isNewBlock = true;
-      }
-    }
-
     final existingPlanIds = <String>{};
     for (final b in _blocks) {
       for (final item in b.items) {
@@ -304,19 +281,20 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
       existingPlanIds.add(p.id);
     }
 
-    if (newItems.isEmpty && !replaceDefault && !isNewBlock) return null;
+    if (newItems.isEmpty) return null;
 
+    late _EditableBlock target;
     setState(() {
-      if (replaceDefault) {
-        _blocks[0] = targetBlock;
-      } else if (isNewBlock) {
-        _blocks.add(targetBlock);
+      final resolved = _resolveInjectionTarget();
+      target = resolved.target;
+      if (resolved.isNewBlock) {
+        _blocks.add(target);
       }
-      targetBlock.items.addAll(newItems);
+      target.items.addAll(newItems);
       _sortBlocks();
     });
 
-    return newItems.isEmpty ? null : targetBlock;
+    return target;
   }
 
   RoutineBlock _toRoutineBlock(_EditableBlock b) {
@@ -853,10 +831,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     }
 
     final otherTimes = _blocks.map((b) => b.time).toList();
-    final adjusted = adjustTimeForMinimumGap(
-      const TimeOfDay(hour: 12, minute: 0),
-      otherTimes,
-    );
+    final adjusted = adjustTimeForMinimumGap(TimeOfDay.now(), otherTimes);
 
     if (adjusted == null) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/practice/presentation/screens/edit_routine_screen.dart
+++ b/lib/features/practice/presentation/screens/edit_routine_screen.dart
@@ -11,12 +11,17 @@ import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/data/services/notification_service.dart';
 import 'package:flutter_pecha/features/notifications/data/special_plan_notifications.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
 import 'package:flutter_pecha/features/plans/domain/usecases/user_plans_usecases.dart';
 import 'package:flutter_pecha/features/plans/plans.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/use_case_providers.dart'
     show getUserPlansUseCaseProvider;
 import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
 import 'package:flutter_pecha/features/practice/data/models/session_selection.dart';
+import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 import 'package:flutter_pecha/features/practice/data/utils/routine_api_mapper.dart';
 import 'package:flutter_pecha/features/practice/data/utils/routine_time_utils.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/practice_providers.dart';
@@ -971,65 +976,140 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
         ),
       );
 
-      if (result != null && mounted) {
-        final (newItemId, newItemType) = switch (result) {
-          PlanSessionSelection(:final plan) => (plan.id, RoutineItemType.plan),
-          RecitationSessionSelection(:final recitation) => (
-            recitation.textId,
-            RoutineItemType.recitation,
-          ),
-        };
+      if (result == null || !mounted) return;
 
-        final isDuplicate = _blocks[blockIndex].items.any(
-          (item) => item.id == newItemId && item.type == newItemType,
-        );
-
-        if (isDuplicate) {
-          _logger.warning('Duplicate item prevented: $newItemId');
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(context.l10n.duplicateItem),
-                duration: const Duration(seconds: 2),
-              ),
-            );
-          }
-          return;
-        }
-
-        final RoutineItem newItem;
-        switch (result) {
-          case PlanSessionSelection(:final plan):
-            newItem = RoutineItem(
-              id: plan.id,
-              title: plan.title,
-              imageUrl: plan.coverImageUrl,
-              type: RoutineItemType.plan,
-              enrolledAt: DateTime.now(),
-            );
-          case RecitationSessionSelection(:final recitation):
-            newItem = RoutineItem(
-              id: recitation.textId,
-              title: recitation.title,
-              type: RoutineItemType.recitation,
-            );
-        }
-
-        final block = _blocks[blockIndex];
-        setState(() => block.items.add(newItem));
-
-        try {
-          await _syncBlock(block);
-        } catch (e) {
-          if (mounted) {
-            setState(() => block.items.remove(newItem));
-            _showErrorSnackBar(_mapError(e));
-          }
-        }
+      switch (result) {
+        case PlanSessionSelection(:final plan):
+          await _addPlanToBlock(blockIndex, plan);
+        case RecitationSessionSelection(:final recitation):
+          await _addRecitationToBlock(blockIndex, recitation);
+        case SeriesSessionSelection(:final series):
+          await _handleSeriesEnrollmentFromSelection(series);
       }
     } finally {
       _isSelectingSession = false;
     }
+  }
+
+  Future<void> _addPlanToBlock(int blockIndex, Plan plan) async {
+    final isDuplicate = _blocks[blockIndex].items.any(
+      (item) => item.id == plan.id && item.type == RoutineItemType.plan,
+    );
+    if (isDuplicate) {
+      _logger.warning('Duplicate item prevented: ${plan.id}');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.duplicateItem),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
+    final newItem = RoutineItem(
+      id: plan.id,
+      title: plan.title,
+      imageUrl: plan.coverImageUrl,
+      type: RoutineItemType.plan,
+      enrolledAt: DateTime.now(),
+    );
+    final block = _blocks[blockIndex];
+    setState(() => block.items.add(newItem));
+
+    try {
+      await _syncBlock(block);
+    } catch (e) {
+      if (mounted) {
+        setState(() => block.items.remove(newItem));
+        _showErrorSnackBar(_mapError(e));
+      }
+    }
+  }
+
+  Future<void> _addRecitationToBlock(
+    int blockIndex,
+    RecitationModel recitation,
+  ) async {
+    final isDuplicate = _blocks[blockIndex].items.any(
+      (item) =>
+          item.id == recitation.textId &&
+          item.type == RoutineItemType.recitation,
+    );
+    if (isDuplicate) {
+      _logger.warning('Duplicate item prevented: ${recitation.textId}');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.duplicateItem),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
+    final newItem = RoutineItem(
+      id: recitation.textId,
+      title: recitation.title,
+      type: RoutineItemType.recitation,
+    );
+    final block = _blocks[blockIndex];
+    setState(() => block.items.add(newItem));
+
+    try {
+      await _syncBlock(block);
+    } catch (e) {
+      if (mounted) {
+        setState(() => block.items.remove(newItem));
+        _showErrorSnackBar(_mapError(e));
+      }
+    }
+  }
+
+  /// Enrolls the user in [series], then routes to `edit-routine` with
+  /// `enrollSeriesId` so the existing one-time prefill handoff runs through
+  /// the same entrypoint as Home.
+  ///
+  /// Auth guard: guests get the login drawer instead of an enroll attempt.
+  /// Re-enrollment guard: if the user is somehow already enrolled (e.g. a
+  /// stale list slipped through `userSeriesEnrollmentsProvider`), skip the
+  /// POST and just rehydrate. `_isSelectingSession` already serializes taps
+  /// at the caller, so no extra in-flight flag is needed here.
+  Future<void> _handleSeriesEnrollmentFromSelection(Series series) async {
+    final auth = ref.read(authProvider);
+    if (auth.isGuest) {
+      if (mounted) LoginDrawer.show(context, ref);
+      return;
+    }
+
+    final seriesId = series.id;
+    final alreadyEnrolled = ref
+            .read(userSeriesEnrollmentsProvider)
+            .valueOrNull
+            ?.contains(seriesId) ??
+        false;
+
+    if (!alreadyEnrolled) {
+      final notifier = ref.read(seriesEnrollmentProvider(seriesId).notifier);
+      final ok = await notifier.enroll();
+      if (!mounted) return;
+
+      if (!ok) {
+        final state = ref.read(seriesEnrollmentProvider(seriesId));
+        final message = state is SeriesEnrollmentFailure
+            ? state.failure.message
+            : 'Failed to enroll in series';
+        _showErrorSnackBar(message);
+        return;
+      }
+    }
+
+    if (!mounted) return;
+    unawaited(
+      context.pushNamed('edit-routine', extra: {'enrollSeriesId': seriesId}),
+    );
   }
 
   // ─── Build ───

--- a/lib/features/practice/presentation/screens/select_session_screen.dart
+++ b/lib/features/practice/presentation/screens/select_session_screen.dart
@@ -6,19 +6,26 @@ import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
-import 'package:flutter_pecha/features/plans/presentation/providers/plans_providers.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
 import 'package:flutter_pecha/features/practice/data/models/session_selection.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_item.dart';
+import 'package:flutter_pecha/features/practice/domain/entities/practice_items_tab.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/practice_items_paginated_provider.dart';
 import 'package:flutter_pecha/features/recitation/presentation/providers/recitations_providers.dart';
 import 'package:flutter_pecha/features/recitation/presentation/widgets/recitation_list_skeleton.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final _logger = AppLogger('SelectSessionScreen');
 
-/// Combined screen for selecting either a Plan or Recitation to add to routine.
-/// Returns [SessionSelection] - either [PlanSessionSelection] or [RecitationSessionSelection].
+/// Combined screen for selecting either a Plan, Series, or Recitation to add
+/// to the routine. Returns a [SessionSelection] subtype that the caller
+/// (`EditRoutineScreen`) dispatches on.
 ///
-/// Automatically enrolls plans / saves recitations on selection.
-/// Filters out already enrolled/saved items and items already in the routine.
+/// Plans/series come from `GET /practice/items` (page-based). Recitations
+/// remain on their own list endpoint. The plans tab filters out:
+///   - plan IDs already in the routine (`excludedPlanIds`)
+///   - series IDs the user is already enrolled in
+///     (`userSeriesEnrollmentsProvider`)
 class SelectSessionScreen extends ConsumerStatefulWidget {
   /// IDs of plans already in the routine (across all blocks).
   final Set<String> excludedPlanIds;
@@ -32,11 +39,17 @@ class SelectSessionScreen extends ConsumerStatefulWidget {
 
 class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
     with SingleTickerProviderStateMixin {
+  /// Tab used by the practice picker. Both plans and series live on the same
+  /// "Add Plan" tab; recitations get their own tab.
+  static const PracticeItemsTab _practiceTab = PracticeItemsTab.all;
+
   late TabController _tabController;
   final ScrollController _plansScrollController = ScrollController();
 
   /// ID of the item currently being enrolled/saved (null if idle).
-  String? _enrollingItemId;
+  /// Reserved for future inline-loading affordances; today's flow pops
+  /// immediately, so this stays null in normal use.
+  final String? _enrollingItemId = null;
 
   @override
   void initState() {
@@ -57,13 +70,19 @@ class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
   void _onPlansScroll() {
     if (_plansScrollController.position.pixels >=
         _plansScrollController.position.maxScrollExtent - 200) {
-      ref.read(findPlansPaginatedProvider.notifier).loadMore();
+      ref
+          .read(practiceItemsPaginatedProvider(_practiceTab).notifier)
+          .loadMore();
     }
   }
 
-  void _onPlanSelected(dynamic plan) {
+  void _onPracticeItemSelected(PracticeItem item) {
     if (_enrollingItemId != null) return;
-    Navigator.of(context).pop(PlanSessionSelection(plan));
+    final selection = switch (item) {
+      PracticePlanItem(:final plan) => PlanSessionSelection(plan),
+      PracticeSeriesItem(:final series) => SeriesSessionSelection(series),
+    };
+    Navigator.of(context).pop<SessionSelection>(selection);
   }
 
   Future<void> _onRecitationSelected(dynamic recitation) async {
@@ -76,9 +95,7 @@ class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
     _logger.debug('🎨 ===== BUILD STARTED =====');
     final localizations = AppLocalizations.of(context)!;
 
-    // Plans: only exclude items already in routine blocks (enrollment handled by backend)
     final allExcludedPlanIds = widget.excludedPlanIds;
-
     _logger.debug('📊 Excluded Plan IDs: ${allExcludedPlanIds.length}');
 
     return Scaffold(
@@ -103,24 +120,23 @@ class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
             fontWeight: FontWeight.normal,
             fontSize: 16,
           ),
-          labelColor:
-              Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white
-                  : Colors.black,
-          unselectedLabelColor:
-              Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white.withValues(alpha: 0.5)
-                  : Colors.black.withValues(alpha: 0.5),
+          labelColor: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white
+              : Colors.black,
+          unselectedLabelColor: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white.withValues(alpha: 0.5)
+              : Colors.black.withValues(alpha: 0.5),
         ),
       ),
       body: TabBarView(
         controller: _tabController,
         children: [
-          _PlansTab(
+          _PracticeItemsTab(
+            tab: _practiceTab,
             scrollController: _plansScrollController,
             excludedPlanIds: allExcludedPlanIds,
             enrollingItemId: _enrollingItemId,
-            onPlanSelected: _onPlanSelected,
+            onItemSelected: _onPracticeItemSelected,
           ),
           _RecitationsTab(
             enrollingItemId: _enrollingItemId,
@@ -132,58 +148,96 @@ class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
   }
 }
 
-/// Tab content for displaying and selecting plans.
-/// Filters out plans that are already enrolled or in the routine.
-class _PlansTab extends ConsumerWidget {
+/// Tab content for the practice picker (plans + series).
+///
+/// Filtering rules:
+///   - plan rows whose id is in [excludedPlanIds] are dropped (already in
+///     the routine);
+///   - series rows whose id is in [userSeriesEnrollmentsProvider] are
+///     dropped (user is already enrolled — re-enrolling would be a no-op).
+class _PracticeItemsTab extends ConsumerWidget {
+  final PracticeItemsTab tab;
   final ScrollController scrollController;
   final Set<String> excludedPlanIds;
   final String? enrollingItemId;
-  final void Function(dynamic plan) onPlanSelected;
+  final void Function(PracticeItem item) onItemSelected;
 
-  const _PlansTab({
+  const _PracticeItemsTab({
+    required this.tab,
     required this.scrollController,
     required this.excludedPlanIds,
     required this.enrollingItemId,
-    required this.onPlanSelected,
+    required this.onItemSelected,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final localizations = AppLocalizations.of(context)!;
-    final plansState = ref.watch(findPlansPaginatedProvider);
+    final itemsState = ref.watch(practiceItemsPaginatedProvider(tab));
+
+    // Defensive fallback: if the enrolled-series fetch is still loading or
+    // failed, hide nothing — matching the home enrollment flow's
+    // `valueOrNull ?? {}` semantics so the list stays usable.
+    final enrolledSeriesIds =
+        ref.watch(userSeriesEnrollmentsProvider).valueOrNull ??
+            const <String>{};
 
     _logger.debug(
-      '📋 _PlansTab BUILD: ${plansState.plans.length} plans, isLoading: ${plansState.isLoading}, error: ${plansState.error}',
+      '📋 _PracticeItemsTab BUILD: ${itemsState.items.length} items, '
+      'isLoading: ${itemsState.isLoading}, error: ${itemsState.error}',
     );
-    _logger.debug('🚫 Excluded IDs: ${excludedPlanIds.length}');
 
-    if (plansState.isLoading && plansState.plans.isEmpty) {
-      _logger.debug('⏳ SHOWING: Loading skeleton');
+    if (itemsState.isLoading && itemsState.items.isEmpty) {
       return const PlanListSkeleton();
     }
 
-    if (plansState.error != null && plansState.plans.isEmpty) {
-      _logger.debug('❌ SHOWING: Error - ${plansState.error}');
+    if (itemsState.error != null && itemsState.items.isEmpty) {
       return ErrorStateWidget(
-        error: plansState.error!,
-        onRetry: () => ref.read(findPlansPaginatedProvider.notifier).retry(),
+        error: itemsState.error!,
+        onRetry: () =>
+            ref.read(practiceItemsPaginatedProvider(tab).notifier).retry(),
         customMessage: 'Unable to load plans.\nPlease try again later.',
       );
     }
 
-    // Filter out ONLY plans already in routine (not enrolled plans)
-    // Users should be able to add enrolled plans to their routine
-    final availablePlans =
-        plansState.plans
-            .where((plan) => !excludedPlanIds.contains(plan.id))
-            .toList();
+    final availableItems = itemsState.items.where((item) {
+      switch (item) {
+        case PracticePlanItem(:final plan):
+          return !excludedPlanIds.contains(plan.id);
+        case PracticeSeriesItem(:final series):
+          return !enrolledSeriesIds.contains(series.id);
+      }
+    }).toList();
 
     _logger.debug(
-      '✅ Available plans after filtering (routine only): ${availablePlans.length}',
+      '✅ Available practice items after filtering: ${availableItems.length}',
     );
 
-    if (availablePlans.isEmpty && !plansState.isLoading) {
-      _logger.debug('📭 SHOWING: Empty state (no available plans)');
+    if (availableItems.isEmpty && !itemsState.isLoading) {
+      // Edge case: after filtering (already-in-routine plans + enrolled
+      // series), the current loaded pages may all be hidden while the API
+      // still has more pages that could contain visible items. Keep advancing
+      // pagination instead of showing a false empty-state.
+      if (itemsState.hasMore) {
+        if (itemsState.error != null) {
+          return ErrorStateWidget(
+            error: itemsState.error!,
+            onRetry: () =>
+                ref.read(practiceItemsPaginatedProvider(tab).notifier).retry(),
+            customMessage: 'Unable to load more plans.\nPlease try again.',
+          );
+        }
+
+        if (!itemsState.isLoadingMore) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!context.mounted) return;
+            ref.read(practiceItemsPaginatedProvider(tab).notifier).loadMore();
+          });
+        }
+
+        return const Center(child: CircularProgressIndicator());
+      }
+
       return Center(
         child: Text(
           localizations.no_plans_found,
@@ -192,39 +246,52 @@ class _PlansTab extends ConsumerWidget {
       );
     }
 
-    _logger.debug('🎯 SHOWING: ListView with ${availablePlans.length} plans');
     return ListView.separated(
       controller: scrollController,
       padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
-      itemCount: availablePlans.length + (plansState.hasMore ? 1 : 0),
+      itemCount: availableItems.length + (itemsState.hasMore ? 1 : 0),
       separatorBuilder: (_, __) => const Divider(height: 1),
       itemBuilder: (context, index) {
-        if (index == availablePlans.length) {
+        if (index == availableItems.length) {
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 16.0),
             child: Center(
-              child:
-                  plansState.isLoadingMore
-                      ? const CircularProgressIndicator()
-                      : const SizedBox.shrink(),
+              child: itemsState.isLoadingMore
+                  ? const CircularProgressIndicator()
+                  : const SizedBox.shrink(),
             ),
           );
         }
 
-        final plan = availablePlans[index];
-        final authorName = plan.authorName;
-        final isEnrolling = enrollingItemId == plan.id;
+        final item = availableItems[index];
+        return _buildItemTile(item);
+      },
+    );
+  }
 
+  Widget _buildItemTile(PracticeItem item) {
+    switch (item) {
+      case PracticePlanItem(:final plan):
+        final isEnrolling = enrollingItemId == plan.id;
         return _SessionListTile(
           title: plan.title,
           subtitle: null,
           imageUrl: plan.coverImageUrl,
           isLoading: isEnrolling,
           isDisabled: enrollingItemId != null,
-          onTap: () => onPlanSelected(plan),
+          onTap: () => onItemSelected(item),
         );
-      },
-    );
+      case PracticeSeriesItem(:final series):
+        final isEnrolling = enrollingItemId == series.id;
+        return _SessionListTile(
+          title: series.title,
+          subtitle: series.description.isNotEmpty ? series.description : null,
+          imageUrl: series.imageUrl,
+          isLoading: isEnrolling,
+          isDisabled: enrollingItemId != null,
+          onTap: () => onItemSelected(item),
+        );
+    }
   }
 }
 
@@ -299,7 +366,7 @@ class _RecitationsTab extends ConsumerWidget {
   }
 }
 
-/// Reusable list tile for session selection (plans and recitations).
+/// Reusable list tile for session selection (plans, series, recitations).
 /// Supports loading and disabled states for enrollment/save feedback.
 class _SessionListTile extends StatelessWidget {
   final String title;

--- a/lib/features/practice/presentation/screens/select_session_screen.dart
+++ b/lib/features/practice/presentation/screens/select_session_screen.dart
@@ -120,12 +120,14 @@ class _SelectSessionScreenState extends ConsumerState<SelectSessionScreen>
             fontWeight: FontWeight.normal,
             fontSize: 16,
           ),
-          labelColor: Theme.of(context).brightness == Brightness.dark
-              ? Colors.white
-              : Colors.black,
-          unselectedLabelColor: Theme.of(context).brightness == Brightness.dark
-              ? Colors.white.withValues(alpha: 0.5)
-              : Colors.black.withValues(alpha: 0.5),
+          labelColor:
+              Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black,
+          unselectedLabelColor:
+              Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white.withValues(alpha: 0.5)
+                  : Colors.black.withValues(alpha: 0.5),
         ),
       ),
       body: TabBarView(
@@ -180,7 +182,7 @@ class _PracticeItemsTab extends ConsumerWidget {
     // `valueOrNull ?? {}` semantics so the list stays usable.
     final enrolledSeriesIds =
         ref.watch(userSeriesEnrollmentsProvider).valueOrNull ??
-            const <String>{};
+        const <String>{};
 
     _logger.debug(
       '📋 _PracticeItemsTab BUILD: ${itemsState.items.length} items, '
@@ -194,20 +196,22 @@ class _PracticeItemsTab extends ConsumerWidget {
     if (itemsState.error != null && itemsState.items.isEmpty) {
       return ErrorStateWidget(
         error: itemsState.error!,
-        onRetry: () =>
-            ref.read(practiceItemsPaginatedProvider(tab).notifier).retry(),
+        onRetry:
+            () =>
+                ref.read(practiceItemsPaginatedProvider(tab).notifier).retry(),
         customMessage: 'Unable to load plans.\nPlease try again later.',
       );
     }
 
-    final availableItems = itemsState.items.where((item) {
-      switch (item) {
-        case PracticePlanItem(:final plan):
-          return !excludedPlanIds.contains(plan.id);
-        case PracticeSeriesItem(:final series):
-          return !enrolledSeriesIds.contains(series.id);
-      }
-    }).toList();
+    final availableItems =
+        itemsState.items.where((item) {
+          switch (item) {
+            case PracticePlanItem(:final plan):
+              return !excludedPlanIds.contains(plan.id);
+            case PracticeSeriesItem(:final series):
+              return !enrolledSeriesIds.contains(series.id);
+          }
+        }).toList();
 
     _logger.debug(
       '✅ Available practice items after filtering: ${availableItems.length}',
@@ -222,8 +226,11 @@ class _PracticeItemsTab extends ConsumerWidget {
         if (itemsState.error != null) {
           return ErrorStateWidget(
             error: itemsState.error!,
-            onRetry: () =>
-                ref.read(practiceItemsPaginatedProvider(tab).notifier).retry(),
+            onRetry:
+                () =>
+                    ref
+                        .read(practiceItemsPaginatedProvider(tab).notifier)
+                        .retry(),
             customMessage: 'Unable to load more plans.\nPlease try again.',
           );
         }
@@ -256,9 +263,10 @@ class _PracticeItemsTab extends ConsumerWidget {
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 16.0),
             child: Center(
-              child: itemsState.isLoadingMore
-                  ? const CircularProgressIndicator()
-                  : const SizedBox.shrink(),
+              child:
+                  itemsState.isLoadingMore
+                      ? const CircularProgressIndicator()
+                      : const SizedBox.shrink(),
             ),
           );
         }


### PR DESCRIPTION
Switch the Add Session plans tab to `/practice/items` with page-based loading and enrolled-series filtering so users only see actionable items. Reuse the authenticated series enrollment path and route handoff to `edit-routine` with `enrollSeriesId` for consistent auto-prefill behavior.