### PR TITLE
Feat: PostHog Analytics refactored and update

### DIFF
--- a/lib/core/analytics/analytics_events.dart
+++ b/lib/core/analytics/analytics_events.dart
@@ -1,18 +1,37 @@
 /// PostHog event names using [object]_[verb] convention.
 abstract final class AnalyticsEvents {
+  // Auth
   static const String authLoginSucceeded = 'auth_login_succeeded';
   static const String authLoginFailed = 'auth_login_failed';
   static const String authGuestStarted = 'auth_guest_started';
+
+  // Onboarding
+  static const String onboardingCompleted = 'onboarding_completed';
+
+  // Plans
   static const String planEnrolled = 'plan_enrolled';
+  static const String planViewed = 'plan_viewed';
+  static const String planDayCompleted = 'plan_day_completed';
+
+  // Practice / Routine
   static const String routineSaved = 'routine_saved';
 }
 
 /// Shared analytics property keys.
 abstract final class AnalyticsProperties {
+  // Auth
   static const String method = 'method';
   static const String reason = 'reason';
+  static const String isGuest = 'is_guest';
+
+  // Plans
   static const String planId = 'plan_id';
+  static const String planName = 'plan_name';
+  static const String dayNumber = 'day_number';
+  static const String totalDays = 'total_days';
+  static const String completedDays = 'completed_days';
+
+  // Routine
   static const String blockCount = 'block_count';
   static const String itemCount = 'item_count';
-  static const String isGuest = 'is_guest';
 }

--- a/lib/core/analytics/analytics_service.dart
+++ b/lib/core/analytics/analytics_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+
 /// Product analytics abstraction. Features depend on this interface, not PostHog.
 abstract class AnalyticsService {
   Future<void> initialize();
@@ -15,4 +17,7 @@ abstract class AnalyticsService {
   });
 
   Future<void> setSuperProperties(Map<String, Object?> properties);
+
+  /// Navigator observer wired into GoRouter so screen transitions are tracked.
+  NavigatorObserver get routeObserver;
 }

--- a/lib/core/analytics/no_op_analytics_service.dart
+++ b/lib/core/analytics/no_op_analytics_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_pecha/core/analytics/analytics_service.dart';
 
 /// No-op analytics used when PostHog is disabled or not configured.
@@ -24,4 +25,9 @@ class NoOpAnalyticsService implements AnalyticsService {
 
   @override
   Future<void> setSuperProperties(Map<String, Object?> properties) async {}
+
+  @override
+  NavigatorObserver get routeObserver => _NoOpNavigatorObserver();
 }
+
+class _NoOpNavigatorObserver extends NavigatorObserver {}

--- a/lib/core/analytics/posthog_analytics_service.dart
+++ b/lib/core/analytics/posthog_analytics_service.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_pecha/core/analytics/analytics_service.dart';
 import 'package:flutter_pecha/core/analytics/no_op_analytics_service.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/env.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 
 final _logger = AppLogger('PostHogAnalytics');
@@ -28,9 +31,7 @@ class PostHogAnalyticsService implements AnalyticsService {
 
   @override
   Future<void> initialize() async {
-    if (_isInitialized || !Env.posthogEnabled) {
-      return;
-    }
+    if (_isInitialized || !Env.posthogEnabled) return;
 
     final String? apiKey = Env.posthogApiKey;
     if (apiKey == null || apiKey.isEmpty) {
@@ -44,6 +45,12 @@ class PostHogAnalyticsService implements AnalyticsService {
     config.personProfiles = PostHogPersonProfiles.identifiedOnly;
     config.beforeSend = [_redactPii];
 
+    if (kReleaseMode) {
+      config.sessionReplay = true;
+      config.sessionReplayConfig.maskAllTexts = true;
+      config.sessionReplayConfig.maskAllImages = false;
+    }
+
     await Posthog().setup(config);
     await _registerDefaultSuperProperties();
 
@@ -56,9 +63,7 @@ class PostHogAnalyticsService implements AnalyticsService {
     required String userId,
     Map<String, Object?>? properties,
   }) async {
-    if (!_isInitialized) {
-      return;
-    }
+    if (!_isInitialized) return;
 
     await Posthog().identify(
       userId: userId,
@@ -68,9 +73,7 @@ class PostHogAnalyticsService implements AnalyticsService {
 
   @override
   Future<void> reset() async {
-    if (!_isInitialized) {
-      return;
-    }
+    if (!_isInitialized) return;
 
     await Posthog().reset();
     await _registerDefaultSuperProperties();
@@ -81,9 +84,7 @@ class PostHogAnalyticsService implements AnalyticsService {
     String event, {
     Map<String, Object?>? properties,
   }) async {
-    if (!_isInitialized) {
-      return;
-    }
+    if (!_isInitialized) return;
 
     await Posthog().capture(
       eventName: event,
@@ -93,9 +94,7 @@ class PostHogAnalyticsService implements AnalyticsService {
 
   @override
   Future<void> setSuperProperties(Map<String, Object?> properties) async {
-    if (!_isInitialized) {
-      return;
-    }
+    if (!_isInitialized) return;
 
     for (final MapEntry<String, Object?> entry in properties.entries) {
       final Object? value = entry.value;
@@ -105,11 +104,23 @@ class PostHogAnalyticsService implements AnalyticsService {
     }
   }
 
+  @override
+  NavigatorObserver get routeObserver => PosthogObserver();
+
   Future<void> _registerDefaultSuperProperties() async {
+    PackageInfo? packageInfo;
+    try {
+      packageInfo = await PackageInfo.fromPlatform();
+    } catch (_) {
+      // Unavailable in test environments — version properties skipped.
+    }
+
     await setSuperProperties({
       'environment': Env.environment,
       'app_flavor': Env.appFlavor,
       'platform': Platform.operatingSystem,
+      if (packageInfo != null) 'app_version': packageInfo.version,
+      if (packageInfo != null) 'build_number': packageInfo.buildNumber,
     });
   }
 

--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -35,9 +35,9 @@ import 'package:flutter_pecha/features/texts/presentation/segment_image/choose_i
 import 'package:flutter_pecha/features/texts/presentation/segment_image/create_image.dart';
 import 'package:flutter_pecha/features/texts/presentation/version_selection/language_selection.dart';
 import 'package:flutter_pecha/features/texts/presentation/version_selection/version_selection_screen.dart';
+import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:posthog_flutter/posthog_flutter.dart';
 
 final _logger = AppLogger('AppRouter');
 
@@ -57,7 +57,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: AppRoutes.home,
     debugLogDiagnostics: true,
-    observers: [PosthogObserver()],
+    observers: [ref.read(analyticsServiceProvider).routeObserver],
 
     // Re-evaluate redirect whenever auth state changes.
     refreshListenable: GoRouterRefreshStream(

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -519,8 +519,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
-  /// Wraps a non-scrollable state (empty / error) in an always-scrollable
-  /// viewport so pull-to-refresh works even when there is no grid content.
   Widget _buildScrollableMessage(Widget child) {
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/lib/features/onboarding/application/event_enrollment_service.dart
+++ b/lib/features/onboarding/application/event_enrollment_service.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter_pecha/core/analytics/analytics_events.dart';
+import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/application/plan_enrollment_hook.dart';
 import 'package:flutter_pecha/features/notifications/application/special_plan_enrollment_hook.dart';
@@ -99,7 +103,17 @@ class EventEnrollmentService {
         // be enrolled from a previous onboarding attempt.
         _logger.warning('subscribe plan $planId: ${failure.message} (continuing)');
       },
-      (_) => _logger.info('Subscribed to plan $planId'),
+      (success) {
+        _logger.info('Subscribed to plan $planId');
+        if (success) {
+          unawaited(
+            _ref.read(analyticsServiceProvider).track(
+              AnalyticsEvents.planEnrolled,
+              properties: {AnalyticsProperties.planId: planId},
+            ),
+          );
+        }
+      },
     );
   }
 

--- a/lib/features/onboarding/application/onboarding_notifier.dart
+++ b/lib/features/onboarding/application/onboarding_notifier.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter_pecha/core/analytics/analytics_events.dart';
+import 'package:flutter_pecha/core/analytics/analytics_service.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/onboarding/application/onboarding_state.dart';
 import 'package:flutter_pecha/features/onboarding/domain/usecases/onboarding_usecases.dart';
@@ -16,10 +20,12 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
     required SaveOnboardingPreferencesUseCase saveOnboardingPreferencesUseCase,
     required CompleteOnboardingUseCase completeOnboardingUseCase,
     required ClearOnboardingPreferencesUseCase clearOnboardingPreferencesUseCase,
+    required AnalyticsService analyticsService,
   })  : _loadSavedPreferencesUseCase = loadSavedPreferencesUseCase,
         _saveOnboardingPreferencesUseCase = saveOnboardingPreferencesUseCase,
         _completeOnboardingUseCase = completeOnboardingUseCase,
         _clearOnboardingPreferencesUseCase = clearOnboardingPreferencesUseCase,
+        _analytics = analyticsService,
         super(OnboardingState.initial()) {
     loadSavedPreferences();
   }
@@ -28,6 +34,7 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
   final SaveOnboardingPreferencesUseCase _saveOnboardingPreferencesUseCase;
   final CompleteOnboardingUseCase _completeOnboardingUseCase;
   final ClearOnboardingPreferencesUseCase _clearOnboardingPreferencesUseCase;
+  final AnalyticsService _analytics;
 
   /// Load saved preferences from local storage on initialization.
   Future<void> loadSavedPreferences() async {
@@ -123,6 +130,10 @@ class OnboardingNotifier extends StateNotifier<OnboardingState> {
           completed = true;
         },
       );
+
+      if (completed) {
+        unawaited(_analytics.track(AnalyticsEvents.onboardingCompleted));
+      }
 
       state = state.copyWithLoading(false);
       return completed;

--- a/lib/features/onboarding/application/onboarding_provider.dart
+++ b/lib/features/onboarding/application/onboarding_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/features/onboarding/application/onboarding_notifier.dart';
 import 'package:flutter_pecha/features/onboarding/application/onboarding_state.dart';
 import 'package:flutter_pecha/features/onboarding/presentation/providers/use_case_providers.dart';
@@ -15,5 +16,6 @@ final onboardingProvider =
             ref.read(completeOnboardingUseCaseProvider),
         clearOnboardingPreferencesUseCase:
             ref.read(clearOnboardingPreferencesUseCaseProvider),
+        analyticsService: ref.read(analyticsServiceProvider),
       );
     });

--- a/lib/features/plans/domain/usecases/user_plans_usecases.dart
+++ b/lib/features/plans/domain/usecases/user_plans_usecases.dart
@@ -5,8 +5,6 @@ import 'package:flutter_pecha/features/plans/data/models/plan_progress_model.dar
 import 'package:flutter_pecha/features/plans/data/models/response/user_plan_day_detail_response.dart';
 import 'package:flutter_pecha/features/plans/data/models/response/user_plan_list_response_model.dart';
 import 'package:flutter_pecha/features/plans/domain/repositories/user_plans_repository.dart';
-import 'package:flutter_pecha/core/analytics/analytics_events.dart';
-import 'package:flutter_pecha/core/analytics/analytics_service.dart';
 import 'package:flutter_pecha/shared/domain/base_classes/usecase.dart';
 
 /// Use case for getting user's enrolled plans with pagination.
@@ -49,29 +47,15 @@ class GetUserPlansParams extends Equatable {
 /// Use case for subscribing to a plan.
 class SubscribeToPlanUseCase extends UseCase<bool, SubscribeToPlanParams> {
   final UserPlansRepositoryInterface _repository;
-  final AnalyticsService _analytics;
 
-  SubscribeToPlanUseCase(this._repository, this._analytics);
+  SubscribeToPlanUseCase(this._repository);
 
   @override
   Future<Either<Failure, bool>> call(SubscribeToPlanParams params) async {
     if (params.planId.isEmpty) {
       return const Left(ValidationFailure('Plan ID cannot be empty'));
     }
-
-    final Either<Failure, bool> result =
-        await _repository.subscribeToPlan(params.planId);
-
-    result.fold((_) => null, (bool success) {
-      if (success) {
-        _analytics.track(
-          AnalyticsEvents.planEnrolled,
-          properties: {AnalyticsProperties.planId: params.planId},
-        );
-      }
-    });
-
-    return result;
+    return await _repository.subscribeToPlan(params.planId);
   }
 }
 

--- a/lib/features/plans/presentation/providers/use_case_providers.dart
+++ b/lib/features/plans/presentation/providers/use_case_providers.dart
@@ -14,7 +14,6 @@ import 'package:flutter_pecha/features/plans/domain/repositories/user_plans_repo
 import 'package:flutter_pecha/features/plans/domain/usecases/plan_days_usecases.dart';
 import 'package:flutter_pecha/features/plans/domain/usecases/plans_usecases.dart';
 import 'package:flutter_pecha/features/plans/domain/usecases/tasks_usecases.dart';
-import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/features/plans/domain/usecases/user_plans_usecases.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -95,10 +94,7 @@ final getUserPlansUseCaseProvider = Provider<GetUserPlansUseCase>((ref) {
 
 /// Provider for SubscribeToPlanUseCase.
 final subscribeToPlanUseCaseProvider = Provider<SubscribeToPlanUseCase>((ref) {
-  return SubscribeToPlanUseCase(
-    ref.watch(userPlansDomainRepositoryProvider),
-    ref.watch(analyticsServiceProvider),
-  );
+  return SubscribeToPlanUseCase(ref.watch(userPlansDomainRepositoryProvider));
 });
 
 /// Provider for UnsubscribeFromPlanUseCase.

--- a/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:fpdart/fpdart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/analytics/analytics_events.dart';
+import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
@@ -49,6 +53,16 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     super.initState();
     selectedDay = widget.selectedDay;
     _logger.info('PlanDetails opened — id: ${widget.plan.id} | title: "${widget.plan.title}"');
+    unawaited(
+      ref.read(analyticsServiceProvider).track(
+        AnalyticsEvents.planViewed,
+        properties: {
+          AnalyticsProperties.planId: widget.plan.id,
+          AnalyticsProperties.planName: widget.plan.title,
+          AnalyticsProperties.totalDays: widget.plan.totalDays,
+        },
+      ),
+    );
   }
 
   @override
@@ -134,6 +148,19 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
         },
         (completionStatus) {
           final completedDays = completionStatus.values.where((v) => v).length;
+
+          unawaited(
+            ref.read(analyticsServiceProvider).track(
+              AnalyticsEvents.planDayCompleted,
+              properties: {
+                AnalyticsProperties.planId: widget.plan.id,
+                AnalyticsProperties.planName: widget.plan.title,
+                AnalyticsProperties.dayNumber: dayNumber,
+                AnalyticsProperties.totalDays: widget.plan.totalDays,
+                AnalyticsProperties.completedDays: completedDays,
+              },
+            ),
+          );
 
           if (!mounted) return;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "942a4791cd385a68ccb3b32c71c427aba508a1bb949b86dff2adbe4049f16239"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -365,10 +365,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -631,50 +639,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.2.2"
   flutter_story_presenter:
     dependency: "direct main"
     description:
@@ -817,10 +825,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -977,26 +985,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1046,21 +1054,21 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: transitive
     description:
@@ -1306,18 +1314,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "13.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1535,10 +1543,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:
@@ -1567,10 +1575,10 @@ packages:
     dependency: "direct main"
     description:
       name: upgrader
-      sha256: "4ba3f840691ffa43c6d71a93a6ad3ae01590c7895c3eb33f9f683513f736a9f7"
+      sha256: "6282524d4b664e48e24736ce343eedd115dcc1ce79198fc0bd46f14692e1f05e"
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "13.5.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1599,10 +1607,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
@@ -1623,18 +1631,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
@@ -1759,10 +1767,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1796,5 +1804,5 @@ packages:
     source: hosted
     version: "9.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   dio_cache_interceptor: ^3.4.0
 
   # Secure Storage
-  flutter_secure_storage: ^9.2.2
+  flutter_secure_storage: ^10.3.1
 
   # Functional Programming
   fpdart: ^1.1.0
@@ -116,7 +116,7 @@ dependencies:
 
   # Shared preferences
   shared_preferences: ^2.5.3
-  share_plus: ^11.0.0
+  share_plus: ^13.1.0
   screenshot: ^3.0.0
   path_provider: ^2.1.5
   scrollable_positioned_list: ^0.3.8
@@ -126,7 +126,7 @@ dependencies:
 
   # Network connectivity
   connectivity_plus: ^6.1.1
-  upgrader: ^12.3.0
+  upgrader: ^13.5.0
   # QR code generation
   qr_flutter: ^4.1.0
   skeletonizer: ^2.1.2
@@ -141,6 +141,7 @@ dependencies:
   firebase_analytics: ^12.2.0
   firebase_crashlytics: ^5.1.0
   posthog_flutter: ^5.24.0
+  package_info_plus: ^10.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
PostHog Analytics — Full Implementation
                                                                                                                                                                              
  What was fixed                                                                                                                                                                                                                         
  - Analytics tracking was added inside the domain layer (use cases), which violates Clean Architecture                                                                       
                                                                                                                                                                              
  What was added                                                                                                                                                              
  - AnalyticsService interface — all features depend on the interface, not PostHog directly                                                                                   
  - NoOpAnalyticsService — used as fallback when PostHog is disabled (e.g. no API key)                                                                                        
  - Screen tracking via routeObserver wired into the router through the interface                                                                                           
  - Session replay enabled in release builds only (kReleaseMode)                                                                                                              
  - Super properties on every event: environment, app_flavor, platform, app_version, build_number                                                                             
                                                                                                                                                                              
  Events now tracked                                                                                                                                                          
  - auth_login_succeeded / auth_login_failed / auth_guest_started                                                                                                             
  - onboarding_completed                                                                                                                                                      
  - plan_enrolled (when user subscribes to a plan)                                                                                                                          
  - plan_viewed (when plan detail screen opens)                                                                                                                               
  - plan_day_completed (when user completes a day)                                                                                                                          
  - routine_saved                                                                                                                                                             
  - Automatic screen views on every navigation
                                                                                                                                                          