### PR TITLE
feat: implement series/plan discovery, celebrations, and 3-dot manage…

### DIFF
--- a/lib/core/l10n/app_bo.arb
+++ b/lib/core/l10n/app_bo.arb
@@ -96,6 +96,51 @@
   "plan_unenroll": "ཉམས་ལེན་ནས་ཕྱིར་ཐོན།",
   "unenroll_confirmation": "ནས་ཕྱིར་འཐེན་བྱེད་རྒྱུ་གཏན་ཁེལ་ཡིན་ནམ།",
   "unenroll_message": "ཉམས་ལེན་ནས་ཕྱིར་ཐོན་ཚེ་དེ་དང་འབྲེལ་ཡོད་གནས་ཚུལ་མེད་པར་འགྱུར་གྱི་རེད།",
+  "plan_options_about": "About",
+  "plan_options_reminders": "Reminders",
+  "reminders_daily_title": "Daily reminder",
+  "reminders_subtitle": "Change when we remind you, or turn reminders off.",
+  "reminders_remind_me": "Remind me",
+  "reminders_not_in_routine": "Add this plan to your routine first to set a reminder.",
+  "reminders_updated": "Reminder updated to {time}",
+  "@reminders_updated": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "reminders_turned_off": "Reminders turned off",
+  "series_unenroll_title": "Unenroll from this series?",
+  "series_unenroll_body": "You'll lose all your progress in this series. You can re-enroll any time.",
+  "plan_unenroll_title": "Unenroll from this plan?",
+  "plan_unenroll_body": "You'll lose all your progress in this plan. You can re-enroll any time.",
+  "about_this_plan": "About this plan",
+  "celebration_day_done": "DAY DONE",
+  "celebration_day_complete": "Day {day} of {total} complete.",
+  "@celebration_day_complete": {
+    "placeholders": {
+      "day": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "celebration_day_body": "You showed up. Same time tomorrow.",
+  "celebration_back_to_home": "Back to home",
+  "celebration_plan_done": "PLAN DONE",
+  "celebration_plan_subtitle": "The next begins when you're ready.",
+  "celebration_plan_days": "{days, plural, =1{1 day} other{{days} days}}",
+  "@celebration_plan_days": {
+    "placeholders": {
+      "days": { "type": "int" }
+    }
+  },
+  "celebration_continue_to": "Continue to {title} →",
+  "@celebration_continue_to": {
+    "placeholders": {
+      "title": { "type": "String" }
+    }
+  },
+  "celebration_series_done": "SERIES DONE",
+  "celebration_series_find_another": "Find another series",
+  "celebration_series_stay": "Stay & revisit any plan",
   "practice_plan": "ཉམས་ལེན་འཆར་གཞི་ཡིས་ཁྱེད་རང་ཉམས་ལེན་ལ་རྒྱུན་མཐུད་ནས་གནས་པར་རོགས་རམ་བྱེད་ཀྱི་ཡོད། ང་ཚོར་འདེམས་རྒྱུའི་འཆར་གཞི་སྣ་ཚོགས་ཡོད་པ་དང་དུས་ཡུན་མི་འདྲ་བ་ཡོད།",
   "search_plans": "ཉམས་ལེན་འཚོལ།",
   "search_for_plans": "ཉམས་ལེན་འཚོལ་ཞིབ་བྱེད།",
@@ -210,6 +255,36 @@
   "audio_init_error": "སྒྲ་གཏོང་ཐུབ་མ་སོང་བས། རྗེས་ནས་ཚོད་ལྟ་བྱེད་རོགས།",
   "meditation_audio_load_error": "Unable to load. Check your connection and try again",
   "prayer_audio_load_error": "Unable to load audio. Check your connection and try again",
+  "home_featured": "Featured",
+  "home_continue_today": "Continue today",
+  "home_explore_more": "Browse Buddhist content",
+  "home_series_n_plans": "{count, plural, =1{1 plan} other{{count} plans}}",
+  "@home_series_n_plans": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_n_days": "{count, plural, =1{1 day} other{{count} days}}",
+  "@home_series_n_days": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_progress": "{percent}% complete",
+  "@home_series_progress": {
+    "placeholders": {
+      "percent": { "type": "int" }
+    }
+  },
+  "home_series_in_progress": "In progress",
+  "home_series_about_creator": "About the creator",
+  "home_series_included_plans": "Included plans",
+  "home_series_view_creator_page": "View {name}'s page →",
+  "@home_series_view_creator_page": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "home_no_series_found": "རིམ་པ་ཅན་རྙེད་མ་སོང་།",
   "home_no_tags_found": "No tags found",
   "home_celebrated_by": "སྤེལ་མཁན་ནི་ ",
@@ -554,6 +629,8 @@
   },
   "plan_enrolled": "Enrolled",
   "plan_status_on_track": "On Track!",
+  "plan_status_just_started": "Just started",
+  "plan_status_last_day": "Last day",
   "start_now": "ད་ལྟ་འགོ་འཛུགས།",
   "plan_enroll": "ཞུགས་སྒྲིག",
   "plan_starts_on": "འགོ་འཛུགས། {date}",

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -96,6 +96,51 @@
   "plan_unenroll": "Unenroll",
   "unenroll_confirmation": "Are you sure you want to unenroll in",
   "unenroll_message": "Your progress will be permanently lost and cannot be recovered",
+  "plan_options_about": "About",
+  "plan_options_reminders": "Reminders",
+  "reminders_daily_title": "Daily reminder",
+  "reminders_subtitle": "Change when we remind you, or turn reminders off.",
+  "reminders_remind_me": "Remind me",
+  "reminders_not_in_routine": "Add this plan to your routine first to set a reminder.",
+  "reminders_updated": "Reminder updated to {time}",
+  "@reminders_updated": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "reminders_turned_off": "Reminders turned off",
+  "series_unenroll_title": "Unenroll from this series?",
+  "series_unenroll_body": "You'll lose all your progress in this series. You can re-enroll any time.",
+  "plan_unenroll_title": "Unenroll from this plan?",
+  "plan_unenroll_body": "You'll lose all your progress in this plan. You can re-enroll any time.",
+  "about_this_plan": "About this plan",
+  "celebration_day_done": "DAY DONE",
+  "celebration_day_complete": "Day {day} of {total} complete.",
+  "@celebration_day_complete": {
+    "placeholders": {
+      "day": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "celebration_day_body": "You showed up. Same time tomorrow.",
+  "celebration_back_to_home": "Back to home",
+  "celebration_plan_done": "PLAN DONE",
+  "celebration_plan_subtitle": "The next begins when you're ready.",
+  "celebration_plan_days": "{days, plural, =1{1 day} other{{days} days}}",
+  "@celebration_plan_days": {
+    "placeholders": {
+      "days": { "type": "int" }
+    }
+  },
+  "celebration_continue_to": "Continue to {title} →",
+  "@celebration_continue_to": {
+    "placeholders": {
+      "title": { "type": "String" }
+    }
+  },
+  "celebration_series_done": "SERIES DONE",
+  "celebration_series_find_another": "Find another series",
+  "celebration_series_stay": "Stay & revisit any plan",
   "practice_plan": "Build a daily practice. Explore what fits you.",
   "search_plans": "Search plans...",
   "search_for_plans": "Search for plans",
@@ -210,6 +255,36 @@
   "audio_init_error": "Unable to initialize audio player. Check your connection and try again",
   "meditation_audio_load_error": "Unable to load. Check your connection and try again",
   "prayer_audio_load_error": "Unable to load audio. Check your connection and try again",
+  "home_featured": "Featured",
+  "home_continue_today": "Continue today",
+  "home_explore_more": "Browse Buddhist content",
+  "home_series_n_plans": "{count, plural, =1{1 plan} other{{count} plans}}",
+  "@home_series_n_plans": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_n_days": "{count, plural, =1{1 day} other{{count} days}}",
+  "@home_series_n_days": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_progress": "{percent}% complete",
+  "@home_series_progress": {
+    "placeholders": {
+      "percent": { "type": "int" }
+    }
+  },
+  "home_series_in_progress": "In progress",
+  "home_series_about_creator": "About the creator",
+  "home_series_included_plans": "Included plans",
+  "home_series_view_creator_page": "View {name}'s page →",
+  "@home_series_view_creator_page": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "home_no_series_found": "No series found",
   "home_no_tags_found": "No tags found",
   "home_celebrated_by": "Celebrated by: ",
@@ -610,6 +685,8 @@
   },
   "plan_enrolled": "Enrolled",
   "plan_status_on_track": "On Track!",
+  "plan_status_just_started": "Just started",
+  "plan_status_last_day": "Last day",
   "start_now": "Start now",
   "plan_enroll": "Enroll",
   "plan_starts_on": "Starts {date}",

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -96,6 +96,51 @@
   "plan_unenroll": "退出計畫",
   "unenroll_confirmation": "確定要退出嗎",
   "unenroll_message": "您的進度將被永久刪除，且無法復原",
+  "plan_options_about": "About",
+  "plan_options_reminders": "Reminders",
+  "reminders_daily_title": "Daily reminder",
+  "reminders_subtitle": "Change when we remind you, or turn reminders off.",
+  "reminders_remind_me": "Remind me",
+  "reminders_not_in_routine": "Add this plan to your routine first to set a reminder.",
+  "reminders_updated": "Reminder updated to {time}",
+  "@reminders_updated": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "reminders_turned_off": "Reminders turned off",
+  "series_unenroll_title": "Unenroll from this series?",
+  "series_unenroll_body": "You'll lose all your progress in this series. You can re-enroll any time.",
+  "plan_unenroll_title": "Unenroll from this plan?",
+  "plan_unenroll_body": "You'll lose all your progress in this plan. You can re-enroll any time.",
+  "about_this_plan": "About this plan",
+  "celebration_day_done": "DAY DONE",
+  "celebration_day_complete": "Day {day} of {total} complete.",
+  "@celebration_day_complete": {
+    "placeholders": {
+      "day": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "celebration_day_body": "You showed up. Same time tomorrow.",
+  "celebration_back_to_home": "Back to home",
+  "celebration_plan_done": "PLAN DONE",
+  "celebration_plan_subtitle": "The next begins when you're ready.",
+  "celebration_plan_days": "{days, plural, =1{1 day} other{{days} days}}",
+  "@celebration_plan_days": {
+    "placeholders": {
+      "days": { "type": "int" }
+    }
+  },
+  "celebration_continue_to": "Continue to {title} →",
+  "@celebration_continue_to": {
+    "placeholders": {
+      "title": { "type": "String" }
+    }
+  },
+  "celebration_series_done": "SERIES DONE",
+  "celebration_series_find_another": "Find another series",
+  "celebration_series_stay": "Stay & revisit any plan",
   "practice_plan": "建立每日修持。探索適合您的內容",
   "search_plans": "搜尋計畫...",
   "search_for_plans": "搜尋計畫",
@@ -210,6 +255,36 @@
   "audio_init_error": "無法啟動播放器。請再試一次。",
   "meditation_audio_load_error": "無法載入。請檢查您的網路連線，然後再試一次。",
   "prayer_audio_load_error": "無法載入語音檔。請檢查您的網路連線後再試。",
+  "home_featured": "精選",
+  "home_continue_today": "繼續今日",
+  "home_explore_more": "瀏覽佛教內容",
+  "home_series_n_plans": "{count, plural, =1{1 個計畫} other{{count} 個計畫}}",
+  "@home_series_n_plans": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_n_days": "{count, plural, =1{1 天} other{{count} 天}}",
+  "@home_series_n_days": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "home_series_progress": "{percent}% 完成",
+  "@home_series_progress": {
+    "placeholders": {
+      "percent": { "type": "int" }
+    }
+  },
+  "home_series_in_progress": "進行中",
+  "home_series_about_creator": "關於創作者",
+  "home_series_included_plans": "包含的計畫",
+  "home_series_view_creator_page": "查看 {name} 的頁面 →",
+  "@home_series_view_creator_page": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "home_no_series_found": "找不到該系列",
   "home_no_tags_found": "找不到該標籤",
   "home_celebrated_by": "慶祝者：",
@@ -554,6 +629,8 @@
   },
   "plan_enrolled": "已加入",
   "plan_status_on_track": "進度正常！",
+  "plan_status_just_started": "剛開始",
+  "plan_status_last_day": "最後一天",
   "start_now": "立即開始",
   "plan_enroll": "加入",
   "plan_starts_on": "開始於 {date}",

--- a/lib/core/l10n/generated/app_localizations.dart
+++ b/lib/core/l10n/generated/app_localizations.dart
@@ -676,6 +676,150 @@ abstract class AppLocalizations {
   /// **'Your progress will be permanently lost and cannot be recovered'**
   String get unenroll_message;
 
+  /// No description provided for @plan_options_about.
+  ///
+  /// In en, this message translates to:
+  /// **'About'**
+  String get plan_options_about;
+
+  /// No description provided for @plan_options_reminders.
+  ///
+  /// In en, this message translates to:
+  /// **'Reminders'**
+  String get plan_options_reminders;
+
+  /// No description provided for @reminders_daily_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily reminder'**
+  String get reminders_daily_title;
+
+  /// No description provided for @reminders_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Change when we remind you, or turn reminders off.'**
+  String get reminders_subtitle;
+
+  /// No description provided for @reminders_remind_me.
+  ///
+  /// In en, this message translates to:
+  /// **'Remind me'**
+  String get reminders_remind_me;
+
+  /// No description provided for @reminders_not_in_routine.
+  ///
+  /// In en, this message translates to:
+  /// **'Add this plan to your routine first to set a reminder.'**
+  String get reminders_not_in_routine;
+
+  /// No description provided for @reminders_updated.
+  ///
+  /// In en, this message translates to:
+  /// **'Reminder updated to {time}'**
+  String reminders_updated(String time);
+
+  /// No description provided for @reminders_turned_off.
+  ///
+  /// In en, this message translates to:
+  /// **'Reminders turned off'**
+  String get reminders_turned_off;
+
+  /// No description provided for @series_unenroll_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Unenroll from this series?'**
+  String get series_unenroll_title;
+
+  /// No description provided for @series_unenroll_body.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'ll lose all your progress in this series. You can re-enroll any time.'**
+  String get series_unenroll_body;
+
+  /// No description provided for @plan_unenroll_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Unenroll from this plan?'**
+  String get plan_unenroll_title;
+
+  /// No description provided for @plan_unenroll_body.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'ll lose all your progress in this plan. You can re-enroll any time.'**
+  String get plan_unenroll_body;
+
+  /// No description provided for @about_this_plan.
+  ///
+  /// In en, this message translates to:
+  /// **'About this plan'**
+  String get about_this_plan;
+
+  /// No description provided for @celebration_day_done.
+  ///
+  /// In en, this message translates to:
+  /// **'DAY DONE'**
+  String get celebration_day_done;
+
+  /// No description provided for @celebration_day_complete.
+  ///
+  /// In en, this message translates to:
+  /// **'Day {day} of {total} complete.'**
+  String celebration_day_complete(int day, int total);
+
+  /// No description provided for @celebration_day_body.
+  ///
+  /// In en, this message translates to:
+  /// **'You showed up. Same time tomorrow.'**
+  String get celebration_day_body;
+
+  /// No description provided for @celebration_back_to_home.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to home'**
+  String get celebration_back_to_home;
+
+  /// No description provided for @celebration_plan_done.
+  ///
+  /// In en, this message translates to:
+  /// **'PLAN DONE'**
+  String get celebration_plan_done;
+
+  /// No description provided for @celebration_plan_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'The next begins when you\'re ready.'**
+  String get celebration_plan_subtitle;
+
+  /// No description provided for @celebration_plan_days.
+  ///
+  /// In en, this message translates to:
+  /// **'{days, plural, =1{1 day} other{{days} days}}'**
+  String celebration_plan_days(int days);
+
+  /// No description provided for @celebration_continue_to.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue to {title} →'**
+  String celebration_continue_to(String title);
+
+  /// No description provided for @celebration_series_done.
+  ///
+  /// In en, this message translates to:
+  /// **'SERIES DONE'**
+  String get celebration_series_done;
+
+  /// No description provided for @celebration_series_find_another.
+  ///
+  /// In en, this message translates to:
+  /// **'Find another series'**
+  String get celebration_series_find_another;
+
+  /// No description provided for @celebration_series_stay.
+  ///
+  /// In en, this message translates to:
+  /// **'Stay & revisit any plan'**
+  String get celebration_series_stay;
+
   /// No description provided for @practice_plan.
   ///
   /// In en, this message translates to:
@@ -1299,6 +1443,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Unable to load audio. Check your connection and try again'**
   String get prayer_audio_load_error;
+
+  /// No description provided for @home_featured.
+  ///
+  /// In en, this message translates to:
+  /// **'Featured'**
+  String get home_featured;
+
+  /// No description provided for @home_continue_today.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue today'**
+  String get home_continue_today;
+
+  /// No description provided for @home_explore_more.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse Buddhist content'**
+  String get home_explore_more;
+
+  /// No description provided for @home_series_n_plans.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 plan} other{{count} plans}}'**
+  String home_series_n_plans(int count);
+
+  /// No description provided for @home_series_n_days.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 day} other{{count} days}}'**
+  String home_series_n_days(int count);
+
+  /// No description provided for @home_series_progress.
+  ///
+  /// In en, this message translates to:
+  /// **'{percent}% complete'**
+  String home_series_progress(int percent);
+
+  /// No description provided for @home_series_in_progress.
+  ///
+  /// In en, this message translates to:
+  /// **'In progress'**
+  String get home_series_in_progress;
+
+  /// No description provided for @home_series_about_creator.
+  ///
+  /// In en, this message translates to:
+  /// **'About the creator'**
+  String get home_series_about_creator;
+
+  /// No description provided for @home_series_included_plans.
+  ///
+  /// In en, this message translates to:
+  /// **'Included plans'**
+  String get home_series_included_plans;
+
+  /// No description provided for @home_series_view_creator_page.
+  ///
+  /// In en, this message translates to:
+  /// **'View {name}\'s page →'**
+  String home_series_view_creator_page(String name);
 
   /// No description provided for @home_no_series_found.
   ///
@@ -2547,6 +2751,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'On Track!'**
   String get plan_status_on_track;
+
+  /// No description provided for @plan_status_just_started.
+  ///
+  /// In en, this message translates to:
+  /// **'Just started'**
+  String get plan_status_just_started;
+
+  /// No description provided for @plan_status_last_day.
+  ///
+  /// In en, this message translates to:
+  /// **'Last day'**
+  String get plan_status_last_day;
 
   /// No description provided for @start_now.
   ///

--- a/lib/core/l10n/generated/app_localizations_bo.dart
+++ b/lib/core/l10n/generated/app_localizations_bo.dart
@@ -304,6 +304,96 @@ class AppLocalizationsBo extends AppLocalizations {
       'ཉམས་ལེན་ནས་ཕྱིར་ཐོན་ཚེ་དེ་དང་འབྲེལ་ཡོད་གནས་ཚུལ་མེད་པར་འགྱུར་གྱི་རེད།';
 
   @override
+  String get plan_options_about => 'About';
+
+  @override
+  String get plan_options_reminders => 'Reminders';
+
+  @override
+  String get reminders_daily_title => 'Daily reminder';
+
+  @override
+  String get reminders_subtitle =>
+      'Change when we remind you, or turn reminders off.';
+
+  @override
+  String get reminders_remind_me => 'Remind me';
+
+  @override
+  String get reminders_not_in_routine =>
+      'Add this plan to your routine first to set a reminder.';
+
+  @override
+  String reminders_updated(String time) {
+    return 'Reminder updated to $time';
+  }
+
+  @override
+  String get reminders_turned_off => 'Reminders turned off';
+
+  @override
+  String get series_unenroll_title => 'Unenroll from this series?';
+
+  @override
+  String get series_unenroll_body =>
+      'You\'ll lose all your progress in this series. You can re-enroll any time.';
+
+  @override
+  String get plan_unenroll_title => 'Unenroll from this plan?';
+
+  @override
+  String get plan_unenroll_body =>
+      'You\'ll lose all your progress in this plan. You can re-enroll any time.';
+
+  @override
+  String get about_this_plan => 'About this plan';
+
+  @override
+  String get celebration_day_done => 'DAY DONE';
+
+  @override
+  String celebration_day_complete(int day, int total) {
+    return 'Day $day of $total complete.';
+  }
+
+  @override
+  String get celebration_day_body => 'You showed up. Same time tomorrow.';
+
+  @override
+  String get celebration_back_to_home => 'Back to home';
+
+  @override
+  String get celebration_plan_done => 'PLAN DONE';
+
+  @override
+  String get celebration_plan_subtitle => 'The next begins when you\'re ready.';
+
+  @override
+  String celebration_plan_days(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String celebration_continue_to(String title) {
+    return 'Continue to $title →';
+  }
+
+  @override
+  String get celebration_series_done => 'SERIES DONE';
+
+  @override
+  String get celebration_series_find_another => 'Find another series';
+
+  @override
+  String get celebration_series_stay => 'Stay & revisit any plan';
+
+  @override
   String get practice_plan =>
       'ཉམས་ལེན་འཆར་གཞི་ཡིས་ཁྱེད་རང་ཉམས་ལེན་ལ་རྒྱུན་མཐུད་ནས་གནས་པར་རོགས་རམ་བྱེད་ཀྱི་ཡོད། ང་ཚོར་འདེམས་རྒྱུའི་འཆར་གཞི་སྣ་ཚོགས་ཡོད་པ་དང་དུས་ཡུན་མི་འདྲ་བ་ཡོད།';
 
@@ -644,6 +734,56 @@ class AppLocalizationsBo extends AppLocalizations {
   @override
   String get prayer_audio_load_error =>
       'Unable to load audio. Check your connection and try again';
+
+  @override
+  String get home_featured => 'Featured';
+
+  @override
+  String get home_continue_today => 'Continue today';
+
+  @override
+  String get home_explore_more => 'Browse Buddhist content';
+
+  @override
+  String home_series_n_plans(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count plans',
+      one: '1 plan',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_n_days(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_progress(int percent) {
+    return '$percent% complete';
+  }
+
+  @override
+  String get home_series_in_progress => 'In progress';
+
+  @override
+  String get home_series_about_creator => 'About the creator';
+
+  @override
+  String get home_series_included_plans => 'Included plans';
+
+  @override
+  String home_series_view_creator_page(String name) {
+    return 'View $name\'s page →';
+  }
 
   @override
   String get home_no_series_found => 'རིམ་པ་ཅན་རྙེད་མ་སོང་།';
@@ -1351,6 +1491,12 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get plan_status_on_track => 'On Track!';
+
+  @override
+  String get plan_status_just_started => 'Just started';
+
+  @override
+  String get plan_status_last_day => 'Last day';
 
   @override
   String get start_now => 'ད་ལྟ་འགོ་འཛུགས།';

--- a/lib/core/l10n/generated/app_localizations_en.dart
+++ b/lib/core/l10n/generated/app_localizations_en.dart
@@ -303,6 +303,96 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your progress will be permanently lost and cannot be recovered';
 
   @override
+  String get plan_options_about => 'About';
+
+  @override
+  String get plan_options_reminders => 'Reminders';
+
+  @override
+  String get reminders_daily_title => 'Daily reminder';
+
+  @override
+  String get reminders_subtitle =>
+      'Change when we remind you, or turn reminders off.';
+
+  @override
+  String get reminders_remind_me => 'Remind me';
+
+  @override
+  String get reminders_not_in_routine =>
+      'Add this plan to your routine first to set a reminder.';
+
+  @override
+  String reminders_updated(String time) {
+    return 'Reminder updated to $time';
+  }
+
+  @override
+  String get reminders_turned_off => 'Reminders turned off';
+
+  @override
+  String get series_unenroll_title => 'Unenroll from this series?';
+
+  @override
+  String get series_unenroll_body =>
+      'You\'ll lose all your progress in this series. You can re-enroll any time.';
+
+  @override
+  String get plan_unenroll_title => 'Unenroll from this plan?';
+
+  @override
+  String get plan_unenroll_body =>
+      'You\'ll lose all your progress in this plan. You can re-enroll any time.';
+
+  @override
+  String get about_this_plan => 'About this plan';
+
+  @override
+  String get celebration_day_done => 'DAY DONE';
+
+  @override
+  String celebration_day_complete(int day, int total) {
+    return 'Day $day of $total complete.';
+  }
+
+  @override
+  String get celebration_day_body => 'You showed up. Same time tomorrow.';
+
+  @override
+  String get celebration_back_to_home => 'Back to home';
+
+  @override
+  String get celebration_plan_done => 'PLAN DONE';
+
+  @override
+  String get celebration_plan_subtitle => 'The next begins when you\'re ready.';
+
+  @override
+  String celebration_plan_days(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String celebration_continue_to(String title) {
+    return 'Continue to $title →';
+  }
+
+  @override
+  String get celebration_series_done => 'SERIES DONE';
+
+  @override
+  String get celebration_series_find_another => 'Find another series';
+
+  @override
+  String get celebration_series_stay => 'Stay & revisit any plan';
+
+  @override
   String get practice_plan => 'Build a daily practice. Explore what fits you.';
 
   @override
@@ -642,6 +732,56 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get prayer_audio_load_error =>
       'Unable to load audio. Check your connection and try again';
+
+  @override
+  String get home_featured => 'Featured';
+
+  @override
+  String get home_continue_today => 'Continue today';
+
+  @override
+  String get home_explore_more => 'Browse Buddhist content';
+
+  @override
+  String home_series_n_plans(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count plans',
+      one: '1 plan',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_n_days(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_progress(int percent) {
+    return '$percent% complete';
+  }
+
+  @override
+  String get home_series_in_progress => 'In progress';
+
+  @override
+  String get home_series_about_creator => 'About the creator';
+
+  @override
+  String get home_series_included_plans => 'Included plans';
+
+  @override
+  String home_series_view_creator_page(String name) {
+    return 'View $name\'s page →';
+  }
 
   @override
   String get home_no_series_found => 'No series found';
@@ -1353,6 +1493,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get plan_status_on_track => 'On Track!';
+
+  @override
+  String get plan_status_just_started => 'Just started';
+
+  @override
+  String get plan_status_last_day => 'Last day';
 
   @override
   String get start_now => 'Start now';

--- a/lib/core/l10n/generated/app_localizations_zh.dart
+++ b/lib/core/l10n/generated/app_localizations_zh.dart
@@ -298,6 +298,96 @@ class AppLocalizationsZh extends AppLocalizations {
   String get unenroll_message => '您的進度將被永久刪除，且無法復原';
 
   @override
+  String get plan_options_about => 'About';
+
+  @override
+  String get plan_options_reminders => 'Reminders';
+
+  @override
+  String get reminders_daily_title => 'Daily reminder';
+
+  @override
+  String get reminders_subtitle =>
+      'Change when we remind you, or turn reminders off.';
+
+  @override
+  String get reminders_remind_me => 'Remind me';
+
+  @override
+  String get reminders_not_in_routine =>
+      'Add this plan to your routine first to set a reminder.';
+
+  @override
+  String reminders_updated(String time) {
+    return 'Reminder updated to $time';
+  }
+
+  @override
+  String get reminders_turned_off => 'Reminders turned off';
+
+  @override
+  String get series_unenroll_title => 'Unenroll from this series?';
+
+  @override
+  String get series_unenroll_body =>
+      'You\'ll lose all your progress in this series. You can re-enroll any time.';
+
+  @override
+  String get plan_unenroll_title => 'Unenroll from this plan?';
+
+  @override
+  String get plan_unenroll_body =>
+      'You\'ll lose all your progress in this plan. You can re-enroll any time.';
+
+  @override
+  String get about_this_plan => 'About this plan';
+
+  @override
+  String get celebration_day_done => 'DAY DONE';
+
+  @override
+  String celebration_day_complete(int day, int total) {
+    return 'Day $day of $total complete.';
+  }
+
+  @override
+  String get celebration_day_body => 'You showed up. Same time tomorrow.';
+
+  @override
+  String get celebration_back_to_home => 'Back to home';
+
+  @override
+  String get celebration_plan_done => 'PLAN DONE';
+
+  @override
+  String get celebration_plan_subtitle => 'The next begins when you\'re ready.';
+
+  @override
+  String celebration_plan_days(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String celebration_continue_to(String title) {
+    return 'Continue to $title →';
+  }
+
+  @override
+  String get celebration_series_done => 'SERIES DONE';
+
+  @override
+  String get celebration_series_find_another => 'Find another series';
+
+  @override
+  String get celebration_series_stay => 'Stay & revisit any plan';
+
+  @override
   String get practice_plan => '建立每日修持。探索適合您的內容';
 
   @override
@@ -612,6 +702,56 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get prayer_audio_load_error => '無法載入語音檔。請檢查您的網路連線後再試。';
+
+  @override
+  String get home_featured => '精選';
+
+  @override
+  String get home_continue_today => '繼續今日';
+
+  @override
+  String get home_explore_more => '瀏覽佛教內容';
+
+  @override
+  String home_series_n_plans(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 個計畫',
+      one: '1 個計畫',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_n_days(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 天',
+      one: '1 天',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String home_series_progress(int percent) {
+    return '$percent% 完成';
+  }
+
+  @override
+  String get home_series_in_progress => '進行中';
+
+  @override
+  String get home_series_about_creator => '關於創作者';
+
+  @override
+  String get home_series_included_plans => '包含的計畫';
+
+  @override
+  String home_series_view_creator_page(String name) {
+    return '查看 $name 的頁面 →';
+  }
 
   @override
   String get home_no_series_found => '找不到該系列';
@@ -1298,6 +1438,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get plan_status_on_track => '進度正常！';
+
+  @override
+  String get plan_status_just_started => '剛開始';
+
+  @override
+  String get plan_status_last_day => '最後一天';
 
   @override
   String get start_now => '立即開始';

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -11,16 +11,20 @@ import 'package:flutter_pecha/core/services/upgrade/upgrade_provider.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
 import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
 import 'package:flutter_pecha/features/home/presentation/providers/series_provider.dart';
 import 'package:flutter_pecha/features/home/presentation/home_screen_constants.dart';
+import 'package:flutter_pecha/features/home/presentation/widgets/continue_today_card.dart';
+import 'package:flutter_pecha/features/home/presentation/widgets/featured_series_card.dart';
 import 'package:flutter_pecha/features/home/presentation/widgets/series_card.dart';
 import 'package:flutter_pecha/features/notifications/application/plan_enrollment_hook.dart';
 import 'package:flutter_pecha/features/notifications/application/special_plan_enrollment_hook.dart';
 import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
-import 'package:flutter_pecha/features/practice/presentation/providers/routine_provider.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/my_plans_paginated_provider.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
-import 'package:flutter_pecha/shared/utils/helper_functions.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
@@ -38,14 +42,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _hasRequestedPermissions = false;
   bool _showUpdateBanner = false;
 
-  // For proper keyboard dismissal with SearchAnchor
   final FocusScopeNode _searchFocusScopeNode = FocusScopeNode();
   bool _didJustDismissSearch = false;
 
   @override
   void initState() {
     super.initState();
-    // Request notification permissions when home screen loads
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _requestNotificationPermissionsIfNeeded();
     });
@@ -75,7 +77,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
 
     try {
-      // Check if permissions are already granted
       final alreadyEnabled =
           await notificationService.areNotificationsEnabled();
       _log.info('[HOME-SCREEN] alreadyEnabled=$alreadyEnabled');
@@ -90,20 +91,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       );
     }
 
-    // Permission flow has run — fire any pending special-plan Day 1
-    // notifications now (e.g. user just enrolled in ITCC during onboarding
-    // after 09:00). Without permission, `_plugin.show()` silently no-ops, so
-    // this MUST run after the permission request above.
     await _firePendingSpecialPlanDay1IfNeeded();
-
-    // After the permission flow (dialog shown or already granted), check
-    // whether onboarding left a plan waiting to be opened in Practice.
     _navigateToPendingPlanIfNeeded();
   }
 
   Future<void> _firePendingSpecialPlanDay1IfNeeded() async {
-    // Invalidate first — the provider may have been evaluated pre-login
-    // (no auth header) and cached a Forbidden failure. We need a fresh read.
     _log.info('invalidating userPlansFutureProvider for fresh fetch');
     ref.invalidate(userPlansFutureProvider);
 
@@ -153,19 +145,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _log.info('_firePendingSpecialPlanDay1IfNeeded EXIT');
   }
 
-  /// Consumes [pendingOnboardingPlanProvider] and navigates to the Practice
-  /// tab + plan detail screen. Called once, right after notification setup.
   void _navigateToPendingPlanIfNeeded() {
     if (!mounted) return;
     final plan = ref.read(pendingOnboardingPlanProvider);
     if (plan == null) return;
 
-    // Clear immediately so back-navigation never re-triggers this.
     ref.read(pendingOnboardingPlanProvider.notifier).state = null;
 
-    // Push plan details FIRST while HomeScreen is still mounted.
-    // Switching the tab index BEFORE the push would unmount HomeScreen,
-    // making the subsequent context.push a no-op.
     final anchor = plan.effectiveStartDate;
     final selectedDay = PlanUtils.dayNumberFor(
       anchor,
@@ -184,23 +170,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       extra: {'plan': plan, 'selectedDay': selectedDay, 'startDate': anchor},
     );
 
-    // Switch bottom-nav to Practice so popping back from plan details
-    // lands on the Practice tab rather than Home.
     ref.read(mainNavigationIndexProvider.notifier).state =
         MainTab.practice.index;
   }
 
-  /// Pull-to-refresh handler. Invalidates the series list and awaits the
-  /// refreshed result so the RefreshIndicator spinner stays until data lands.
   Future<void> _onRefresh() async {
     ref.invalidate(seriesListFutureProvider);
     await ref.read(seriesListFutureProvider.future);
-  }
-
-  /// Manual refetch/retry method that can be called from UI.
-  /// Reuses the same logic as pull-to-refresh for consistent behavior.
-  void _refetchSeries() {
-    _onRefresh();
   }
 
   void _navigateToSeries(Series series) {
@@ -211,12 +187,17 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
+  String _buildGreeting(AppLocalizations l10n) {
+    final hour = DateTime.now().hour;
+    if (hour < 12) return l10n.home_good_morning;
+    if (hour < 17) return l10n.home_good_afternoon;
+    return l10n.home_good_evening;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final seriesAsync = ref.watch(seriesListFutureProvider);
     final l10n = context.l10n;
 
-    // Check for app updates (only show once per app session)
     final updateAvailable = ref.watch(updateAvailableProvider);
     final bannerAlreadyShown = ref.watch(updateBannerShownProvider);
 
@@ -225,52 +206,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) {
             setState(() => _showUpdateBanner = true);
-            // Mark as shown so it won't appear again this session
             ref.read(updateBannerShownProvider.notifier).state = true;
           }
         });
       }
     });
 
+    final seriesAsync = ref.watch(seriesListFutureProvider);
+    final userState = ref.watch(userProvider);
+    final firstName = userState.user?.firstName?.trim() ?? '';
+    final greeting =
+        firstName.isNotEmpty
+            ? '${_buildGreeting(l10n)}, $firstName'
+            : _buildGreeting(l10n);
+
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      appBar: AppBar(
-        scrolledUnderElevation: 0,
-        centerTitle: false,
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: Text(
-          l10n.nav_home,
-          strutStyle: context.tibetanStrutStyle(
-            Theme.of(context).textTheme.headlineMedium?.fontSize ?? 28,
-          ),
-          style: Theme.of(
-            context,
-          ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
-        ),
-      ),
       body: SafeArea(
         child: Stack(
           children: [
-            Column(
-              children: [
-                _buildSearchSection(l10n, seriesAsync),
-                SizedBox(height: HomeScreenConstants.bodyVerticalPadding),
-                _buildBody(context, l10n),
-              ],
-            ),
+            _buildScrollBody(context, l10n, greeting, seriesAsync),
             if (_showUpdateBanner)
               Positioned(
                 left: 0,
                 right: 0,
                 bottom: 0,
                 child: UpdateBanner(
-                  onUpdateTap: () {
-                    ref.read(openAppStoreProvider)();
-                  },
+                  onUpdateTap: () => ref.read(openAppStoreProvider)(),
                   onDismissed: () {
-                    if (mounted) {
-                      setState(() => _showUpdateBanner = false);
-                    }
+                    if (mounted) setState(() => _showUpdateBanner = false);
                   },
                 ),
               ),
@@ -280,258 +244,383 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
-  TextStyle _searchHintTextStyle(BuildContext context) {
-    final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    return TextStyle(
-      fontSize: 16,
-      color: isDarkMode ? AppColors.textTertiaryDark : AppColors.textSecondary,
-    );
-  }
-
-  Widget _buildSearchSection(
-    AppLocalizations localizations,
+  Widget _buildScrollBody(
+    BuildContext context,
+    AppLocalizations l10n,
+    String greeting,
     AsyncValue<Either<Failure, List<Series>>> seriesAsync,
   ) {
-    final locale = ref.watch(localeProvider);
-    final lineHeight = getLineHeight(locale.languageCode);
-    final fontSize = locale.languageCode == 'bo' ? 18.0 : 16.0;
-    final TextStyle searchHintStyle = _searchHintTextStyle(context);
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-      child: seriesAsync.when(
-        data: (seriesEither) {
-          return seriesEither.fold(
-            (failure) => const SizedBox.shrink(),
-            (seriesList) => FocusScope(
-              node: _searchFocusScopeNode,
-              onFocusChange: (isFocused) {
-                if (_didJustDismissSearch && isFocused) {
-                  _didJustDismissSearch = false;
-                  _searchFocusScopeNode.unfocus();
-                }
-              },
-              child: SearchAnchor(
-                builder: (BuildContext context, SearchController controller) {
-                  return SearchBar(
-                    controller: controller,
-                    constraints: HomeScreenConstants.searchBarConstraints,
-                    padding: const WidgetStatePropertyAll<EdgeInsets>(
-                      EdgeInsets.symmetric(
-                        horizontal:
-                            HomeScreenConstants.searchBarHorizontalPadding,
-                      ),
-                    ),
-                    elevation: const WidgetStatePropertyAll(0.0),
-                    shadowColor: const WidgetStatePropertyAll(
-                      Colors.transparent,
-                    ),
-                    onTap: () {
-                      controller.openView();
-                    },
-                    onChanged: (_) {
-                      controller.openView();
-                    },
-                    leading: Icon(
-                      Icons.search,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                    hintText: localizations.text_search,
-                    hintStyle: WidgetStatePropertyAll(searchHintStyle),
-                  );
-                },
-                viewLeading: IconButton(
-                  icon: const Icon(Icons.arrow_back_ios),
-                  onPressed: () {
-                    _didJustDismissSearch = true;
-                    Navigator.of(context).pop();
-                  },
-                ),
-                suggestionsBuilder: (
-                  BuildContext context,
-                  SearchController controller,
-                ) {
-                  final query = controller.text.toLowerCase();
-                  final filtered =
-                      query.isEmpty
-                          ? seriesList
-                          : seriesList
-                              .where(
-                                (s) => s.title.toLowerCase().contains(query),
-                              )
-                              .toList();
-
-                  if (filtered.isEmpty) {
-                    return [
-                      Padding(
-                        padding: const EdgeInsets.all(32.0),
-                        child: Center(
-                          child: Text(
-                            localizations.home_no_series_found,
-                            style: TextStyle(
-                              fontSize: fontSize,
-                              height: lineHeight,
-                              color:
-                                  Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ];
-                  }
-
-                  return filtered.map((series) {
-                    return ListTile(
-                      leading: Icon(
-                        Icons.tag,
-                        size: 20,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      title: Text(
-                        series.title,
-                        style: TextStyle(
-                          fontSize: fontSize,
-                          fontWeight: FontWeight.w500,
-                          height: lineHeight,
-                        ),
-                      ),
-                      trailing: Icon(
-                        Icons.arrow_forward_ios,
-                        size: 16,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                      onTap: () {
-                        _didJustDismissSearch = true;
-                        controller.closeView(series.title);
-                        _log.info('Series selected from search: ${series.id}');
-                        _navigateToSeries(series);
-                      },
-                    );
-                  }).toList();
-                },
+    return RefreshIndicator(
+      onRefresh: _onRefresh,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          // ── Greeting app bar ──────────────────────────────────────────
+          SliverAppBar(
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+            scrolledUnderElevation: 0,
+            pinned: false,
+            floating: true,
+            snap: true,
+            title: Text(
+              greeting,
+              strutStyle: context.tibetanStrutStyle(
+                Theme.of(context).textTheme.headlineSmall?.fontSize ?? 24,
+              ),
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
               ),
             ),
-          );
-        },
-        loading:
-            () => SearchBar(
-              constraints: HomeScreenConstants.searchBarConstraints,
-              padding: const WidgetStatePropertyAll<EdgeInsets>(
-                EdgeInsets.symmetric(
-                  horizontal: HomeScreenConstants.searchBarHorizontalPadding,
+            actions: [
+              _buildSearchAction(l10n, seriesAsync),
+              const SizedBox(width: 4),
+            ],
+          ),
+
+          // ── Content body ─────────────────────────────────────────────
+          seriesAsync.when(
+            data: (seriesEither) => seriesEither.fold(
+              (failure) => SliverFillRemaining(
+                child: ErrorStateWidget(
+                  error: failure,
+                  onRetry: _onRefresh,
                 ),
               ),
-              enabled: false,
-              elevation: const WidgetStatePropertyAll(0.0),
-              leading: Icon(
-                Icons.search,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-              hintText: localizations.text_search,
-              hintStyle: WidgetStatePropertyAll(searchHintStyle),
+              (seriesList) => _buildSeriesSections(context, l10n, seriesList),
             ),
-        error:
-            (_, __) => SearchBar(
-              constraints: HomeScreenConstants.searchBarConstraints,
-              padding: const WidgetStatePropertyAll<EdgeInsets>(
-                EdgeInsets.symmetric(
-                  horizontal: HomeScreenConstants.searchBarHorizontalPadding,
-                ),
-              ),
-              enabled: false,
-              leading: Icon(
-                Icons.search,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-              hintText: localizations.text_search,
-              hintStyle: WidgetStatePropertyAll(searchHintStyle),
+            loading: () => const SliverFillRemaining(
+              child: TagGridSkeleton(),
             ),
+            error: (error, _) => SliverFillRemaining(
+              child: ErrorStateWidget(
+                error: error,
+                onRetry: _onRefresh,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildBody(BuildContext context, AppLocalizations localizations) {
-    final seriesAsync = ref.watch(seriesListFutureProvider);
-    final language = ref.watch(localeProvider).languageCode;
-    final fontSize = language == 'bo' ? 22.0 : 18.0;
+  Widget _buildSeriesSections(
+    BuildContext context,
+    AppLocalizations l10n,
+    List<Series> seriesList,
+  ) {
+    if (seriesList.isEmpty) {
+      return SliverFillRemaining(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(HomeScreenConstants.emptyStatePadding),
+            child: Text(
+              l10n.no_feature_content,
+              style: const TextStyle(fontSize: 18),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    }
 
-    return Expanded(
-      child: RefreshIndicator(
-        onRefresh: _onRefresh,
-        child: seriesAsync.when(
-          data: (seriesEither) {
-            return seriesEither.fold(
-              (failure) => _buildScrollableMessage(
-                ErrorStateWidget(error: failure, onRetry: _refetchSeries),
+    final enrolledIds =
+        ref.watch(userSeriesEnrollmentsProvider).valueOrNull ?? const <String>{};
+    final myPlansState = ref.watch(myPlansPaginatedProvider);
+
+    // Split series into featured, enrolled (continue today), and explore more.
+    final featured = seriesList.where((s) => s.featured).toList();
+    final featuredSeries = featured.isNotEmpty ? featured.first : seriesList.first;
+
+    final enrolledSeries =
+        seriesList.where((s) => enrolledIds.contains(s.id)).toList();
+
+    final exploreSeries =
+        seriesList
+            .where((s) => !enrolledIds.contains(s.id) && s.id != featuredSeries.id)
+            .toList();
+    // If the featured series is enrolled, include it in explore only if not enrolled.
+    final exploreSeriesWithFeatured =
+        enrolledIds.contains(featuredSeries.id)
+            ? exploreSeries
+            : [
+                if (!exploreSeries.any((s) => s.id == featuredSeries.id))
+                  // featured already shown above; don't duplicate in grid
+                  ...exploreSeries
+                else
+                  ...exploreSeries,
+              ];
+
+    return SliverList(
+      delegate: SliverChildListDelegate([
+        // ── Search bar ─────────────────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: _buildSearchBar(l10n, seriesList),
+        ),
+
+        // ── Featured ───────────────────────────────────────────────────
+        if (!enrolledIds.contains(featuredSeries.id)) ...[
+          _buildSectionHeader(context, l10n.home_featured),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: FeaturedSeriesCard(
+              series: featuredSeries,
+              onTap: () => _navigateToSeries(featuredSeries),
+              creatorName: _creatorNameFor(featuredSeries),
+            ),
+          ),
+        ],
+
+        // ── Continue today ─────────────────────────────────────────────
+        if (enrolledSeries.isNotEmpty) ...[
+          _buildSectionHeader(context, l10n.home_continue_today),
+          ...enrolledSeries.map((series) {
+            final progress = _computeProgress(series, myPlansState);
+            return Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: ContinueTodayCard(
+                series: series,
+                onTap: () => _navigateToSeries(series),
+                creatorName: _creatorNameFor(series),
+                progressPercent: progress?.percent,
+                currentPlanLabel: progress?.label,
               ),
-              (seriesList) {
-                if (seriesList.isEmpty) {
-                  return _buildScrollableMessage(
-                    Padding(
-                      padding: const EdgeInsets.all(
-                        HomeScreenConstants.emptyStatePadding,
-                      ),
-                      child: Text(
-                        localizations.no_feature_content,
-                        style: TextStyle(fontSize: fontSize),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  );
-                }
+            );
+          }),
+        ],
 
-                return GridView.builder(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: HomeScreenConstants.bodyHorizontalPadding,
-                    vertical: HomeScreenConstants.bodyVerticalPadding,
-                  ),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    crossAxisSpacing: 8,
-                    mainAxisSpacing: 8,
-                    childAspectRatio: 1.3,
-                  ),
-                  itemCount: seriesList.length,
-                  itemBuilder: (context, index) {
-                    final series = seriesList[index];
-                    return SeriesCard(
-                      series: series,
-                      onTap: () {
-                        _log.info('Series tapped: ${series.id}');
-                        _navigateToSeries(series);
-                      },
-                    );
-                  },
+        // ── Explore more ───────────────────────────────────────────────
+        if (exploreSeriesWithFeatured.isNotEmpty) ...[
+          _buildSectionHeader(context, l10n.home_explore_more),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: HomeScreenConstants.bodyHorizontalPadding,
+            ),
+            child: GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+                childAspectRatio: 1.3,
+              ),
+              itemCount: exploreSeriesWithFeatured.length,
+              itemBuilder: (context, index) {
+                final series = exploreSeriesWithFeatured[index];
+                return SeriesCard(
+                  series: series,
+                  onTap: () => _navigateToSeries(series),
                 );
               },
-            );
-          },
-          loading: () => const TagGridSkeleton(),
-          error:
-              (error, stackTrace) => _buildScrollableMessage(
-                ErrorStateWidget(error: error, onRetry: _refetchSeries),
-              ),
+            ),
+          ),
+        ],
+
+        const SizedBox(height: 32),
+      ]),
+    );
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title) {
+    final locale = ref.watch(localeProvider);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final labelColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
+      child: Text(
+        title.toUpperCase(),
+        strutStyle: context.tibetanStrutStyle(
+          Theme.of(context).textTheme.labelMedium?.fontSize ?? 12,
+        ),
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          color: labelColor,
+          fontWeight: FontWeight.w600,
+          letterSpacing: locale.languageCode == 'bo' ? 0 : 1.2,
         ),
       ),
     );
   }
 
-  /// Wraps a non-scrollable state (empty / error) in an always-scrollable
-  /// viewport so pull-to-refresh works even when there is no grid content.
-  Widget _buildScrollableMessage(Widget child) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(child: child),
-          ),
-        );
-      },
+  // ── Search ──────────────────────────────────────────────────────────────
+
+  Widget _buildSearchAction(
+    AppLocalizations l10n,
+    AsyncValue<Either<Failure, List<Series>>> seriesAsync,
+  ) {
+    final seriesList =
+        seriesAsync.whenOrNull(data: (e) => e.fold((_) => null, (l) => l)) ??
+        <Series>[];
+    return IconButton(
+      icon: const Icon(Icons.search),
+      tooltip: l10n.text_search,
+      onPressed: () => _showSearchSheet(context, l10n, seriesList),
     );
   }
+
+  Widget _buildSearchBar(AppLocalizations l10n, List<Series> seriesList) {
+    final locale = ref.watch(localeProvider);
+    final fontSize = locale.languageCode == 'bo' ? 18.0 : 16.0;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final hintColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    return FocusScope(
+      node: _searchFocusScopeNode,
+      onFocusChange: (isFocused) {
+        if (_didJustDismissSearch && isFocused) {
+          _didJustDismissSearch = false;
+          _searchFocusScopeNode.unfocus();
+        }
+      },
+      child: SearchAnchor(
+        builder: (context, controller) => SearchBar(
+          controller: controller,
+          constraints: HomeScreenConstants.searchBarConstraints,
+          padding: const WidgetStatePropertyAll<EdgeInsets>(
+            EdgeInsets.symmetric(
+              horizontal: HomeScreenConstants.searchBarHorizontalPadding,
+            ),
+          ),
+          elevation: const WidgetStatePropertyAll(0.0),
+          shadowColor: const WidgetStatePropertyAll(Colors.transparent),
+          onTap: controller.openView,
+          onChanged: (_) => controller.openView(),
+          leading: Icon(
+            Icons.search,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          hintText: l10n.text_search,
+          hintStyle: WidgetStatePropertyAll(
+            TextStyle(fontSize: fontSize, color: hintColor),
+          ),
+        ),
+        viewLeading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () {
+            _didJustDismissSearch = true;
+            Navigator.of(context).pop();
+          },
+        ),
+        suggestionsBuilder: (context, controller) {
+          final query = controller.text.toLowerCase();
+          final filtered =
+              query.isEmpty
+                  ? seriesList
+                  : seriesList
+                      .where((s) => s.title.toLowerCase().contains(query))
+                      .toList();
+
+          if (filtered.isEmpty) {
+            return [
+              Padding(
+                padding: const EdgeInsets.all(32),
+                child: Center(
+                  child: Text(
+                    l10n.home_no_series_found,
+                    style: TextStyle(
+                      fontSize: fontSize,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+            ];
+          }
+
+          return filtered.map((series) => ListTile(
+            leading: Icon(
+              Icons.tag,
+              size: 20,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            title: Text(
+              series.title,
+              style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w500),
+            ),
+            trailing: Icon(
+              Icons.arrow_forward_ios,
+              size: 16,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            onTap: () {
+              _didJustDismissSearch = true;
+              controller.closeView(series.title);
+              _navigateToSeries(series);
+            },
+          )).toList();
+        },
+      ),
+    );
+  }
+
+  void _showSearchSheet(
+    BuildContext context,
+    AppLocalizations l10n,
+    List<Series> seriesList,
+  ) {
+    // Handled inline by SearchAnchor in the bar — no separate sheet needed.
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  /// Returns the author name from the first plan in the series, if available.
+  String? _creatorNameFor(Series series) {
+    if (series.plans.isEmpty) return null;
+    return series.plans.first.authorName;
+  }
+
+  /// Computes rough series progress from enrolled plan data.
+  _SeriesProgress? _computeProgress(
+    Series series,
+    MyPlansState myPlansState,
+  ) {
+    if (series.plans.isEmpty || series.totalDays <= 0) return null;
+
+    // Match series plans against user's enrolled plans.
+    final seriesPlanIds = series.plans.map((p) => p.id).toSet();
+    final enrolledUserPlans =
+        myPlansState.plans
+            .where((up) => seriesPlanIds.contains(up.id))
+            .toList();
+
+    if (enrolledUserPlans.isEmpty) return null;
+
+    // Compute total completed days across all enrolled plans.
+    int completedDays = 0;
+    for (final userPlan in enrolledUserPlans) {
+      final anchor = userPlan.effectiveStartDate;
+      final dayNum = PlanUtils.dayNumberFor(anchor, DateTime.now(), userPlan.totalDays);
+      // Days completed = current day - 1 (don't count today as "done" yet).
+      completedDays += (dayNum - 1).clamp(0, userPlan.totalDays);
+    }
+
+    final percent = ((completedDays / series.totalDays) * 100).round().clamp(0, 100);
+
+    // Find the current active plan (last enrolled plan that isn't fully done).
+    String? planLabel;
+    final sortedByStart =
+        [...enrolledUserPlans]..sort(
+          (a, b) => a.effectiveStartDate.compareTo(b.effectiveStartDate),
+        );
+    for (var i = 0; i < sortedByStart.length; i++) {
+      final up = sortedByStart[i];
+      final anchor = up.effectiveStartDate;
+      final dayNum = PlanUtils.dayNumberFor(anchor, DateTime.now(), up.totalDays);
+      if (dayNum <= up.totalDays) {
+        planLabel = 'Plan ${i + 1} · Day $dayNum';
+        break;
+      }
+    }
+
+    return _SeriesProgress(percent: percent, label: planLabel);
+  }
+}
+
+class _SeriesProgress {
+  final int percent;
+  final String? label;
+  const _SeriesProgress({required this.percent, this.label});
 }

--- a/lib/features/home/presentation/screens/series_detail_screen.dart
+++ b/lib/features/home/presentation/screens/series_detail_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
-import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
 import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
 import 'package:flutter_pecha/features/home/presentation/providers/series_provider.dart';
-import 'package:flutter_pecha/features/home/presentation/widgets/plan_list_view.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
+import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_track/plan_date_range_label.dart';
+import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -23,59 +32,679 @@ class SeriesDetailScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(
-      myPlansPaginatedProvider,
-    ); // pre-warm so enrolled state is ready when list items render
+    ref.watch(myPlansPaginatedProvider);
     final seriesAsync = ref.watch(seriesByIdProvider(seriesId));
-    final localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      body: SafeArea(
-        child: Column(
-          children: [
-            _buildAppBar(
-              context,
-              seriesAsync.whenOrNull(
-                    data: (either) => either.fold((_) => null, (s) => s.title),
-                  ) ??
-                  series?.title ??
-                  '',
+      body: seriesAsync.when(
+        data: (either) => either.fold(
+          (failure) => _buildError(context, ref, failure),
+          (s) => _SeriesAboutBody(
+            series: s,
+            onRefresh: () => _onRefresh(ref),
+          ),
+        ),
+        loading: () => _buildLoading(context),
+        error: (error, _) => _buildError(context, ref, error),
+      ),
+    );
+  }
+
+  Widget _buildLoading(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          _buildMinimalAppBar(context, series?.title ?? ''),
+          const Expanded(child: PlanListSkeleton()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context, WidgetRef ref, Object error) {
+    return SafeArea(
+      child: Column(
+        children: [
+          _buildMinimalAppBar(context, series?.title ?? ''),
+          Expanded(
+            child: Center(
+              child: ErrorStateWidget(
+                error: error,
+                onRetry: () => _onRefresh(ref),
+              ),
             ),
-            Expanded(
-              child: RefreshIndicator(
-                onRefresh: () => _onRefresh(ref),
-                child: seriesAsync.when(
-                  data: (either) {
-                    return either.fold(
-                      (failure) => _buildScrollableMessage(
-                        ErrorStateWidget(
-                          error: failure,
-                          onRetry: () => _onRefresh(ref),
-                        ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMinimalAppBar(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back_ios),
+            onPressed: () => context.pop(),
+          ),
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const SizedBox(width: 48),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Body
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _SeriesAboutBody extends ConsumerWidget {
+  const _SeriesAboutBody({required this.series, required this.onRefresh});
+
+  final Series series;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enrolledIds =
+        ref.watch(userSeriesEnrollmentsProvider).valueOrNull ?? const <String>{};
+    final isEnrolled = enrolledIds.contains(series.id);
+    final enrollmentState = ref.watch(seriesEnrollmentProvider(series.id));
+    final isEnrolling = enrollmentState is SeriesEnrollmentLoading;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final enrollBgColor =
+        isDark ? AppColors.scaffoldBackgroundLight : AppColors.scaffoldBackgroundDark;
+    final enrollFgColor =
+        isDark ? AppColors.textPrimary : AppColors.textPrimaryDark;
+
+    final sorted = [...series.plans]..sort((a, b) {
+      if (a.displayOrder != null && b.displayOrder != null) {
+        return a.displayOrder!.compareTo(b.displayOrder!);
+      }
+      if (a.displayOrder != null) return -1;
+      if (b.displayOrder != null) return 1;
+      return 0;
+    });
+
+    return Stack(
+      children: [
+        RefreshIndicator(
+          onRefresh: () async => onRefresh(),
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              // ── Custom app bar with hero image ────────────────────────
+              _HeroAppBar(
+                series: series,
+                isEnrolled: isEnrolled,
+                onUnenrollTap: () => _showUnenrollSheet(context, ref, sorted),
+              ),
+
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // ── Series title ──────────────────────────────────
+                      Text(
+                        series.title,
+                        style: Theme.of(context).textTheme.headlineSmall
+                            ?.copyWith(fontWeight: FontWeight.bold),
                       ),
-                      (series) {
-                        if (series.plans.isEmpty) {
-                          return _buildScrollableMessage(
-                            _buildEmptyState(context, localizations, ref),
-                          );
-                        }
-                        return PlanListView(
-                          plans: series.plans,
-                          seriesId: seriesId,
-                        );
-                      },
-                    );
-                  },
-                  loading: () => const PlanListSkeleton(),
-                  error:
-                      (error, stackTrace) => _buildScrollableMessage(
-                        ErrorStateWidget(
-                          error: error,
-                          onRetry: () => _onRefresh(ref),
+                      const SizedBox(height: 6),
+
+                      // ── Creator · plans · days ────────────────────────
+                      _SeriesMetaLine(series: sorted),
+                      const SizedBox(height: 20),
+
+                      // ── About section ─────────────────────────────────
+                      if (series.description.trim().isNotEmpty) ...[
+                        _SectionLabel(label: 'About'),
+                        const SizedBox(height: 8),
+                        Text(
+                          series.description,
+                          style: Theme.of(context).textTheme.bodyMedium,
                         ),
-                      ),
+                        const SizedBox(height: 24),
+                      ],
+                    ],
+                  ),
                 ),
+              ),
+
+              // ── About the creator ─────────────────────────────────────
+              if (sorted.isNotEmpty && sorted.first.authorName != null)
+                SliverToBoxAdapter(
+                  child: _AboutCreatorSection(plan: sorted.first),
+                ),
+
+              // ── Included plans ────────────────────────────────────────
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _SectionLabel(label: context.l10n.home_series_included_plans),
+                      const SizedBox(height: 12),
+                    ],
+                  ),
+                ),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                sliver: SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _SeriesPlanRow(
+                      plan: sorted[index],
+                      planIndex: index,
+                      totalPlans: sorted.length,
+                      seriesIsEnrolled: isEnrolled,
+                    ),
+                    childCount: sorted.length,
+                  ),
+                ),
+              ),
+
+              // ── Bottom padding (+ space for sticky button) ────────────
+              SliverToBoxAdapter(
+                child: SizedBox(height: isEnrolled ? 24 : 100),
+              ),
+            ],
+          ),
+        ),
+
+        // ── Sticky enroll button ──────────────────────────────────────────
+        if (!isEnrolled)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: _StickyEnrollButton(
+              seriesId: series.id,
+              isEnrolling: isEnrolling,
+              enrollBgColor: enrollBgColor,
+              enrollFgColor: enrollFgColor,
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _showUnenrollSheet(
+    BuildContext context,
+    WidgetRef ref,
+    List<Plan> plans,
+  ) {
+    final l10n = context.l10n;
+    showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 16),
+              ListTile(
+                leading: Icon(
+                  Icons.exit_to_app,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                title: Text(
+                  l10n.plan_unenroll,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  _showUnenrollConfirmation(context, ref, plans);
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _showUnenrollConfirmation(
+    BuildContext context,
+    WidgetRef ref,
+    List<Plan> plans,
+  ) {
+    final l10n = context.l10n;
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(l10n.series_unenroll_title),
+          content: Text(l10n.series_unenroll_body),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () async {
+                Navigator.of(dialogContext).pop();
+                await _handleUnenroll(context, ref, plans);
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+              child: Text(l10n.plan_unenroll),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _handleUnenroll(
+    BuildContext context,
+    WidgetRef ref,
+    List<Plan> plans,
+  ) async {
+    bool anyError = false;
+    for (final plan in plans) {
+      final result = await ref.read(
+        userPlanUnsubscribeFutureProvider(plan.id).future,
+      );
+      result.fold((_) => anyError = true, (_) {});
+    }
+
+    ref.invalidate(userSeriesEnrollmentsProvider);
+    ref.invalidate(myPlansPaginatedProvider);
+    ref.invalidate(userPlansFutureProvider);
+
+    if (context.mounted) {
+      if (anyError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.unenrollError)),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.unenrollSuccess(series.title)),
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            behavior: SnackBarBehavior.floating,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+        Navigator.of(context).pop();
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hero app bar with cover image
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _HeroAppBar extends StatelessWidget {
+  const _HeroAppBar({
+    required this.series,
+    required this.isEnrolled,
+    this.onUnenrollTap,
+  });
+
+  final Series series;
+  final bool isEnrolled;
+  final VoidCallback? onUnenrollTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Stack(
+        children: [
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: CachedNetworkImageWidget(
+              imageUrl: series.imageUrl,
+              fallbackAsset: 'assets/images/tag_cover/cover_image.jpg',
+              fit: BoxFit.cover,
+              placeholder: _buildPlaceholder(context),
+              errorWidget: _buildPlaceholder(context),
+            ),
+          ),
+          // Gradient overlay for legible back button
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.45),
+                    Colors.transparent,
+                  ],
+                  stops: const [0.0, 0.4],
+                ),
+              ),
+            ),
+          ),
+          // Back button + optional 3-dot menu
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _ImageNavButton(
+                    icon: Icons.arrow_back_ios_new,
+                    onTap: () => Navigator.of(context).pop(),
+                  ),
+                  if (isEnrolled && onUnenrollTap != null)
+                    _ImageNavButton(
+                      icon: Icons.more_horiz,
+                      onTap: onUnenrollTap!,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlaceholder(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageNavButton extends StatelessWidget {
+  const _ImageNavButton({required this.icon, required this.onTap});
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 40,
+        margin: const EdgeInsets.all(4),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.35),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(icon, color: Colors.white, size: 20),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Series metadata line (Creator · N plans · N days)
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _SeriesMetaLine extends StatelessWidget {
+  const _SeriesMetaLine({required this.series});
+
+  final List<Plan> series;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final color = isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    final parts = <String>[];
+    final creator = series.isNotEmpty ? series.first.authorName : null;
+    if (creator != null && creator.isNotEmpty) parts.add(creator);
+    if (series.isNotEmpty) parts.add(l10n.home_series_n_plans(series.length));
+
+    return Text(
+      parts.join(' · '),
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// About the creator section
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _AboutCreatorSection extends StatelessWidget {
+  const _AboutCreatorSection({required this.plan});
+
+  final Plan plan;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final creatorName = plan.authorName ?? '';
+    if (creatorName.isEmpty) return const SizedBox.shrink();
+
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final dividerColor = isDark ? AppColors.cardBorderDark : AppColors.greyLight;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _SectionLabel(label: l10n.home_series_about_creator),
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Author avatar placeholder
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
+                    ),
+                    child: Icon(
+                      Icons.person,
+                      size: 24,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          creatorName,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 16),
+                        GestureDetector(
+                          onTap: () {
+                            // Navigate to creator page in a future sub-issue.
+                          },
+                          child: Text(
+                            l10n.home_series_view_creator_page(creatorName),
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                              color: Theme.of(context).colorScheme.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        Divider(height: 1, color: dividerColor),
+      ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plan row within the series About page
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _SeriesPlanRow extends ConsumerWidget {
+  const _SeriesPlanRow({
+    required this.plan,
+    required this.planIndex,
+    required this.totalPlans,
+    required this.seriesIsEnrolled,
+  });
+
+  final Plan plan;
+  final int planIndex;
+  final int totalPlans;
+  final bool seriesIsEnrolled;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(localeProvider);
+    final lineHeight = getLineHeight(locale.languageCode);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final subtitleColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    // Pre-warm so _getEnrolledInfo below sees current plan list.
+    ref.watch(myPlansPaginatedProvider);
+    final isGuest = ref.watch(authProvider).isGuest;
+    final enrolledInfo =
+        (!isGuest && seriesIsEnrolled)
+            ? _getEnrolledInfo(ref, plan.id)
+            : null;
+
+    final dateRange = PlanDateRange.tryCreate(
+      startDate: plan.startDate,
+      totalDays: plan.totalDays,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: InkWell(
+        onTap: () => _onTap(context, ref, enrolledInfo),
+        borderRadius: BorderRadius.circular(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Cover thumbnail ───────────────────────────────────────
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                color: Theme.of(context).colorScheme.surfaceContainer,
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: _PlanThumbnail(imageUrl: plan.coverImageUrl),
+            ),
+            const SizedBox(width: 12),
+
+            // ── Plan details ──────────────────────────────────────────
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Plan N of M label
+                  Text(
+                    'Plan ${planIndex + 1} of $totalPlans',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 0.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    plan.title,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      height: lineHeight,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      if (plan.totalDays > 0)
+                        Text(
+                          context.l10n.home_series_n_days(plan.totalDays),
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(color: subtitleColor),
+                        ),
+                      if (dateRange != null) ...[
+                        const SizedBox(width: 8),
+                        PlanDateRangeLabel(
+                          dateRange: dateRange,
+                          lineHeight: lineHeight,
+                        ),
+                      ],
+                    ],
+                  ),
+                  if (seriesIsEnrolled && enrolledInfo != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: _EnrolledChip(
+                        dayNum: enrolledInfo.selectedDay,
+                        totalDays: plan.totalDays,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+
+            // ── Chevron ───────────────────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Icon(
+                Icons.arrow_forward_ios,
+                size: 14,
+                color: subtitleColor,
               ),
             ),
           ],
@@ -84,63 +713,239 @@ class SeriesDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildAppBar(BuildContext context, String title) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-      child: Row(
-        children: [
-          IconButton(
-            icon: const Icon(Icons.arrow_back_ios),
-            onPressed: () => context.pop(),
-          ),
-          Expanded(
-            child: Center(
-              child: Text(
-                title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: 48, height: 48),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildEmptyState(
+  void _onTap(
     BuildContext context,
-    AppLocalizations localizations,
     WidgetRef ref,
+    _EnrolledPlanInfo? enrolledInfo,
   ) {
-    final locale = ref.watch(localeProvider);
-    final fontSize = locale.languageCode == 'bo' ? 22.0 : 18.0;
+    if (enrolledInfo != null) {
+      context.push(
+        '/practice/details',
+        extra: {
+          'plan': enrolledInfo.userPlan,
+          'selectedDay': enrolledInfo.selectedDay,
+          'startDate': enrolledInfo.startDate,
+        },
+      );
+    } else {
+      context.push('/practice/plans/preview', extra: {'plan': plan});
+    }
+  }
 
-    return Padding(
-      padding: const EdgeInsets.all(32.0),
+  _EnrolledPlanInfo? _getEnrolledInfo(WidgetRef ref, String planId) {
+    final myPlansState = ref.watch(myPlansPaginatedProvider);
+    UserPlansModel? userPlan;
+    for (final p in myPlansState.plans) {
+      if (p.id == planId) {
+        userPlan = p;
+        break;
+      }
+    }
+    if (userPlan == null) return null;
+
+    final anchor = userPlan.effectiveStartDate;
+    final dayNum = PlanUtils.dayNumberFor(anchor, DateTime.now(), userPlan.totalDays);
+    final selectedDay = dayNum.clamp(1, userPlan.totalDays);
+    return _EnrolledPlanInfo(
+      userPlan: userPlan,
+      selectedDay: selectedDay,
+      startDate: anchor,
+    );
+  }
+}
+
+class _EnrolledChip extends StatelessWidget {
+  const _EnrolledChip({required this.dayNum, required this.totalDays});
+
+  final int dayNum;
+  final int totalDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDone = dayNum > totalDays;
+    final label =
+        isDone ? 'Complete' : 'Day $dayNum of $totalDays';
+    final color =
+        isDone
+            ? Colors.green
+            : Theme.of(context).colorScheme.primary;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
       child: Text(
-        localizations.no_feature_content,
-        style: TextStyle(fontSize: fontSize),
-        textAlign: TextAlign.center,
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanThumbnail extends StatelessWidget {
+  const _PlanThumbnail({required this.imageUrl});
+
+  final String? imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    if (imageUrl != null && imageUrl!.isNotEmpty) {
+      return CachedNetworkImageWidget(
+        imageUrl: imageUrl,
+        fit: BoxFit.cover,
+        placeholder: _placeholder(context),
+        errorWidget: _placeholder(context),
+      );
+    }
+    return _placeholder(context);
+  }
+
+  Widget _placeholder(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.25),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+          ],
+        ),
+      ),
+      child: Center(
+        child: Icon(
+          Icons.image_outlined,
+          size: 24,
+          color: Colors.white.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sticky enroll button
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _StickyEnrollButton extends ConsumerWidget {
+  const _StickyEnrollButton({
+    required this.seriesId,
+    required this.isEnrolling,
+    required this.enrollBgColor,
+    required this.enrollFgColor,
+  });
+
+  final String seriesId;
+  final bool isEnrolling;
+  final Color enrollBgColor;
+  final Color enrollFgColor;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+      child: SizedBox(
+        width: double.infinity,
+        height: 52,
+        child: ElevatedButton(
+          onPressed: isEnrolling ? null : () => _onEnroll(context, ref),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: enrollBgColor,
+            foregroundColor: enrollFgColor,
+            disabledBackgroundColor: enrollBgColor.withValues(alpha: 0.5),
+            disabledForegroundColor: enrollFgColor.withValues(alpha: 0.5),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            elevation: 0,
+          ),
+          child: isEnrolling
+              ? SizedBox(
+                  height: 22,
+                  width: 22,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(enrollFgColor),
+                  ),
+                )
+              : Text(
+                  context.l10n.plan_enroll,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+        ),
       ),
     );
   }
 
-  Widget _buildScrollableMessage(Widget child) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(child: child),
-          ),
-        );
-      },
+  Future<void> _onEnroll(BuildContext context, WidgetRef ref) async {
+    final isGuest = ref.read(authProvider).isGuest;
+    if (isGuest) {
+      LoginDrawer.show(context, ref);
+      return;
+    }
+
+    final alreadyEnrolled =
+        ref.read(userSeriesEnrollmentsProvider).valueOrNull?.contains(seriesId) ??
+        false;
+    if (alreadyEnrolled) return;
+
+    final notifier = ref.read(seriesEnrollmentProvider(seriesId).notifier);
+    final ok = await notifier.enroll();
+    if (!context.mounted) return;
+
+    if (ok) {
+      context.pushNamed('edit-routine', extra: {'enrollSeriesId': seriesId});
+    } else {
+      final state = ref.read(seriesEnrollmentProvider(seriesId));
+      final message =
+          state is SeriesEnrollmentFailure
+              ? state.failure.message
+              : 'Failed to enroll in series';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message), backgroundColor: Colors.red),
+      );
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Text(
+      label.toUpperCase(),
+      style: Theme.of(context).textTheme.labelMedium?.copyWith(
+        color: isDark ? AppColors.textTertiaryDark : AppColors.textSecondary,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1.0,
+      ),
     );
   }
+}
+
+class _EnrolledPlanInfo {
+  final UserPlansModel userPlan;
+  final int selectedDay;
+  final DateTime startDate;
+
+  const _EnrolledPlanInfo({
+    required this.userPlan,
+    required this.selectedDay,
+    required this.startDate,
+  });
 }

--- a/lib/features/home/presentation/widgets/continue_today_card.dart
+++ b/lib/features/home/presentation/widgets/continue_today_card.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+
+/// Card shown in the "Continue today" section of the Home screen for an
+/// enrolled series. Shows the series image, title, creator/duration metadata,
+/// and overall progress.
+class ContinueTodayCard extends StatelessWidget {
+  const ContinueTodayCard({
+    super.key,
+    required this.series,
+    required this.onTap,
+    this.creatorName,
+    this.progressPercent,
+    this.currentPlanLabel,
+  });
+
+  final Series series;
+  final VoidCallback onTap;
+  final String? creatorName;
+
+  /// 0–100 overall series progress (null = unknown / loading).
+  final int? progressPercent;
+
+  /// Short label like "Plan 2 · Day 3" shown near the progress chip.
+  final String? currentPlanLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final subtitleColor = isDark ? Colors.white70 : Colors.black54;
+    final cardColor =
+        isDark ? AppColors.surfaceDark : AppColors.cardBackgroundLight;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: cardColor,
+          border: isDark
+              ? Border.all(color: AppColors.cardBorderDark, width: 1)
+              : null,
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 100,
+              height: 100,
+              child: CachedNetworkImageWidget(
+                imageUrl: series.imageUrl,
+                fallbackAsset: 'assets/images/tag_cover/cover_image.jpg',
+                fit: BoxFit.cover,
+                placeholder: _buildPlaceholder(context),
+                errorWidget: _buildPlaceholder(context),
+              ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (currentPlanLabel != null) ...[
+                      Text(
+                        currentPlanLabel!,
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                    ],
+                    Text(
+                      series.title,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _buildSubtitle(context),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: subtitleColor,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    _buildProgressRow(context),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressRow(BuildContext context) {
+    final l10n = context.l10n;
+    final pct = progressPercent;
+
+    if (pct == null) {
+      return Text(
+        l10n.home_series_in_progress,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: Theme.of(
+                  context,
+                ).colorScheme.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                l10n.home_series_progress(pct),
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: pct / 100.0,
+            minHeight: 4,
+            backgroundColor: Theme.of(
+              context,
+            ).colorScheme.primary.withValues(alpha: 0.15),
+            valueColor: AlwaysStoppedAnimation<Color>(
+              Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _buildSubtitle(BuildContext context) {
+    final l10n = context.l10n;
+    final parts = <String>[];
+    if (creatorName != null && creatorName!.isNotEmpty) {
+      parts.add(creatorName!);
+    }
+    if (series.totalDays > 0) {
+      parts.add(l10n.home_series_n_days(series.totalDays));
+    }
+    return parts.join(' · ');
+  }
+
+  Widget _buildPlaceholder(BuildContext context) {
+    return Container(
+      color: Theme.of(context).colorScheme.surfaceContainer,
+      child: Center(
+        child: Icon(
+          Icons.image_outlined,
+          size: 28,
+          color: Theme.of(
+            context,
+          ).colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/featured_series_card.dart
+++ b/lib/features/home/presentation/widgets/featured_series_card.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+
+class FeaturedSeriesCard extends StatelessWidget {
+  const FeaturedSeriesCard({
+    super.key,
+    required this.series,
+    required this.onTap,
+    this.creatorName,
+  });
+
+  final Series series;
+  final VoidCallback onTap;
+  final String? creatorName;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final subtitleColor = isDark ? Colors.white70 : Colors.black54;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: Theme.of(context).colorScheme.surfaceContainer,
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AspectRatio(
+              aspectRatio: 16 / 9,
+              child: CachedNetworkImageWidget(
+                imageUrl: series.imageUrl,
+                fallbackAsset: 'assets/images/tag_cover/cover_image.jpg',
+                fit: BoxFit.cover,
+                placeholder: _buildPlaceholder(context),
+                errorWidget: _buildPlaceholder(context),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    series.title,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    _buildSubtitle(context),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: subtitleColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _buildSubtitle(BuildContext context) {
+    final l10n = context.l10n;
+    final parts = <String>[];
+    if (creatorName != null && creatorName!.isNotEmpty) {
+      parts.add(creatorName!);
+    }
+    if (series.plans.isNotEmpty) {
+      parts.add(l10n.home_series_n_plans(series.plans.length));
+    }
+    if (series.totalDays > 0) {
+      parts.add(l10n.home_series_n_days(series.totalDays));
+    }
+    return parts.join(' · ');
+  }
+
+  Widget _buildPlaceholder(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+          ],
+        ),
+      ),
+      child: Center(
+        child: Icon(
+          Icons.image_outlined,
+          size: 48,
+          color: Colors.white.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plans/presentation/widgets/celebration/day_celebration_modal.dart
+++ b/lib/features/plans/presentation/widgets/celebration/day_celebration_modal.dart
@@ -1,0 +1,116 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+
+/// Full-screen dialog shown when the user completes all tasks for a non-last day.
+/// Matches Figma "Celebration — Daily completion".
+class DayCelebrationModal extends StatelessWidget {
+  const DayCelebrationModal({
+    super.key,
+    required this.dayNumber,
+    required this.totalDays,
+    required this.onDismiss,
+  });
+
+  final int dayNumber;
+  final int totalDays;
+  final VoidCallback onDismiss;
+
+  static const _headings = [
+    'Great work!',
+    'Well done!',
+    "You're on a roll!",
+    'Keep it up!',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final heading = _headings[Random().nextInt(_headings.length)];
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final primaryColor = Theme.of(context).colorScheme.primary;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 28),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Checkmark circle
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: primaryColor, width: 2.5),
+              ),
+              child: Icon(Icons.check_rounded, size: 36, color: primaryColor),
+            ),
+            const SizedBox(height: 16),
+            // "DAY DONE" label
+            Text(
+              l10n.celebration_day_done,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.2,
+                color: primaryColor,
+              ),
+            ),
+            const SizedBox(height: 8),
+            // Random heading
+            Text(
+              heading,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            // "Day X of Y complete."
+            Text(
+              l10n.celebration_day_complete(dayNumber, totalDays),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: isDark ? Colors.white70 : Colors.black54,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 4),
+            // "You showed up..."
+            Text(
+              l10n.celebration_day_body,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: isDark ? Colors.white54 : Colors.black45,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+            // Back to home button
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onDismiss,
+                style: FilledButton.styleFrom(
+                  backgroundColor: isDark ? Colors.white : Colors.black,
+                  foregroundColor: isDark ? Colors.black : Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(l10n.celebration_back_to_home),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plans/presentation/widgets/celebration/plan_celebration_modal.dart
+++ b/lib/features/plans/presentation/widgets/celebration/plan_celebration_modal.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+
+/// Dialog shown when the user completes the last day of a plan.
+/// Shows "Continue to [next plan]" if the plan is part of a series with a next plan.
+/// Matches Figma "Celebration — Plan completion".
+class PlanCelebrationModal extends StatelessWidget {
+  const PlanCelebrationModal({
+    super.key,
+    required this.planTitle,
+    required this.totalDays,
+    this.nextPlanTitle,
+    required this.onContinue,
+  });
+
+  final String planTitle;
+  final int totalDays;
+
+  /// Title of the next plan in the series. Null for standalone or last plan.
+  final String? nextPlanTitle;
+
+  /// Called when the primary action button is tapped.
+  /// For series plans: navigates to next plan.
+  /// For standalone / last plan: dismisses (back to home).
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final primaryColor = Theme.of(context).colorScheme.primary;
+    final hasNextPlan = nextPlanTitle != null;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 28),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Checkmark circle
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: primaryColor, width: 2.5),
+              ),
+              child: Icon(Icons.check_rounded, size: 36, color: primaryColor),
+            ),
+            const SizedBox(height: 16),
+            // "PLAN DONE" label
+            Text(
+              l10n.celebration_plan_done,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.2,
+                color: primaryColor,
+              ),
+            ),
+            const SizedBox(height: 8),
+            // Plan title
+            Text(
+              planTitle,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            if (hasNextPlan) ...[
+              Text(
+                l10n.celebration_plan_subtitle,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: isDark ? Colors.white70 : Colors.black54,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 4),
+            ],
+            // Duration
+            Text(
+              l10n.celebration_plan_days(totalDays),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: isDark ? Colors.white54 : Colors.black45,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+            // Primary action button
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onContinue,
+                style: FilledButton.styleFrom(
+                  backgroundColor: isDark ? Colors.white : Colors.black,
+                  foregroundColor: isDark ? Colors.black : Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(
+                  hasNextPlan
+                      ? l10n.celebration_continue_to(nextPlanTitle!)
+                      : l10n.celebration_back_to_home,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plans/presentation/widgets/celebration/series_celebration_modal.dart
+++ b/lib/features/plans/presentation/widgets/celebration/series_celebration_modal.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+
+/// Full-screen dialog shown when the user completes the last plan in a series.
+/// Matches Figma "Celebration — Series completion".
+class SeriesCelebrationModal extends StatelessWidget {
+  const SeriesCelebrationModal({
+    super.key,
+    required this.series,
+    required this.onFindAnotherSeries,
+    required this.onStay,
+  });
+
+  final Series series;
+  final VoidCallback onFindAnotherSeries;
+  final VoidCallback onStay;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final totalDays = series.totalDays;
+    final totalPlans = series.plans.length;
+
+    final metaLine = [
+      '$totalPlans ${totalPlans == 1 ? "plan" : "plans"}',
+      if (totalDays > 0) '$totalDays days',
+    ].join(' · ');
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 28),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Large filled checkmark for series
+            Container(
+              width: 72,
+              height: 72,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [Color(0xFFFFB800), Color(0xFFFF8C00)],
+                ),
+              ),
+              child: const Icon(
+                Icons.check_rounded,
+                size: 40,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 16),
+            // "SERIES DONE" label
+            const Text(
+              'SERIES DONE',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.2,
+                color: Color(0xFFFF8C00),
+              ),
+            ),
+            const SizedBox(height: 8),
+            // Series title
+            Text(
+              series.title,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 6),
+            // "X plans · Y days"
+            Text(
+              metaLine,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: isDark ? Colors.white54 : Colors.black45,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+            // "Find another series" — primary dark button
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onFindAnotherSeries,
+                style: FilledButton.styleFrom(
+                  backgroundColor: isDark ? Colors.white : Colors.black,
+                  foregroundColor: isDark ? Colors.black : Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(l10n.celebration_series_find_another),
+              ),
+            ),
+            const SizedBox(height: 10),
+            // "Stay & revisit any plan" — text button
+            TextButton(
+              onPressed: onStay,
+              child: Text(
+                l10n.celebration_series_stay,
+                style: TextStyle(
+                  color: isDark ? Colors.white70 : Colors.black54,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plans/presentation/widgets/day_carousel.dart
+++ b/lib/features/plans/presentation/widgets/day_carousel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/features/plans/data/models/plan_days_model.dart';
 import 'package:intl/intl.dart';
+import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 
 class DayCarousel extends StatefulWidget {
   final String language;
@@ -82,22 +83,38 @@ class _DayCarouselState extends State<DayCarousel> {
   Widget build(BuildContext context) {
     final localStartDate = DateUtils.dateOnly(widget.startDate.toLocal());
     final today = DateUtils.dateOnly(DateTime.now());
+    final l10n = AppLocalizations.of(context)!;
+    final totalDays = widget.days.length;
+    final primaryColor = Theme.of(context).colorScheme.primary;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return SizedBox(
-      height: 80,
+      height: 88,
       child: ListView.builder(
         controller: _scrollController,
         scrollDirection: Axis.horizontal,
         physics: const BouncingScrollPhysics(),
         padding: const EdgeInsets.symmetric(horizontal: 12),
-        itemCount: widget.days.length,
+        itemCount: totalDays,
         itemBuilder: (context, index) {
           final day = widget.days[index];
           final dayDate = localStartDate.add(Duration(days: day.dayNumber - 1));
-          final dayDateString = DateFormat('dd MMM').format(dayDate);
           final isSelected = widget.selectedDay == day.dayNumber;
           final isCompleted = widget.dayCompletionStatus?[day.dayNumber] ?? false;
           final isToday = dayDate.isAtSameMomentAs(today);
+          final isLastDay = day.dayNumber == totalDays;
+
+          // Sub-label: "Last day" for final day, "dd MMM" otherwise.
+          final subLabel = isLastDay
+              ? l10n.plan_status_last_day
+              : DateFormat('dd MMM').format(dayDate);
+
+          final borderColor = isSelected ? primaryColor : Colors.transparent;
+          final cardColor = isSelected
+              ? (isDark
+                  ? primaryColor.withValues(alpha: 0.15)
+                  : primaryColor.withValues(alpha: 0.08))
+              : Theme.of(context).cardColor;
 
           return GestureDetector(
             onTap: () {
@@ -107,26 +124,12 @@ class _DayCarouselState extends State<DayCarousel> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 200),
               curve: Curves.easeInOut,
-              width: 80,
-              margin: const EdgeInsets.symmetric(horizontal: 4),
+              width: 72,
+              margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
               decoration: BoxDecoration(
-                color: Theme.of(context).cardColor,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: isSelected
-                      ? const Color(0xFF1E3A8A)
-                      : Theme.of(context).cardColor,
-                  width: 2,
-                ),
-                boxShadow: isSelected
-                    ? [
-                        BoxShadow(
-                          color: const Color(0xFF1E3A8A).withValues(alpha: 0.2),
-                          blurRadius: 8,
-                          offset: const Offset(0, 2),
-                        ),
-                      ]
-                    : null,
+                color: cardColor,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: borderColor, width: 1.5),
               ),
               child: Stack(
                 alignment: Alignment.center,
@@ -134,11 +137,11 @@ class _DayCarouselState extends State<DayCarousel> {
                   if (isCompleted)
                     Positioned(
                       top: 4,
-                      right: 4,
+                      right: 6,
                       child: Icon(
                         Icons.check,
-                        size: 14,
-                        color: Theme.of(context).colorScheme.primary,
+                        size: 13,
+                        color: primaryColor,
                       ),
                     ),
                   Column(
@@ -146,31 +149,39 @@ class _DayCarouselState extends State<DayCarousel> {
                     children: [
                       Text(
                         '${day.dayNumber}',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
+                          color: isSelected ? primaryColor : null,
                         ),
                       ),
                       const SizedBox(height: 4),
                       Container(
                         padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
+                          horizontal: 6,
                           vertical: 2,
                         ),
-                        decoration: isToday
+                        decoration: isToday && !isSelected
                             ? BoxDecoration(
-                                color: Theme.of(context).brightness == Brightness.dark
+                                color: isDark
                                     ? Colors.white.withValues(alpha: 0.2)
                                     : const Color(0xFF1A1A1A),
-                                borderRadius: BorderRadius.circular(12),
+                                borderRadius: BorderRadius.circular(10),
                               )
                             : null,
                         child: Text(
-                          dayDateString,
+                          subLabel,
                           style: TextStyle(
-                            fontSize: 11,
-                            color: isToday ? Colors.white : null,
+                            fontSize: 10,
+                            color: isLastDay
+                                ? primaryColor
+                                : isToday && !isSelected
+                                    ? Colors.white
+                                    : null,
+                            fontWeight: isLastDay ? FontWeight.w600 : null,
                           ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                     ],

--- a/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
@@ -1,10 +1,25 @@
+import 'dart:io';
+
 import 'package:fpdart/fpdart.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+// locale_notifier removed — localeProvider no longer used in this file
 import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/core/widgets/skeletons/skeletons.dart';
+import 'package:flutter_pecha/features/home/domain/entities/series.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_provider.dart';
+import 'package:flutter_pecha/features/home/presentation/screens/main_navigation_screen.dart';
+import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
+// routine_api_models not needed directly — TimeBlockRequest inferred via routineBlockToRequest
+import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
+import 'package:flutter_pecha/features/practice/data/utils/routine_api_mapper.dart';
+import 'package:flutter_pecha/features/practice/data/utils/routine_time_utils.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_api_providers.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/plans_providers.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
@@ -16,11 +31,14 @@ import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigatio
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import '../day_completion_bottom_sheet.dart';
-import '../plan_cover_image.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
+import '../celebration/day_celebration_modal.dart';
+import '../celebration/plan_celebration_modal.dart';
+import '../celebration/series_celebration_modal.dart';
 import '../day_carousel.dart';
 import 'activity_list.dart';
 import 'missed_days_badge.dart';
+import 'on_track_badge.dart';
 
 final _logger = AppLogger('PlanDetails');
 
@@ -67,7 +85,7 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PlanCoverImage(imageUrl: widget.plan.imageUrl ?? ''),
+                  _buildSeriesBreadcrumb(context),
                   _buildDayCarouselSection(language),
                   _buildDayContentSection(context, language),
                 ],
@@ -76,6 +94,41 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
           ),
           _buildStartReadingButton(context, localizations),
         ],
+      ),
+    );
+  }
+
+  /// Looks up which series (if any) this plan belongs to and returns a
+  /// breadcrumb like "FOUR NOBLE TRUTHS · PLAN 2 OF 4". Returns an empty
+  /// widget when the plan is standalone.
+  Widget _buildSeriesBreadcrumb(BuildContext context) {
+    final seriesAsync = ref.watch(seriesListFutureProvider);
+    final seriesEntry = seriesAsync.whenOrNull(
+      data: (either) => either.fold((_) => null, (list) {
+        for (final s in list) {
+          final idx = s.plans.indexWhere((p) => p.id == widget.plan.id);
+          if (idx >= 0) return (series: s, index: idx);
+        }
+        return null;
+      }),
+    );
+
+    if (seriesEntry == null) return const SizedBox.shrink();
+
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final color = isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      child: Text(
+        '${seriesEntry.series.title.toUpperCase()} · PLAN ${seriesEntry.index + 1} OF ${seriesEntry.series.plans.length}',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.8,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
       ),
     );
   }
@@ -123,38 +176,124 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
   }
 
   Future<void> _onDayCompleted(int dayNumber) async {
-    try {
-      final completionStatusEither = await ref.read(
-        userPlanDaysCompletionStatusProvider(widget.plan.id).future,
-      );
+    if (!mounted) return;
+    final isLastDay = dayNumber == widget.plan.totalDays;
 
-      completionStatusEither.fold(
-        (failure) {
-          _logger.error('Error fetching completion status: ${failure.message}');
-        },
-        (completionStatus) {
-          final completedDays = completionStatus.values.where((v) => v).length;
-
-          if (!mounted) return;
-
-          showModalBottomSheet(
-            context: context,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder:
-                (_) => DayCompletionBottomSheet(
-                  dayNumber: dayNumber,
-                  totalDays: widget.plan.totalDays,
-                  completedDays: completedDays,
-                  imageUrl: widget.plan.imageUrl,
-                  planTitle: widget.plan.title,
-                ),
-          );
-        },
-      );
-    } catch (e) {
-      _logger.error('Error showing day completion', e);
+    if (!isLastDay) {
+      _showDailyCelebration(dayNumber);
+      return;
     }
+
+    // Last day — determine series context. Await ensures data is loaded
+    // even if the user navigated here directly from the Practice tab.
+    ({Series series, int planIndex})? seriesEntry;
+    try {
+      final seriesResult = await ref.read(seriesListFutureProvider.future);
+      seriesResult.fold((_) {}, (list) {
+        for (final s in list) {
+          final idx = s.plans.indexWhere((p) => p.id == widget.plan.id);
+          if (idx >= 0) {
+            seriesEntry = (series: s, planIndex: idx);
+            break;
+          }
+        }
+      });
+    } catch (_) {}
+
+    if (seriesEntry == null) {
+      // Standalone plan — plan done, no next plan.
+      _showPlanCelebration(nextPlanTitle: null, onContinue: () {
+        if (mounted) Navigator.of(context).pop();
+      });
+      return;
+    }
+
+    final series = seriesEntry!.series;
+    final planIndex = seriesEntry!.planIndex;
+    final isLastPlan = planIndex >= series.plans.length - 1;
+
+    if (isLastPlan) {
+      _showSeriesCelebration(series);
+    } else {
+      final nextPlan = series.plans[planIndex + 1];
+      // Resolve the enrolled UserPlan for the next plan.
+      UserPlansModel? nextUserPlan;
+      try {
+        final result = await ref.read(userPlansFutureProvider.future);
+        result.fold((_) {}, (response) {
+          final matches =
+              response.userPlans.where((p) => p.id == nextPlan.id).toList();
+          if (matches.isNotEmpty) nextUserPlan = matches.first;
+        });
+      } catch (_) {}
+
+      if (!mounted) return;
+      _showPlanCelebration(
+        nextPlanTitle: nextPlan.title,
+        onContinue: () {
+          Navigator.of(context).pop(); // dismiss modal
+          if (nextUserPlan != null) {
+            final startDate =
+                nextUserPlan!.startDate ?? nextUserPlan!.startedAt;
+            context.push(
+              '/practice/details',
+              extra: {
+                'plan': nextUserPlan,
+                'selectedDay': 1,
+                'startDate': startDate,
+              },
+            );
+            // Refresh routine so it auto-advances to the next plan.
+            ref.invalidate(userRoutineProvider);
+          }
+        },
+      );
+    }
+  }
+
+  void _showDailyCelebration(int dayNumber) {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (_) => DayCelebrationModal(
+        dayNumber: dayNumber,
+        totalDays: widget.plan.totalDays,
+        onDismiss: () => Navigator.of(context).pop(),
+      ),
+    );
+  }
+
+  void _showPlanCelebration({
+    required String? nextPlanTitle,
+    required VoidCallback onContinue,
+  }) {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => PlanCelebrationModal(
+        planTitle: widget.plan.title,
+        totalDays: widget.plan.totalDays,
+        nextPlanTitle: nextPlanTitle,
+        onContinue: onContinue,
+      ),
+    );
+  }
+
+  void _showSeriesCelebration(Series series) {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => SeriesCelebrationModal(
+        series: series,
+        onFindAnotherSeries: () {
+          Navigator.of(context).pop();
+          // Switch to Home tab so user can discover more series.
+          ref.read(mainNavigationIndexProvider.notifier).state =
+              MainTab.home.index;
+        },
+        onStay: () => Navigator.of(context).pop(),
+      ),
+    );
   }
 
   AppBar _buildAppBar(
@@ -163,8 +302,22 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     AppLocalizations localizations,
   ) {
     return AppBar(
-      title: Text(widget.plan.title, style: TextStyle(fontSize: 20)),
+      title: Text(
+        widget.plan.title,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      centerTitle: true,
       elevation: 0,
+      scrolledUnderElevation: 0,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.more_horiz),
+          tooltip: 'Options',
+          onPressed: () => _showOptionsSheet(context),
+        ),
+      ],
     );
   }
 
@@ -258,6 +411,8 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
             selectedDay,
             completionStatus.valueOrNull,
           ),
+          if (selectedDay == 1 && widget.plan.description.trim().isNotEmpty)
+            _buildAboutThisPlan(context),
           userPlanDayContent.when(
             data: (dayContentEither) {
               return dayContentEither.fold(
@@ -309,36 +464,89 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     );
   }
 
+  Widget _buildAboutThisPlan(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final labelColor = isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 20, bottom: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.l10n.about_this_plan.toUpperCase(),
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: labelColor,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            widget.plan.description,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: isDark ? Colors.white70 : Colors.black87,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+
   Widget _buildDayTitle(
     BuildContext context,
     String language,
     int day,
     Either<Failure, Map<int, bool>>? completionStatusEither,
   ) {
-    // Extract Map from Either, or null if not available
     final completionStatus = completionStatusEither?.fold(
-      (failure) => null,
+      (_) => null,
       (status) => status,
     );
+    final l10n = context.l10n;
+    final totalDays = widget.plan.totalDays;
+    final isLastDay = day == totalDays;
+    final isFirstDay = day == 1;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Text(
-          "Day $day of ${widget.plan.totalDays}",
-          style: TextStyle(
+          'Day $day of $totalDays',
+          style: const TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.bold,
-            fontFamily: "Inter",
+            fontFamily: 'Inter',
           ),
         ),
-        if (completionStatus != null)
-          MissedDaysBadge(
-            planStartDate: widget.startDate,
-            userJoinDate: widget.plan.startedAt,
-            totalDays: widget.plan.totalDays,
-            completionStatus: completionStatus,
-          ),
+        if (isLastDay)
+          _StatusBadge(
+            label: l10n.plan_status_last_day,
+            color: Theme.of(context).colorScheme.primary,
+          )
+        else if (isFirstDay)
+          _StatusBadge(
+            label: l10n.plan_status_just_started,
+            color: Colors.green,
+          )
+        else if (completionStatus != null)
+          if (PlanUtils.calculateMissedDays(
+                widget.startDate,
+                widget.plan.startedAt,
+                totalDays,
+                completionStatus,
+              ) >
+              0)
+            MissedDaysBadge(
+              planStartDate: widget.startDate,
+              userJoinDate: widget.plan.startedAt,
+              totalDays: totalDays,
+              completionStatus: completionStatus,
+            )
+          else
+            const OnTrackBadge(),
       ],
     );
   }
@@ -415,31 +623,449 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     }
   }
 
-  // TODO: Wire up this dialog to a menu button in the AppBar
-  // ignore: unused_element
+  // ─── 3-dot options sheet ─────────────────────────────────────────────────
+
+  void _showOptionsSheet(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    // Resolve series membership so "About" can navigate immediately.
+    final seriesAsync = ref.read(seriesListFutureProvider);
+    ({Series series, int index})? seriesEntry;
+    seriesAsync.whenOrNull(
+      data: (either) => either.fold((_) => null, (list) {
+        for (final s in list) {
+          final idx = s.plans.indexWhere((p) => p.id == widget.plan.id);
+          if (idx >= 0) {
+            seriesEntry = (series: s, index: idx);
+            return;
+          }
+        }
+      }),
+    );
+
+    // Resolve reminder time for the subtitle on the Reminders row.
+    final routineAsync = ref.read(userRoutineProvider);
+    RoutineBlock? planBlock;
+    routineAsync.whenOrNull(
+      data: (data) {
+        if (data == null) return;
+        for (final b in data.blocks) {
+          if (b.items.any((i) => i.id == widget.plan.id)) {
+            planBlock = b;
+            break;
+          }
+        }
+      },
+    );
+    final reminderSubtitle = planBlock == null
+        ? null
+        : planBlock!.notificationEnabled
+            ? formatRoutineTime(planBlock!.time)
+            : l10n.reminders_turned_off;
+
+    showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: (isDark ? Colors.white : Colors.black)
+                      .withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 8),
+              // About
+              ListTile(
+                leading: const Icon(Icons.info_outline),
+                title: Text(l10n.plan_options_about),
+                onTap: () {
+                  Navigator.of(sheetCtx).pop();
+                  if (seriesEntry != null) {
+                    context.pushNamed(
+                      'home-series-detail',
+                      pathParameters: {'id': seriesEntry!.series.id},
+                      extra: {'series': seriesEntry!.series},
+                    );
+                  } else {
+                    final plan = Plan(
+                      id: widget.plan.id,
+                      title: widget.plan.title,
+                      description: widget.plan.description,
+                      language: widget.plan.language,
+                      authorId: '',
+                      totalDays: widget.plan.totalDays,
+                      difficulty: DifficultyLevel.beginner,
+                      coverImageUrl: widget.plan.imageUrl,
+                      startDate: widget.plan.startDate,
+                    );
+                    context.pushNamed(
+                      'practice-plan-info',
+                      extra: {'plan': plan},
+                    );
+                  }
+                },
+              ),
+              // Reminders
+              ListTile(
+                leading: const Icon(Icons.notifications_outlined),
+                title: Text(l10n.plan_options_reminders),
+                subtitle: reminderSubtitle != null
+                    ? Text(reminderSubtitle)
+                    : null,
+                onTap: () {
+                  Navigator.of(sheetCtx).pop();
+                  _showRemindersSheet(context);
+                },
+              ),
+              // Unenroll
+              ListTile(
+                leading: Icon(
+                  Icons.exit_to_app,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                title: Text(
+                  l10n.plan_unenroll,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.of(sheetCtx).pop();
+                  _showUnenrollDialog(context);
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  // ─── Reminders sheet ─────────────────────────────────────────────────────
+
+  void _showRemindersSheet(BuildContext context) {
+    final l10n = context.l10n;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    final routineData = ref.read(userRoutineProvider).valueOrNull;
+    if (routineData == null ||
+        routineData.apiRoutineId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.reminders_not_in_routine)),
+      );
+      return;
+    }
+
+    RoutineBlock? planBlock;
+    for (final b in routineData.blocks) {
+      if (b.items.any((i) => i.id == widget.plan.id)) {
+        planBlock = b;
+        break;
+      }
+    }
+
+    if (planBlock == null || planBlock.apiTimeBlockId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.reminders_not_in_routine)),
+      );
+      return;
+    }
+
+    final block = planBlock;
+    final routineId = routineData.apiRoutineId!;
+
+    TimeOfDay selectedTime = block.time;
+    bool reminderEnabled = block.notificationEnabled;
+    bool isSaving = false;
+
+    final use24h = MediaQuery.of(context).alwaysUse24HourFormat;
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) {
+        return StatefulBuilder(
+          builder: (ctx, setSheetState) {
+            Future<void> pickTime() async {
+              TimeOfDay? picked;
+              if (Platform.isIOS) {
+                final now = DateTime.now();
+                var selected = DateTime(
+                  now.year,
+                  now.month,
+                  now.day,
+                  selectedTime.hour,
+                  selectedTime.minute,
+                );
+                final confirmed = await showCupertinoModalPopup<bool>(
+                  context: ctx,
+                  builder: (popupCtx) => CupertinoTheme(
+                    data: CupertinoThemeData(
+                      brightness:
+                          isDark ? Brightness.dark : Brightness.light,
+                    ),
+                    child: Container(
+                      height: 300,
+                      decoration: BoxDecoration(
+                        color: isDark
+                            ? const Color(0xFF1C1C1E)
+                            : Colors.white,
+                        borderRadius: const BorderRadius.vertical(
+                          top: Radius.circular(20),
+                        ),
+                      ),
+                      child: SafeArea(
+                        top: false,
+                        child: Column(
+                          children: [
+                            Container(
+                              margin: const EdgeInsets.only(top: 10),
+                              width: 40,
+                              height: 4,
+                              decoration: BoxDecoration(
+                                color: Colors.grey.withValues(alpha: 0.4),
+                                borderRadius: BorderRadius.circular(2),
+                              ),
+                            ),
+                            Row(
+                              mainAxisAlignment:
+                                  MainAxisAlignment.spaceBetween,
+                              children: [
+                                CupertinoButton(
+                                  onPressed: () =>
+                                      Navigator.of(popupCtx).pop(false),
+                                  child: Text(l10n.cancel),
+                                ),
+                                CupertinoButton(
+                                  onPressed: () {
+                                    HapticFeedback.mediumImpact();
+                                    Navigator.of(popupCtx).pop(true);
+                                  },
+                                  child: Text(l10n.done),
+                                ),
+                              ],
+                            ),
+                            Expanded(
+                              child: CupertinoDatePicker(
+                                mode: CupertinoDatePickerMode.time,
+                                initialDateTime: selected,
+                                use24hFormat: use24h,
+                                onDateTimeChanged: (dt) => selected = dt,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+                if (confirmed == true) {
+                  picked = TimeOfDay(
+                    hour: selected.hour,
+                    minute: selected.minute,
+                  );
+                }
+              } else {
+                picked = await showTimePicker(
+                  context: ctx,
+                  initialTime: selectedTime,
+                );
+              }
+              if (picked != null) {
+                setSheetState(() => selectedTime = picked!);
+              }
+            }
+
+            Future<void> save() async {
+              setSheetState(() => isSaving = true);
+              final updated = block.copyWith(
+                time: selectedTime,
+                notificationEnabled: reminderEnabled,
+              );
+              final request = routineBlockToRequest(updated);
+              final result = await ref.read(updateTimeBlockUseCaseProvider)(
+                routineId,
+                block.apiTimeBlockId!,
+                request,
+              );
+              if (!mounted) return;
+              result.fold(
+                (_) {
+                  setSheetState(() => isSaving = false);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(l10n.unenrollError)),
+                  );
+                },
+                (_) {
+                  Navigator.of(sheetCtx).pop();
+                  ref.invalidate(userRoutineProvider);
+                  final msg = reminderEnabled
+                      ? l10n.reminders_updated(
+                          formatRoutineTime(selectedTime),
+                        )
+                      : l10n.reminders_turned_off;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(msg),
+                      behavior: SnackBarBehavior.floating,
+                    ),
+                  );
+                },
+              );
+            }
+
+            return Padding(
+              padding: EdgeInsets.only(
+                bottom: MediaQuery.of(ctx).viewInsets.bottom,
+              ),
+              child: SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Center(
+                        child: Container(
+                          width: 40,
+                          height: 4,
+                          decoration: BoxDecoration(
+                            color: (isDark ? Colors.white : Colors.black)
+                                .withValues(alpha: 0.2),
+                            borderRadius: BorderRadius.circular(2),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        l10n.reminders_daily_title,
+                        style: Theme.of(ctx).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.reminders_subtitle,
+                        style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                          color: isDark ? Colors.white60 : Colors.black54,
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      // Time tap row
+                      InkWell(
+                        onTap: reminderEnabled ? pickTime : null,
+                        borderRadius: BorderRadius.circular(12),
+                        child: Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 14,
+                          ),
+                          decoration: BoxDecoration(
+                            color: isDark
+                                ? Colors.white.withValues(alpha: 0.07)
+                                : Colors.black.withValues(alpha: 0.04),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            formatRoutineTime(selectedTime),
+                            style: Theme.of(ctx)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: reminderEnabled
+                                  ? null
+                                  : (isDark
+                                      ? Colors.white38
+                                      : Colors.black26),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      // Remind me toggle
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            l10n.reminders_remind_me,
+                            style: Theme.of(ctx).textTheme.bodyLarge,
+                          ),
+                          Switch(
+                            value: reminderEnabled,
+                            onChanged: (v) =>
+                                setSheetState(() => reminderEnabled = v),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      // Save button
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton(
+                          onPressed: isSaving ? null : save,
+                          style: FilledButton.styleFrom(
+                            backgroundColor: isDark
+                                ? Colors.white
+                                : Colors.black,
+                            foregroundColor: isDark
+                                ? Colors.black
+                                : Colors.white,
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          child: isSaving
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : Text(l10n.save),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
   void _showUnenrollDialog(BuildContext context) {
-    final localizations = context.l10n;
-    final locale = ref.watch(localeProvider);
-    final language = locale.languageCode;
-    final fontSize = language == 'bo' || language == 'BO' ? 16.0 : 14.0;
+    final l10n = context.l10n;
     showDialog(
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title: Text(localizations.plan_unenroll),
-          content: Text(
-            language == 'bo' || language == 'BO'
-                ? '${widget.plan.title} ${localizations.unenroll_confirmation}\n\n ${localizations.unenroll_message}'
-                : '${localizations.unenroll_confirmation} "${widget.plan.title}"?\n\n ${localizations.unenroll_message}',
-            style: TextStyle(fontSize: fontSize),
-          ),
+          title: Text(l10n.plan_unenroll_title),
+          content: Text(l10n.plan_unenroll_body),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(dialogContext).pop(),
-              child: Text(
-                localizations.cancel,
-                style: TextStyle(fontSize: fontSize),
-              ),
+              child: Text(l10n.cancel),
             ),
             FilledButton(
               onPressed: () {
@@ -449,10 +1075,7 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
               style: FilledButton.styleFrom(
                 backgroundColor: Theme.of(context).colorScheme.error,
               ),
-              child: Text(
-                localizations.plan_unenroll,
-                style: TextStyle(fontSize: fontSize),
-              ),
+              child: Text(l10n.plan_unenroll),
             ),
           ],
         );
@@ -460,7 +1083,6 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     );
   }
 
-  // ignore: unused_element
   Future<void> _handleUnenroll() async {
     try {
       final resultEither = await ref.read(
@@ -591,6 +1213,34 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small outlined pill badge used for plan day-status labels
+/// ("Just started", "Last day", etc.).
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withValues(alpha: 0.6)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          color: color,
+          fontWeight: FontWeight.w500,
         ),
       ),
     );


### PR DESCRIPTION
feat: implement series/plan discovery, celebrations, and 3-dot management overlays (#269)

- Rebuild Home screen with personalized greeting, FeaturedSeriesCard, and ContinueTodayCard
- Rebuild Series Detail screen with hero image, About section, creator info, and sticky Enroll button
- Add 3-dot options sheet (About, Reminders, Unenroll) to Plan landing screen
- Add Reminders sheet with Cupertino/Material time picker and toggle
- Add series breadcrumb, "ABOUT THIS PLAN" section, and ON TRACK!/status badges to Plan landing
- Implement Daily, Plan, and Series celebration modals matching Figma design
- Polish Day Carousel with Last day label and theme-aware selection style
- Add 35+ localization keys across EN, Tibetan, and Chinese for all new UI