### PR TITLE
feat: add Read Full Text footer to reader collapsed state

### DIFF
--- a/lib/core/l10n/app_bo.arb
+++ b/lib/core/l10n/app_bo.arb
@@ -586,5 +586,8 @@
   "main_text": "Main Text",
   "second_version": "Second Version",
   "second_version_msg": "The second version will appear below each verse of the main text.",
-  "version": "Versions"
+  "version": "Versions",
+  "read_full_text": "Read Full Text",
+  "reader_source_label": "Source",
+  "reader_license_label": "License"
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -642,5 +642,8 @@
   "main_text": "Main Text",
   "second_version": "Second Version",
   "second_version_msg": "The second version will appear below each verse of the main text.",
-  "version": "Versions"
+  "version": "Versions",
+  "read_full_text": "Read Full Text",
+  "reader_source_label": "Source",
+  "reader_license_label": "License"
 }

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -586,5 +586,8 @@
   "main_text": "主文",
   "second_version": "第二種版本",
   "second_version_msg": "第二種翻譯版本會逐句出現在主文的下方",
-  "version": "版本"
+  "version": "Versions",
+  "read_full_text": "Read Full Text",
+  "reader_source_label": "Source",
+  "reader_license_label": "License"
 }

--- a/lib/core/l10n/generated/app_localizations.dart
+++ b/lib/core/l10n/generated/app_localizations.dart
@@ -2661,6 +2661,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Versions'**
   String get version;
+
+  /// No description provided for @read_full_text.
+  ///
+  /// In en, this message translates to:
+  /// **'Read Full Text'**
+  String get read_full_text;
+
+  /// No description provided for @reader_source_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Source'**
+  String get reader_source_label;
+
+  /// No description provided for @reader_license_label.
+  ///
+  /// In en, this message translates to:
+  /// **'License'**
+  String get reader_license_label;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/core/l10n/generated/app_localizations_bo.dart
+++ b/lib/core/l10n/generated/app_localizations_bo.dart
@@ -1419,4 +1419,13 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get version => 'Versions';
+
+  @override
+  String get read_full_text => 'Read Full Text';
+
+  @override
+  String get reader_source_label => 'Source';
+
+  @override
+  String get reader_license_label => 'License';
 }

--- a/lib/core/l10n/generated/app_localizations_en.dart
+++ b/lib/core/l10n/generated/app_localizations_en.dart
@@ -1421,4 +1421,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get version => 'Versions';
+
+  @override
+  String get read_full_text => 'Read Full Text';
+
+  @override
+  String get reader_source_label => 'Source';
+
+  @override
+  String get reader_license_label => 'License';
 }

--- a/lib/core/l10n/generated/app_localizations_zh.dart
+++ b/lib/core/l10n/generated/app_localizations_zh.dart
@@ -1360,5 +1360,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get second_version_msg => '第二種翻譯版本會逐句出現在主文的下方';
 
   @override
-  String get version => '版本';
+  String get version => 'Versions';
+
+  @override
+  String get read_full_text => 'Read Full Text';
+
+  @override
+  String get reader_source_label => 'Source';
+
+  @override
+  String get reader_license_label => 'License';
 }

--- a/lib/features/reader/constants/reader_constants.dart
+++ b/lib/features/reader/constants/reader_constants.dart
@@ -49,7 +49,7 @@ class ReaderConstants {
   static const double segmentHorizontalPadding = 12.0;
   static const double segmentVerticalPadding = 6.0;
   static const double segmentNumberWidth = 28.0;
-  static const double segmentBorderRadius = 8.0;
+  static const double segmentBorderRadius = 16.0;
 
   /// Segment numbers render at a fraction of the segment's content font size.
   static const double segmentNumberFontScale = 0.6;

--- a/lib/features/reader/presentation/widgets/reader_content/read_full_text_footer.dart
+++ b/lib/features/reader/presentation/widgets/reader_content/read_full_text_footer.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/features/reader/constants/reader_constants.dart';
+import 'package:flutter_pecha/features/texts/data/models/text_detail.dart';
+
+/// Footer shown at the end of the active (plan/target) segments when the reader
+/// is in its collapsed state. Exposes a "Read Full Text" action that reveals the
+/// rest of the text, followed by a small metadata block (title / source /
+/// license) sourced from [textDetail].
+class ReadFullTextFooter extends StatelessWidget {
+  final TextDetail? textDetail;
+  final VoidCallback onReadFullText;
+
+  const ReadFullTextFooter({
+    super.key,
+    required this.textDetail,
+    required this.onReadFullText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+
+    final sourceLink = textDetail?.sourceLink;
+    final license = textDetail?.license;
+    final title = textDetail?.title;
+
+    final metadataStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurface.withValues(alpha: 0.45),
+    );
+
+    return Padding(
+      // Extra bottom padding so the footer (and its button) clears the
+      // floating audio player widget pinned at the bottom of the reader.
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 16),
+      child: Column(
+        children: [
+          SizedBox(
+            width: double.infinity,
+            child: Material(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(
+                ReaderConstants.segmentBorderRadius,
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                onTap: onReadFullText,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Center(
+                    child: Text(
+                      l10n.read_full_text,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (title != null && title.isNotEmpty)
+            Text(title, style: metadataStyle, textAlign: TextAlign.center),
+          if (sourceLink != null && sourceLink.isNotEmpty)
+            Text(
+              '${l10n.reader_source_label}: $sourceLink',
+              style: metadataStyle,
+              textAlign: TextAlign.center,
+            ),
+          if (license != null && license.isNotEmpty)
+            Text(
+              '${l10n.reader_license_label}: $license',
+              style: metadataStyle,
+              textAlign: TextAlign.center,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/reader/presentation/widgets/reader_content/reader_content_part.dart
+++ b/lib/features/reader/presentation/widgets/reader_content/reader_content_part.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/reader/constants/reader_constants.dart';
+import 'package:flutter_pecha/features/reader/data/models/flattened_content.dart';
 import 'package:flutter_pecha/features/reader/data/models/flattened_item.dart';
 import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
 import 'package:flutter_pecha/features/reader/data/models/reader_slot_config.dart';
@@ -14,6 +15,7 @@ import 'package:flutter_pecha/features/reader/presentation/providers/reader_noti
 import 'package:flutter_pecha/features/reader/presentation/providers/reader_providers.dart';
 import 'package:flutter_pecha/features/reader/presentation/providers/reader_secondary_content_provider.dart';
 import 'package:flutter_pecha/features/reader/presentation/widgets/reader_content/interlinear_segment_item.dart';
+import 'package:flutter_pecha/features/reader/presentation/widgets/reader_content/read_full_text_footer.dart';
 import 'package:flutter_pecha/features/reader/presentation/widgets/reader_content/section_header.dart';
 import 'package:flutter_pecha/features/reader/presentation/widgets/reader_content/segment_item.dart';
 import 'package:flutter_pecha/features/reader/presentation/widgets/reader_content/segment_skeleton.dart';
@@ -66,8 +68,29 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
   bool _hasUserInteracted = false;
   bool _isProgrammaticScroll = false;
 
-  // Grey-out feature: show only initial segment, disable on first user scroll
-  final bool _enableGreyOut = true;
+  // Collapsed view: when the reader opens pointing at a set of "active"
+  // segments (plan subtask / deep-link / search target), it first renders ONLY
+  // those segments followed by a "Read Full Text" footer. Tapping the footer
+  // expands to the full text for the rest of the session — there is no way back
+  // to the collapsed view without leaving and re-entering the reader.
+  bool _isExpanded = false;
+
+  /// Ordered list of segment ids considered "active" for this navigation: the
+  /// plan subtask's segment range, or the single target segment.
+  List<String> get _activeSegmentIds {
+    final visible = widget.visibleSegmentIds;
+    if (visible != null && visible.isNotEmpty) return visible;
+    final initial = widget.initialSegmentId;
+    if (initial != null) return [initial];
+    return const [];
+  }
+
+  /// True when the reader was opened pointing at specific segments, so the
+  /// collapsed "active segments only" view applies.
+  bool get _hasActiveSegments => _activeSegmentIds.isNotEmpty;
+
+  /// True while only the active segments are shown (before "Read Full Text").
+  bool get _isCollapsed => _hasActiveSegments && !_isExpanded;
 
   // Initial alignment segment for the secondary stream. Computed lazily the
   // first time the secondary is needed, then frozen — the secondary notifier
@@ -148,6 +171,10 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
   }
 
   void _checkPaginationThresholds() {
+    // No pagination while collapsed — only the active segments are on screen,
+    // so the short list would otherwise immediately trip the next-page
+    // threshold and fetch segments the user hasn't asked to see yet.
+    if (_isCollapsed) return;
     // Skip pagination during programmatic scroll (e.g. initial scroll animation)
     // to prevent false triggers from stale visible positions
     if (_isProgrammaticScroll) return;
@@ -353,6 +380,32 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
     }
   }
 
+  /// Expand from the collapsed (active-segments-only) view to the full text.
+  /// Keeps the active block in view by jumping to the first active segment in
+  /// the now-full list, and re-enables normal pagination/scroll behaviour.
+  void _expandFullText() {
+    if (_isExpanded) return;
+    final firstActiveId =
+        _activeSegmentIds.isNotEmpty ? _activeSegmentIds.first : null;
+
+    setState(() => _isExpanded = true);
+
+    if (firstActiveId == null) return;
+    // Suppress the one-shot initial-scroll effect so it doesn't also fire.
+    _hasScrolledToInitial = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_itemScrollController.isAttached) return;
+      final content = ref.read(readerNotifierProvider(widget.params)).content;
+      final index = content?.getSegmentIndex(firstActiveId);
+      if (index == null) return;
+      _isProgrammaticScroll = true;
+      _itemScrollController.jumpTo(index: index);
+      Future.delayed(const Duration(milliseconds: 100), () {
+        _isProgrammaticScroll = false;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(readerNotifierProvider(widget.params));
@@ -385,8 +438,11 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
             )
             : null;
 
-    // Handle initial scroll to segment
-    if (!_hasScrolledToInitial &&
+    // Handle initial scroll to segment. Skipped while collapsed — the active
+    // segments already sit at the top of the collapsed list, and the content
+    // indices used for scrolling don't line up with the filtered list anyway.
+    if (!_isCollapsed &&
+        !_hasScrolledToInitial &&
         state.content != null &&
         state.content!.isNotEmpty &&
         widget.initialSegmentId != null) {
@@ -430,10 +486,18 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
       return const Center(child: CircularProgressIndicator());
     }
 
+    // Collapsed view: render only the active segments + a "Read Full Text"
+    // footer. The extra trailing item is the footer.
+    final bool isCollapsed = _isCollapsed;
+    final List<FlattenedItem> collapsedItems =
+        isCollapsed ? _buildCollapsedItems(content) : const [];
+    final int listItemCount =
+        isCollapsed ? collapsedItems.length + 1 : content.itemCount;
+
     return Column(
       children: [
-        // Loading previous indicator
-        if (state.isLoadingPrevious)
+        // Loading previous indicator (never while collapsed)
+        if (!isCollapsed && state.isLoadingPrevious)
           const SegmentSkeletonList(count: 1, linesPerSegment: 2),
         // Main content list with user gesture detection
         Expanded(
@@ -453,9 +517,28 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
             child: ScrollablePositionedList.builder(
               itemScrollController: _itemScrollController,
               itemPositionsListener: _itemPositionsListener,
-              itemCount: content.itemCount,
+              itemCount: listItemCount,
               padding: const EdgeInsets.only(bottom: 60),
               itemBuilder: (context, index) {
+                if (isCollapsed) {
+                  // Trailing item is the "Read Full Text" footer.
+                  if (index >= collapsedItems.length) {
+                    return ReadFullTextFooter(
+                      textDetail: state.textDetail,
+                      onReadFullText: _expandFullText,
+                    );
+                  }
+                  return _buildItem(
+                    item: collapsedItems[index],
+                    state: state,
+                    dualSecondaryEnabled: dualSettings.secondaryEnabled,
+                    secondarySlot: dualSettings.secondary,
+                    secondaryState: secondaryState,
+                    onSegmentTap:
+                        (segment) => notifier.toggleSegmentSelection(segment),
+                  );
+                }
+
                 final item = content.getItemAt(index);
                 if (item == null) return const SizedBox.shrink();
 
@@ -473,22 +556,25 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
           ),
         ),
 
-        // Loading next indicator
-        if (state.isLoadingNext)
+        // Loading next indicator (never while collapsed)
+        if (!isCollapsed && state.isLoadingNext)
           const SegmentSkeletonList(count: 1, linesPerSegment: 2),
       ],
     );
   }
 
-  bool _isSegmentGreyedOut(String segmentId) {
-    if (widget.visibleSegmentIds != null &&
-        widget.visibleSegmentIds!.isNotEmpty) {
-      return !widget.visibleSegmentIds!.contains(segmentId);
-    }
-    if (widget.initialSegmentId != null) {
-      return widget.initialSegmentId != segmentId;
-    }
-    return false;
+  /// The subset of loaded items that are active segments, in reading order.
+  /// Used to render the collapsed view before "Read Full Text" is tapped.
+  List<FlattenedItem> _buildCollapsedItems(FlattenedContent content) {
+    final activeSet = _activeSegmentIds.toSet();
+    return content.items
+        .where(
+          (item) =>
+              item.isSegment &&
+              item.segmentId != null &&
+              activeSet.contains(item.segmentId),
+        )
+        .toList();
   }
 
   Widget _buildItem({
@@ -514,8 +600,6 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
         final isSelected =
             state.selectedSegment?.segmentId == segment.segmentId;
         final isHighlighted = state.highlightedSegmentId == segment.segmentId;
-        final isGreyedOut =
-            _enableGreyOut && _isSegmentGreyedOut(segment.segmentId);
 
         if (dualSecondaryEnabled) {
           return InterlinearSegmentItem(
@@ -529,7 +613,6 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
             isSelected: isSelected,
             isHighlighted: isHighlighted,
             highlightSource: state.highlightSource,
-            isGreyedOut: isGreyedOut,
             onTap: () => onSegmentTap(segment),
           );
         }
@@ -539,7 +622,6 @@ class _ReaderContentPartState extends ConsumerState<ReaderContentPart> {
           depth: depth,
           language: widget.language,
           isSelected: isSelected,
-          isGreyedOut: isGreyedOut,
           onTap: () {
             HapticFeedback.lightImpact();
             onSegmentTap(segment);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -663,10 +663,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.35"
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -929,10 +929,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      sha256: "956c16a42c0c708f914021666ffcd8265dde36e673c9fa68c81f7d085d9774ad"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+6"
+    version: "0.8.13+3"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1097,26 +1097,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1655,10 +1655,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.6"
   time:
     dependency: transitive
     description:
@@ -1916,5 +1916,5 @@ packages:
     source: hosted
     version: "9.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"


### PR DESCRIPTION
- Introduce ReadFullTextFooter widget shown at the end of active segments, exposing a "Read Full Text" action plus title/source/license metadata.
- Wire it into the reader content and add the supporting l10n keys.