### PR TITLE
fix : routine language error

### DIFF
--- a/lib/features/practice/data/models/routine_api_models.dart
+++ b/lib/features/practice/data/models/routine_api_models.dart
@@ -70,6 +70,8 @@ class SessionDTO {
   final String language;
   final ImageModel? image;
   final int displayOrder;
+  final DateTime? startDate;
+  final DateTime? startedAt;
 
   const SessionDTO({
     required this.id,
@@ -79,6 +81,8 @@ class SessionDTO {
     required this.language,
     this.image,
     required this.displayOrder,
+    this.startDate,
+    this.startedAt,
   });
 
   String? get imageUrl => image?.displayUrl;
@@ -94,6 +98,12 @@ class SessionDTO {
       language: json['language'] as String,
       image: ImageModel.fromJsonMap(json),
       displayOrder: json['display_order'] as int,
+      startDate: json['start_date'] != null
+          ? DateTime.tryParse(json['start_date'] as String)
+          : null,
+      startedAt: json['started_at'] != null
+          ? DateTime.tryParse(json['started_at'] as String)
+          : null,
     );
   }
 }

--- a/lib/features/practice/data/models/routine_model.dart
+++ b/lib/features/practice/data/models/routine_model.dart
@@ -13,6 +13,8 @@ class RoutineItem {
   final ResponsiveImage? coverImage;
   final RoutineItemType type;
   final DateTime? enrolledAt;
+  final String? language;
+  final DateTime? startDate;
 
   const RoutineItem({
     required this.id,
@@ -20,6 +22,8 @@ class RoutineItem {
     this.coverImage,
     required this.type,
     this.enrolledAt,
+    this.language,
+    this.startDate,
   });
 
   /// Smallest cover URL — legacy persistence and notifications.
@@ -32,6 +36,8 @@ class RoutineItem {
     'imageUrl': imageUrl,
     'type': type.name,
     'enrolledAt': enrolledAt?.toIso8601String(),
+    if (language != null) 'language': language,
+    if (startDate != null) 'startDate': startDate!.toIso8601String(),
   };
 
   /// Safely parses a [RoutineItem] from JSON with null checks and fallbacks.
@@ -52,6 +58,8 @@ class RoutineItem {
       coverImage: _parseCoverImage(json),
       type: _parseRoutineItemType(json['type']),
       enrolledAt: _parseDateTime(json['enrolledAt']),
+      language: json['language'] as String?,
+      startDate: _parseDateTime(json['startDate']),
     );
   }
 

--- a/lib/features/practice/data/utils/routine_api_mapper.dart
+++ b/lib/features/practice/data/utils/routine_api_mapper.dart
@@ -32,6 +32,9 @@ RoutineItem routineItemFromSessionDto(SessionDTO s) {
       SessionType.plan => RoutineItemType.plan,
       SessionType.recitation => RoutineItemType.recitation,
     },
+    enrolledAt: s.startedAt,
+    language: s.language,
+    startDate: s.startDate,
   );
 }
 

--- a/lib/features/practice/presentation/widgets/routine_filled_state.dart
+++ b/lib/features/practice/presentation/widgets/routine_filled_state.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/features/notifications/data/models/notification_nav.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/use_case_providers.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_track/enrolled_plan_status_indicator.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_track/plan_date_range_label.dart';
@@ -212,7 +214,11 @@ class _RoutineBlockSection extends ConsumerWidget {
     WidgetRef ref,
     RoutineItem item,
   ) async {
-    final userPlan = await _resolveUserPlan(ref, item.id);
+    final userPlan = await _resolveUserPlan(
+      ref,
+      item.id,
+      language: item.language,
+    );
 
     if (userPlan == null) {
       if (context.mounted) {
@@ -248,20 +254,41 @@ class _RoutineBlockSection extends ConsumerWidget {
     );
   }
 
-  /// Resolves the user plan from cached state, with a fallback refresh.
-  Future<dynamic> _resolveUserPlan(WidgetRef ref, String planId) async {
-    var plans = ref.read(myPlansPaginatedProvider).plans;
-    var userPlan = plans.where((p) => p.id == planId).firstOrNull;
+  /// Resolves the [UserPlansModel] for a routine plan item.
+  ///
+  /// When the plan's language matches the current app locale the cached
+  /// [myPlansPaginatedProvider] is used (instant, no network). Otherwise the
+  /// plan is fetched directly from the API in its own language.
+  Future<UserPlansModel?> _resolveUserPlan(
+    WidgetRef ref,
+    String planId, {
+    String? language,
+  }) async {
+    final currentLocale = ref.read(localeProvider).languageCode;
+    final isSameLanguage = language == null ||
+        language.toLowerCase() == currentLocale.toLowerCase();
 
-    // Safety net: refresh if plan not found (handles edge cases like
-    // enrollment via different flow or stale cache)
-    if (userPlan == null) {
-      await ref.read(myPlansPaginatedProvider.notifier).refresh();
-      plans = ref.read(myPlansPaginatedProvider).plans;
-      userPlan = plans.where((p) => p.id == planId).firstOrNull;
+    if (isSameLanguage) {
+      var plans = ref.read(myPlansPaginatedProvider).plans;
+      var userPlan = plans.where((p) => p.id == planId).firstOrNull;
+
+      if (userPlan == null) {
+        await ref.read(myPlansPaginatedProvider.notifier).refresh();
+        plans = ref.read(myPlansPaginatedProvider).plans;
+        userPlan = plans.where((p) => p.id == planId).firstOrNull;
+      }
+
+      return userPlan;
     }
 
-    return userPlan;
+    // Plan was enrolled in a different language — fetch directly.
+    final repo = ref.read(userPlansDomainRepositoryProvider);
+    final result = await repo.getUserPlans(language: language);
+    return result.fold(
+      (_) => null,
+      (response) =>
+          response.userPlans.where((p) => p.id == planId).firstOrNull,
+    );
   }
 
   /// Resolves the enrolled [UserPlansModel] for a plan-type routine item from


### PR DESCRIPTION
Problem:

The routine screen shows plans in all languages, but when you tap a plan to open it, the app looks up that plan's details from a cache that only holds plans in the current app language. So if you enrolled in an English plan and later switched the app to Tibetan, tapping that English plan failed with "Not found" — because the app was only searching among Tibetan plans.

Solution:

Each plan in the routine now carries its own language (already provided by the API, just wasn't being stored). When you tap a plan, the app checks: does this plan's language match the current app language? If yes, use the fast in-memory cache. If no, fetch it directly from the API using the plan's own language. No wasted lookups, no "Not found" errors.