### PR TITLE
fix: routine enrollment fix on first try

### DIFF
--- a/lib/features/home/data/datasource/series_remote_datasource.dart
+++ b/lib/features/home/data/datasource/series_remote_datasource.dart
@@ -71,6 +71,7 @@ class SeriesRemoteDatasource {
         throw _statusToException(status, 'Failed to enroll in series');
       }
     } on DioException catch (e) {
+      if (e.response?.statusCode == 409) return;
       _logger.error('Dio error in enrollInSeries', e);
       throw _dioToException(e, 'Failed to enroll in series');
     }

--- a/lib/features/home/presentation/widgets/plan_list_view.dart
+++ b/lib/features/home/presentation/widgets/plan_list_view.dart
@@ -280,12 +280,10 @@ class FeaturedPlanCard extends ConsumerWidget {
       return;
     }
 
-    // Defensive no-op: a stale render could allow a tap after the user is
-    // already enrolled. Honor that latest state rather than re-POSTing.
-    final alreadyEnrolled =
-        ref.read(userSeriesEnrollmentsProvider).valueOrNull?.contains(id) ??
-        false;
-    if (alreadyEnrolled) return;
+    final enrollments =
+        await ref.read(userSeriesEnrollmentsProvider.future);
+    if (!context.mounted) return;
+    if (enrollments.contains(id)) return;
 
     final notifier = ref.read(seriesEnrollmentProvider(id).notifier);
     final ok = await notifier.enroll();

--- a/lib/features/practice/presentation/screens/edit_routine_screen.dart
+++ b/lib/features/practice/presentation/screens/edit_routine_screen.dart
@@ -1153,12 +1153,10 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     }
 
     final seriesId = series.id;
-    final alreadyEnrolled =
-        ref
-            .read(userSeriesEnrollmentsProvider)
-            .valueOrNull
-            ?.contains(seriesId) ??
-        false;
+    final enrollments =
+        await ref.read(userSeriesEnrollmentsProvider.future);
+    if (!mounted) return;
+    final alreadyEnrolled = enrollments.contains(seriesId);
 
     if (!alreadyEnrolled) {
       final notifier = ref.read(seriesEnrollmentProvider(seriesId).notifier);


### PR DESCRIPTION
## Summary

### Problem
When editing a routine and adding a session by tapping a **series** (e.g. "Daily Tipitaka"), the **first tap** often failed with **"Failed to enroll in series"**. A **second tap** on the same series usually worked.

### Root cause
Two issues combined:

1. **Stale enrollment cache** — The app checked `userSeriesEnrollmentsProvider` with `.valueOrNull`. While that provider was still loading (or had failed and returned an empty set), the app assumed the user was **not** enrolled and sent `POST /users/me/series` again.

2. **409 treated as failure** — If the user was already enrolled, the backend returned **HTTP 409 Conflict**. The client treated that as an error instead of success, so the snackbar appeared even though enrollment was already in place.

On retry, the enrollment list had usually finished loading, so the app skipped the POST and went straight to fetching plans — which is why the second attempt worked.
