### PR TITLE
feat: implement new home screen layout and components

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -331,15 +331,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  audio_service: cab6c1a0eaf01b5a35b567e11fa67d3cc1956910
-  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   Auth0: 2876d0c36857422eda9cb580a6cc896c7d14cb36
-  auth0_flutter: 0f4846524696ef8441bcb96ceab7bfdbe31b8a05
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  auth0_flutter: 031042ca6cf84f1b21611062b33ea7ec4bf3bc52
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   Firebase: 7cc10425300768ec86292688af5cb228f0604bde
-  firebase_analytics: 1640d06cf3c1a365700857c51ef995d3591df101
-  firebase_core: 059f6939d27b5644ea96ad8ad71a9a6e17db74f1
-  firebase_crashlytics: 842464bf3dcf3ddc67ec7f4a0e48bf268d8e8c6a
+  firebase_analytics: 9ea6c22e60e1d37ee76772de57b4addddb03e276
+  firebase_core: 383e19b49a08df5d7a6cf5017616de6a357ed7af
+  firebase_crashlytics: 88273c8643a258ff74ee26203e319a782aa8b12c
   FirebaseAnalytics: 99364329a3ea4d1ab4a3744b5464371b7351c481
   FirebaseCore: 4939b340b9c598dc1f965d68f8fe57e630b65407
   FirebaseCoreExtension: ee3e3697acea1062288b1900bcdcab4d59ab93b4
@@ -349,34 +349,34 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 40ecdce5a4feee7643b81342f32f1cded905bb07
   FirebaseSessions: c9e7b7829265454f08cb68f7f8a6650c9b221bd4
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
-  flutter_timezone: ac3da59ac941ff1c98a2e1f0293420e020120282
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
   GoogleAdsOnDeviceConversion: 80ce443fa1b4b5750913d53a04ecda644ff57744
   GoogleAppMeasurement: 1987ffa55055dfb22c52e363c31aa50c1e11d349
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_gallery_saver_plus: 782ade975fe6a4600b53e7c1983e3a2979d1e9e5
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
-  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  image_gallery_saver_plus: e597bf65a7846979417a3eae0763b71b6dfec6c3
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   JWTDecode: 7dae24cb9bf9b608eae61e5081029ec169bb5527
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
-  permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   PostHog: 6c74cc84f3872f4335108ff363aecdeb7c278052
-  posthog_flutter: 70c295afe8f9eb52e99eefe031af0001bdf9b735
+  posthog_flutter: 343db84a70d44b12fa0fe2fc35bbb58098074bd4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   SimpleKeychain: 768cf43ae778b1c21816e94dddf01bb8ee96a075
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/lib/features/home/presentation/screens/main_navigation_screen.dart
+++ b/lib/features/home/presentation/screens/main_navigation_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.d
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/features/home/presentation/screens/home_screen.dart';
+import 'package:flutter_pecha/features/home/presentation/screens/new_home_screen.dart'; // DEV: swapped to NewHomeScreen for local preview. Revert to HomeScreen before PR.
 import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/routine_api_providers.dart';
 import 'package:flutter_pecha/features/practice/presentation/screens/practice_screen.dart';
@@ -41,7 +42,9 @@ List<AppBottomBarItemModel<int>> mainNavigationItems(BuildContext context) {
       AppBottomBarItemModel(
         type: 0,
         label: localizations.nav_home,
-        selectedWidget: const HomeScreen(),
+        // DEV: swapped to NewHomeScreen for local preview. Revert to HomeScreen before PR.
+        selectedWidget: const NewHomeScreen(),
+        // selectedWidget: const HomeScreen(),
         selectedIconData: AppAssets.homeSelected,
         unSelectedIconData: AppAssets.homeUnselected,
       ),

--- a/lib/features/home/presentation/screens/new_home_screen.dart
+++ b/lib/features/home/presentation/screens/new_home_screen.dart
@@ -1,0 +1,47 @@
+// DEV / WIP — This file replaces HomeScreen temporarily so the team can
+// preview in-progress home page components on every hot-reload.
+// Swap back to HomeScreen in main_navigation_screen.dart before opening a PR.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/home/presentation/widgets/home_header.dart';
+import 'package:flutter_pecha/features/home/presentation/widgets/home_share_prompt.dart';
+
+class NewHomeScreen extends StatelessWidget {
+  const NewHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Your component ──────────────────────────────────────────
+            // Streak count is hardcoded to 1 to match the design mock-up.
+            // Replace with a real provider once the streak API is integrated.
+            const HomeHeader(streakCount: 1),
+            // ────────────────────────────────────────────────────────────
+
+            // Placeholders for other teammates' components.
+            // Each person will import their widget here once ready.
+            const Divider(height: 1),
+            Expanded(
+              child: Center(
+                child: Text(
+                  'Other home components go here',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.4),
+                  ),
+                ),
+              ),
+            ),
+            const HomeSharePrompt(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_header.dart
+++ b/lib/features/home/presentation/widgets/home_header.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Home screen header that shows a personalised greeting and the user's
+/// current streak count.
+///
+/// Streak data will be wired up once the API endpoint is ready.
+/// For now the count is a placeholder.
+class HomeHeader extends ConsumerWidget {
+  /// The user's current streak count.
+  ///
+  /// TODO: replace with a real provider once the streak API endpoint is
+  /// integrated. For now pass a hardcoded value from the parent.
+  final int streakCount;
+
+  const HomeHeader({super.key, this.streakCount = 0});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(userProvider).user;
+    final firstName = user?.firstName ?? user?.username ?? 'there';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 12.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _Greeting(firstName: firstName),
+          _StreakBadge(count: streakCount),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private sub-widgets
+// ---------------------------------------------------------------------------
+
+class _Greeting extends StatelessWidget {
+  final String firstName;
+
+  const _Greeting({required this.firstName});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+            text: 'Hello, ',
+            style: textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.w400,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          TextSpan(
+            text: firstName,
+            style: textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StreakBadge extends StatelessWidget {
+  final int count;
+
+  const _StreakBadge({required this.count});
+
+  static const _flameColor = Color(0xFFE8630A);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        PhosphorIcon(
+          PhosphorIconsFill.fire,
+          size: 24.0,
+          color: _flameColor,
+        ),
+        const SizedBox(width: 4.0),
+        Text(
+          '$count',
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: Theme.of(context).colorScheme.onSurface,
+            fontSize: 20.0,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_share_prompt.dart
+++ b/lib/features/home/presentation/widgets/home_share_prompt.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/services/app_share/app_share_service.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Home screen prompt that invites the user to share WeBuddhist with others.
+class HomeSharePrompt extends ConsumerWidget {
+  const HomeSharePrompt({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 24.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _PromptLabel(),
+          const SizedBox(height: 12.0),
+          _ShareButton(
+            onTap: () => ref.read(appShareServiceProvider).shareApp(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private sub-widgets
+// ---------------------------------------------------------------------------
+
+class _PromptLabel extends StatelessWidget {
+  const _PromptLabel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'Enjoying WeBuddhist?',
+      textAlign: TextAlign.center,
+      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+        fontWeight: FontWeight.w400,
+        color: AppColors.textPrimaryLight,
+      ),
+    );
+  }
+}
+
+class _ShareButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ShareButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greyLight,
+      borderRadius: BorderRadius.circular(999.0),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999.0),
+        child: SizedBox(
+          width: double.infinity,
+          height: 52.0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              PhosphorIcon(
+                PhosphorIconsBold.export,
+                size: 22.0,
+                color: Theme.of(context).colorScheme.onSurface,
+                
+              ),
+              const SizedBox(width: 8.0),
+              Text(
+                'Share',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  fontFamily: 'Inter',
+                  fontSize: 16.0,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Introduced a temporary `NewHomeScreen` to facilitate local previews of in-progress components.
- Added `HomeHeader` widget to display a personalized greeting and streak count.
- Created `HomeSharePrompt` widget to encourage users to share the app.
- Updated `main_navigation_screen.dart` to use `NewHomeScreen` for local development.