### PR TITLE
chore: bump version to 2.8.8+88 and update Auth0 audience fetching logic

### DIFF
--- a/lib/features/auth/application/config_service.dart
+++ b/lib/features/auth/application/config_service.dart
@@ -26,13 +26,10 @@ class ConfigService {
       final data = jsonDecode(response.body);
       auth0Domain = data['domain'];
       auth0ClientId = data['client_id'];
+      auth0Audience = data['audience'];
       // Prefer the audience advertised by /props; fall back to the env value so
       // the client works even before the backend adds it to /props. Without an
       // audience, Auth0 returns an opaque /userinfo token (not an API JWT).
-      final propsAudience = data['auth0Audience'] as String?;
-      auth0Audience = (propsAudience != null && propsAudience.isNotEmpty)
-          ? propsAudience
-          : dotenv.env['AUTH0_AUDIENCE'];
       _isLoaded = true;
     } else {
       throw Exception('Failed to fetch auth0 config');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.8.8+87
+version: 2.8.8+88
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
- Updated version in pubspec.yaml to 2.8.8+88.
- Simplified audience fetching logic in ConfigService by directly using the audience from the response data.