### PR TITLE
feat(router): refactor app routing and enhance practice navigation

### DIFF
--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -162,6 +162,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: "series/:id",
                 name: "home-series-detail",
+                // Root navigator so this works when my-practices (or any
+                // root-pushed route) is already on the stack above /home.
+                // Without this, go_router inserts a second /home shell page
+                // and hits duplicate page keys.
+                parentNavigatorKey: rootNavigatorKey,
                 builder: (context, state) {
                   final id = state.pathParameters['id'] ?? '';
                   final extra = state.extra as Map<String, dynamic>?;
@@ -172,6 +177,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: "info",
                     name: "home-series-info",
+                    parentNavigatorKey: rootNavigatorKey,
                     builder: (context, state) {
                       final extra = state.extra as Map<String, dynamic>?;
                       final series = extra?['series'] as Series;
@@ -301,49 +307,94 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         },
       ),
 
-      // practice route
+      // Practice routes are flat top-level siblings (not nested under /practice)
+      // so child navigations do not also push a parent /practice page onto the
+      // root navigator — that duplicate page key caused crashes when returning
+      // from edit-routine to my-practices (RoutineFilledState transition).
       GoRoute(
         path: "/practice",
         name: "practice",
         builder: (context, state) => const PracticeExploreScreen(),
+      ),
+      GoRoute(
+        path: "/practice/my-practices",
+        name: "my-practices",
+        builder: (context, state) => const PracticeScreen(showAppBar: true),
+      ),
+      GoRoute(
+        path: "/practice/edit-routine",
+        name: "edit-routine",
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>?;
+          final plan = extra?['initialPlan'] as Plan?;
+          final enrollSeriesId = extra?['enrollSeriesId'] as String?;
+          return EditRoutineScreen(
+            initialPlan: plan,
+            enrollSeriesId: enrollSeriesId,
+          );
+        },
         routes: [
           GoRoute(
-            path: "my-practices",
-            name: "my-practices",
-            parentNavigatorKey: rootNavigatorKey,
-            builder: (context, state) => const PracticeScreen(showAppBar: true),
+            path: "select-plan",
+            name: "select-plan",
+            builder: (context, state) => const SelectPlanScreen(),
           ),
           GoRoute(
-            path: "edit-routine", // route - /practice/edit-routine
-            name: "edit-routine",
-            builder: (context, state) {
-              final extra = state.extra as Map<String, dynamic>?;
-              final plan = extra?['initialPlan'] as Plan?;
-              final enrollSeriesId = extra?['enrollSeriesId'] as String?;
-              return EditRoutineScreen(
-                initialPlan: plan,
-                enrollSeriesId: enrollSeriesId,
-              );
-            },
-            routes: [
-              GoRoute(
-                path:
-                    "select-plan", // route - /practice/edit-routine/select-plan
-                name: "select-plan",
-                builder: (context, state) => const SelectPlanScreen(),
-              ),
-              GoRoute(
-                path:
-                    "select-recitation", // route - /practice/edit-routine/select-recitation
-                name: "select-recitation",
-                builder: (context, state) => const SelectRecitationScreen(),
-              ),
-            ],
+            path: "select-recitation",
+            name: "select-recitation",
+            builder: (context, state) => const SelectRecitationScreen(),
           ),
-          // route - /practice/details
+        ],
+      ),
+      GoRoute(
+        path: "/practice/details",
+        name: "practice-plan-details",
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>?;
+          final plan = extra?['plan'] as UserPlansModel?;
+          final selectedDay = extra?['selectedDay'] as int?;
+          final startDate = extra?['startDate'] as DateTime?;
+          if (plan == null) {
+            throw Exception('Missing required parameters');
+          }
+          return PlanDetails(
+            plan: plan,
+            selectedDay: selectedDay ?? 1,
+            startDate: startDate ?? DateTime.now(),
+          );
+        },
+      ),
+      GoRoute(
+        path: "/practice/plans/preview",
+        name: "practice-plan-preview",
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>?;
+          final plan = extra?['plan'] as Plan?;
+          final seriesId = extra?['seriesId'] as String?;
+          if (plan == null) {
+            throw Exception('Missing required parameters');
+          }
+          return PlanPreviewDetails(
+            plan: plan,
+            seriesId: seriesId,
+          );
+        },
+      ),
+      GoRoute(
+        path: "/practice/plans/info",
+        name: "practice-plan-info",
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>?;
+          final plan = extra?['plan'] as Plan?;
+          if (plan == null) {
+            throw Exception('Missing required parameters');
+          }
+          return PlanInfo(plan: plan);
+        },
+        routes: [
           GoRoute(
             path: "details",
-            name: "practice-plan-details",
+            name: "practice-plan-info-details",
             builder: (context, state) {
               final extra = state.extra as Map<String, dynamic>?;
               final plan = extra?['plan'] as UserPlansModel?;
@@ -358,63 +409,6 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 startDate: startDate ?? DateTime.now(),
               );
             },
-          ),
-          // route - /practice/plans/preview
-          GoRoute(
-            path: "plans/preview",
-            name: "practice-plan-preview",
-            builder: (context, state) {
-              final extra = state.extra as Map<String, dynamic>?;
-              final plan = extra?['plan'] as Plan?;
-              final seriesId = extra?['seriesId'] as String?;
-              if (plan == null) {
-                throw Exception('Missing required parameters');
-              }
-              return PlanPreviewDetails(
-                plan: plan,
-                seriesId: seriesId,
-              );
-            },
-          ),
-          // route - /practice/plans/info
-          GoRoute(
-            path: "plans/info",
-            name: "practice-plan-info",
-            builder: (context, state) {
-              final extra = state.extra as Map<String, dynamic>?;
-              final plan = extra?['plan'] as Plan?;
-              if (plan == null) {
-                throw Exception('Missing required parameters');
-              }
-              return PlanInfo(plan: plan);
-            },
-            routes: [
-              // route - /practice/plans/info/details
-              GoRoute(
-                path: "details",
-                name: "practice-plan-info-details",
-                builder: (context, state) {
-                  final extra = state.extra as Map<String, dynamic>?;
-                  final plan = extra?['plan'] as UserPlansModel?;
-                  final selectedDay = extra?['selectedDay'] as int?;
-                  final startDate = extra?['startDate'] as DateTime?;
-                  if (plan == null) {
-                    throw Exception('Missing required parameters');
-                  }
-                  return PlanDetails(
-                    plan: plan,
-                    selectedDay: selectedDay ?? 1,
-                    startDate: startDate ?? DateTime.now(),
-                  );
-                },
-              ),
-              // route - /practice/plans/info/author
-              // GoRoute(
-              //   path: "author",
-              //   name: "practice-plan-author",
-              //   builder: (context, state) => const AuthorDetailScreen(),
-              // ),
-            ],
           ),
         ],
       ),

--- a/lib/features/practice/presentation/widgets/routine_filled_state.dart
+++ b/lib/features/practice/presentation/widgets/routine_filled_state.dart
@@ -48,7 +48,7 @@ Future<UserPlansModel?> resolveRoutineUserPlan(
 
 final _logger = AppLogger('RoutineFilledState');
 
-class RoutineFilledState extends ConsumerWidget {
+class RoutineFilledState extends ConsumerStatefulWidget {
   final RoutineData routineData;
   final VoidCallback onEdit;
   final bool showTitle;
@@ -61,77 +61,89 @@ class RoutineFilledState extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RoutineFilledState> createState() => _RoutineFilledStateState();
+}
+
+class _RoutineFilledStateState extends ConsumerState<RoutineFilledState> {
+  @override
+  void initState() {
+    super.initState();
+    ref.listenManual(pendingNotificationNavProvider, (previous, next) {
+      if (next != null) {
+        _handlePendingNotificationNav(next);
+      }
+    }, fireImmediately: true);
+  }
+
+  Future<void> _handlePendingNotificationNav(NotificationNav pendingNav) async {
+    if (!mounted) return;
+
+    final itemType = RoutineItemType.values.firstWhere(
+      (e) => e.name == pendingNav.itemType,
+      orElse: () => RoutineItemType.series,
+    );
+    if (itemType == RoutineItemType.recitation) {
+      ref.read(pendingNotificationNavProvider.notifier).state = null;
+      context.push(
+        '/reader/${pendingNav.itemId}',
+        extra: NavigationContext(source: NavigationSource.normal),
+      );
+      return;
+    }
+
+    final planId = pendingNav.planId ?? pendingNav.itemId;
+    final routineItem = _findRoutineItem(widget.routineData, pendingNav.itemId);
+    var userPlan =
+        ref
+            .read(myPlansPaginatedProvider)
+            .plans
+            .where((p) => p.id == planId)
+            .firstOrNull;
+    userPlan ??= await resolveRoutineUserPlan(
+      ref,
+      planId,
+      language: routineItem?.language,
+    );
+    if (!mounted || userPlan == null) {
+      return;
+    }
+
+    ref.read(pendingNotificationNavProvider.notifier).state = null;
+    final startDate = userPlan.effectiveStartDate;
+    final selectedDay = PlanUtils.dayNumberFor(
+      startDate,
+      DateTime.now(),
+      userPlan.totalDays,
+    ).clamp(1, userPlan.totalDays);
+    _logger.info(
+      '[ENROLL-NAV] notification open ${userPlan.id} '
+      'seriesId=${pendingNav.itemId} selectedDay=$selectedDay/${userPlan.totalDays}',
+    );
+    context.push(
+      '/practice/details',
+      extra: {
+        'plan': userPlan,
+        'selectedDay': selectedDay,
+        'startDate': startDate,
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final localizations = context.l10n;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    // Handle deep-link from notification tap.
-    final pendingNav = ref.watch(pendingNotificationNavProvider);
-    if (pendingNav != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) async {
-        if (!context.mounted) return;
-        final itemType = RoutineItemType.values.firstWhere(
-          (e) => e.name == pendingNav.itemType,
-          orElse: () => RoutineItemType.series,
-        );
-        if (itemType == RoutineItemType.recitation) {
-          ref.read(pendingNotificationNavProvider.notifier).state = null;
-          context.push(
-            '/reader/${pendingNav.itemId}',
-            extra: NavigationContext(source: NavigationSource.normal),
-          );
-          return;
-        }
-
-        final planId = pendingNav.planId ?? pendingNav.itemId;
-        final routineItem = _findRoutineItem(routineData, pendingNav.itemId);
-        var userPlan =
-            ref
-                .read(myPlansPaginatedProvider)
-                .plans
-                .where((p) => p.id == planId)
-                .firstOrNull;
-        userPlan ??= await resolveRoutineUserPlan(
-          ref,
-          planId,
-          language: routineItem?.language,
-        );
-        if (userPlan == null) {
-          return;
-        }
-
-        ref.read(pendingNotificationNavProvider.notifier).state = null;
-        final startDate = userPlan.effectiveStartDate;
-        final selectedDay = PlanUtils.dayNumberFor(
-          startDate,
-          DateTime.now(),
-          userPlan.totalDays,
-        ).clamp(1, userPlan.totalDays);
-        _logger.info(
-          '[ENROLL-NAV] notification open ${userPlan.id} '
-          'seriesId=${pendingNav.itemId} selectedDay=$selectedDay/${userPlan.totalDays}',
-        );
-        context.push(
-          '/practice/details',
-          extra: {
-            'plan': userPlan,
-            'selectedDay': selectedDay,
-            'startDate': startDate,
-          },
-        );
-      });
-    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showTitle) ...[
+        if (widget.showTitle) ...[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
             child: _RoutineHeader(
               title: localizations.routine_title,
               editLabel: localizations.routine_edit,
-              onEdit: onEdit,
+              onEdit: widget.onEdit,
               isDark: isDark,
             ),
           ),
@@ -155,9 +167,11 @@ class RoutineFilledState extends ConsumerWidget {
                 horizontal: 20.0,
                 vertical: 12,
               ),
-              itemCount: routineData.blocks.length,
+              itemCount: widget.routineData.blocks.length,
               itemBuilder: (context, index) {
-                return _RoutineBlockSection(block: routineData.blocks[index]);
+                return _RoutineBlockSection(
+                  block: widget.routineData.blocks[index],
+                );
               },
             ),
           ),
@@ -243,7 +257,10 @@ class _RoutineBlockSection extends ConsumerWidget {
         _navigateToReader(context, item.id);
       case RoutineItemType.series:
         if (!context.mounted) return;
-        context.push('/home/series/${item.id}');
+        context.pushNamed(
+          'home-series-detail',
+          pathParameters: {'id': item.id},
+        );
     }
   }
 


### PR DESCRIPTION
- Updated the app router configuration to improve navigation handling, particularly for the practice section, ensuring that routes do not create duplicate pages in the navigation stack.
- Introduced new routes for practice-related screens, including my-practices, edit-routine, and details, with appropriate parameter handling.
- Refactored RoutineFilledState to use a ConsumerStatefulWidget for better state management and improved handling of pending notifications.
- Enhanced navigation logic to ensure smooth transitions and prevent crashes related to duplicate page keys.