### PR TITLE
fix(ci): keep iOS archive green by neutralizing Crashlytics upload phase

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -84,13 +84,6 @@ jobs:
       - name: 📦 flutter pub get
         run: flutter pub get
 
-      - name: 🔥 Install FlutterFire CLI (Crashlytics dSYM upload phase)
-        run: |
-          dart pub global activate flutterfire_cli
-          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-          sudo ln -sf "$HOME/.pub-cache/bin/flutterfire" /usr/local/bin/flutterfire || true
-          flutterfire --version || true
-
       - name: 🍫 CocoaPods install
         run: |
           cd ios
@@ -159,6 +152,25 @@ jobs:
           </dict>
           </plist>
           EOF
+
+      - name: 🚫 Neutralize Crashlytics symbol-upload build phase (CI archive)
+        run: |
+          # Firebase is integrated via Swift Package Manager (not the Podfile),
+          # so the "FlutterFire: flutterfire upload-crashlytics-symbols" Xcode
+          # run-script phase resolves the Crashlytics `run` helper to an SPM
+          # checkout path that doesn't exist at archive time. flutterfire then
+          # aborts with "ProcessException: No such file or directory" and fails
+          # the whole archive even though the app compiled. Symbol upload is
+          # post-build telemetry and must not block a release, so swap that
+          # phase's script for a no-op during the CI archive (dSYMs are still
+          # produced and shipped in the IPA / build artifact).
+          PBXPROJ=ios/Runner.xcodeproj/project.pbxproj
+          perl -i -pe 's/shellScript = ".*";/shellScript = "echo CI Crashlytics upload-symbols phase disabled; exit 0";/ if /upload-crashlytics-symbols/' "$PBXPROJ"
+          if grep -q -- '--upload-symbols-script-path' "$PBXPROJ"; then
+            echo "::warning::Could not patch the Crashlytics build phase; relying on the absent flutterfire CLI to make it skip."
+          else
+            echo "Crashlytics symbol-upload build phase neutralized for the CI archive."
+          fi
 
       - name: 🏗️ Build IPA (${{ inputs.flavor }})
         env:


### PR DESCRIPTION
## Problem

The iOS release build fails inside `flutter build ipa` (both **Release • Dev** and **Release • Prod**), so no IPA reaches TestFlight. Android is unaffected.

The failing step is the Runner target's **`FlutterFire: "flutterfire upload-crashlytics-symbols"`** Xcode run-script build phase, which aborts the archive:

```
Unhandled exception: ProcessException: No such file or directory
  Command: .../SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run --validate ...
→ Command PhaseScriptExecution failed with a nonzero exit code
→ ** ARCHIVE FAILED **
```

**Root cause:** Firebase is integrated via **Swift Package Manager** (it is not in the `Podfile`), so `$PODS_ROOT/FirebaseCrashlytics` never exists and the build phase takes its SPM fallback, resolving the Crashlytics `run` helper to an SPM checkout path that isn't present at archive time. `flutterfire` then throws `ProcessException: No such file or directory` and fails the **whole archive** — even though the app itself compiled cleanly.

## Fix (workflow-only — no app/`pbxproj` changes)

In `.github/workflows/build-ios.yml`:

- **Neutralize the Crashlytics build phase at CI time**, right before the archive: replace that phase's shell script with a no-op. Crashlytics symbol upload is post-build telemetry and must never block a release. The step is self-verifying (warns if the patch didn't apply) and dependency-free (`perl`).
- **Drop the now-unused `Install FlutterFire CLI` step.** With `flutterfire` absent, the build phase's own *"flutterfire not found → skip"* guard acts as a second safety net.

dSYMs are still produced and shipped in the IPA / build artifact; the existing post-build dSYM upload step is unchanged.

## Validation

- `build-ios.yml` parses as valid YAML.
- The `perl` neutralization was run against this repo's actual `ios/Runner.xcodeproj/project.pbxproj`: it rewrites only the Crashlytics phase's `shellScript` to the no-op, leaves the phase name/structure intact, and the `--upload-symbols-script-path` invocation is gone afterward.

> Note: this validates the archive blocker. The subsequent export / TestFlight-upload steps run after a successful archive and are exercised for the first time by this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)