### PR TITLE
chore:  bottom up sheet now covers up the navigation bar everywhere on the app.

### DIFF
--- a/lib/features/auth/presentation/widgets/login_drawer.dart
+++ b/lib/features/auth/presentation/widgets/login_drawer.dart
@@ -11,10 +11,15 @@ class LoginDrawer extends ConsumerStatefulWidget {
   const LoginDrawer({super.key});
 
   /// Show the login drawer as a bottom sheet
-  static Future<void> show(BuildContext context, WidgetRef ref) {
+  static Future<void> show(
+    BuildContext context,
+    WidgetRef ref, {
+    bool useRootNavigator = false,
+  }) {
     return showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      useRootNavigator: useRootNavigator,
       backgroundColor: Colors.transparent,
       isDismissible: true,
       enableDrag: true,
@@ -98,11 +103,7 @@ class _LoginDrawerState extends ConsumerState<LoginDrawer>
                   ),
                 ),
                 // App logo
-                Image.asset(
-                  AppAssets.weBuddhistLogo,
-                  height: 80,
-                  width: 80,
-                ),
+                Image.asset(AppAssets.weBuddhistLogo, height: 80, width: 80),
                 const SizedBox(height: 24),
                 // Title
                 Text(

--- a/lib/features/more/presentation/more_screen.dart
+++ b/lib/features/more/presentation/more_screen.dart
@@ -133,7 +133,9 @@ class MoreScreen extends ConsumerWidget {
                 context,
                 icon: AppAssets.signIn,
                 title: localizations.sign_in,
-                onTap: () => LoginDrawer.show(context, ref),
+                onTap:
+                    () =>
+                        LoginDrawer.show(context, ref, useRootNavigator: true),
               ),
             ] else ...[
               _buildSettingsRow(
@@ -306,6 +308,7 @@ class MoreScreen extends ConsumerWidget {
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
       isScrollControlled: true,
+      useRootNavigator: true,
       builder: (sheetContext) {
         final theme = Theme.of(sheetContext);
         final selected = currentLocale ?? Localizations.localeOf(sheetContext);


### PR DESCRIPTION
add useRootNavigator option to LoginDrawer and update MoreScreen integration.

the bottom up sheet now covers up the navigation bar everywhere on the app.