### PR TITLE
Task/add deep link to all share

### DIFF
--- a/lib/core/config/router/app_router.dart
+++ b/lib/core/config/router/app_router.dart
@@ -85,6 +85,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     navigatorKey: rootNavigatorKey,
     initialLocation: AppRoutes.home,
+    // App links are consumed explicitly by AppLinksDeepLinkService. If
+    // go_router also uses the platform launch URL during cold start, the same
+    // deep link can be inserted twice and leave a stale page under Back.
+    overridePlatformDefaultLocation: true,
     debugLogDiagnostics: true,
     observers: [ref.read(analyticsServiceProvider).routeObserver],
 

--- a/lib/core/deep_linking/app_links_deep_link_service.dart
+++ b/lib/core/deep_linking/app_links_deep_link_service.dart
@@ -17,8 +17,12 @@ class AppLinksDeepLinkService {
   StreamSubscription<Uri>? _subscription;
   GoRouter? _router;
   Uri? _pendingUri;
+  Uri? _lastDispatchedUri;
+  DateTime? _lastDispatchedAt;
   bool _initialized = false;
   void Function(int tabIndex)? _tabSetter;
+
+  static const Duration _duplicateDispatchWindow = Duration(seconds: 5);
 
   Future<void> initialize() async {
     if (_initialized) return;
@@ -78,6 +82,16 @@ class AppLinksDeepLinkService {
       return;
     }
 
+    if (_pendingUri == uri) {
+      _logger.debug('Ignoring duplicate pending app link: $uri');
+      return;
+    }
+
+    if (_wasRecentlyDispatched(uri)) {
+      _logger.debug('Ignoring recently dispatched app link: $uri');
+      return;
+    }
+
     if (_router == null) {
       _pendingUri = uri;
       _logger.info('Router not ready, stored app link: $uri');
@@ -87,16 +101,34 @@ class AppLinksDeepLinkService {
     _dispatch(uri);
   }
 
-  void _dispatch(Uri uri, {String? baseLocation}) {
+  bool _dispatch(Uri uri, {String? baseLocation}) {
     final router = _router;
-    if (router == null) return;
+    if (router == null) return false;
 
-    DeepLinkRouter.route(
+    if (_wasRecentlyDispatched(uri)) {
+      _logger.debug('Skipping duplicate app link dispatch: $uri');
+      return false;
+    }
+
+    final routed = DeepLinkRouter.route(
       uri,
       router,
       source: 'app_links',
       baseLocation: baseLocation,
       tabSetter: _tabSetter,
     );
+    if (routed) {
+      _lastDispatchedUri = uri;
+      _lastDispatchedAt = DateTime.now();
+    }
+    return routed;
+  }
+
+  bool _wasRecentlyDispatched(Uri uri) {
+    final lastUri = _lastDispatchedUri;
+    final lastAt = _lastDispatchedAt;
+    if (lastUri != uri || lastAt == null) return false;
+
+    return DateTime.now().difference(lastAt) < _duplicateDispatchWindow;
   }
 }

--- a/lib/core/deep_linking/app_links_deep_link_service.dart
+++ b/lib/core/deep_linking/app_links_deep_link_service.dart
@@ -18,6 +18,7 @@ class AppLinksDeepLinkService {
   GoRouter? _router;
   Uri? _pendingUri;
   bool _initialized = false;
+  void Function(int tabIndex)? _tabSetter;
 
   Future<void> initialize() async {
     if (_initialized) return;
@@ -48,6 +49,10 @@ class AppLinksDeepLinkService {
 
   void setRouter(GoRouter router) {
     _router = router;
+  }
+
+  void setTabSetter(void Function(int tabIndex) setter) {
+    _tabSetter = setter;
   }
 
   bool drainPendingLink() {
@@ -91,6 +96,7 @@ class AppLinksDeepLinkService {
       router,
       source: 'app_links',
       baseLocation: baseLocation,
+      tabSetter: _tabSetter,
     );
   }
 }

--- a/lib/core/deep_linking/deep_link_router.dart
+++ b/lib/core/deep_linking/deep_link_router.dart
@@ -132,6 +132,16 @@ class DeepLinkRouter {
 
     if (segments.length >= 3 &&
         segments[0] == 'open' &&
+        segments[1] == 'group') {
+      final groupId = segments[2];
+      return _DeepLinkDestination(
+        '/home/group/$groupId',
+        opensOnTop: true,
+      );
+    }
+
+    if (segments.length >= 3 &&
+        segments[0] == 'open' &&
         segments[1] == 'mala') {
       final presetId = segments[2];
       return _DeepLinkDestination(

--- a/lib/core/deep_linking/deep_link_router.dart
+++ b/lib/core/deep_linking/deep_link_router.dart
@@ -14,6 +14,7 @@ class DeepLinkRouter {
     GoRouter router, {
     required String source,
     String? baseLocation,
+    void Function(int tabIndex)? tabSetter,
   }) {
     try {
       final destination = _resolveRoute(uri);
@@ -33,6 +34,14 @@ class DeepLinkRouter {
       } else {
         router.go(destination.location, extra: destination.extra);
       }
+
+      final tabIndex = destination.tabIndex;
+      if (tabIndex != null && tabSetter != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          tabSetter(tabIndex);
+        });
+      }
+
       return true;
     } catch (e, stackTrace) {
       _logger.error(
@@ -67,9 +76,7 @@ class DeepLinkRouter {
     }
 
     if (uri.scheme.toLowerCase() == 'webuddhist') {
-      return _DeepLinkDestination(
-        _routeForWebuddhistHost(uri.host.toLowerCase()),
-      );
+      return _resolveWebuddhistSchemeLink(uri.host.toLowerCase());
     }
 
     if (isAirbridgeLink(uri)) {
@@ -117,39 +124,74 @@ class DeepLinkRouter {
       }
     }
 
+    if (segments.length >= 2 &&
+        segments[0] == 'open' &&
+        segments[1] == 'more') {
+      return const _DeepLinkDestination(AppRoutes.home, tabIndex: _meTabIndex);
+    }
+
+    if (segments.length >= 3 &&
+        segments[0] == 'open' &&
+        segments[1] == 'mala') {
+      final presetId = segments[2];
+      return _DeepLinkDestination(
+        AppRoutes.mala,
+        extra: {'presetId': presetId},
+        opensOnTop: true,
+      );
+    }
+
+    if (segments.length >= 3 &&
+        segments[0] == 'open' &&
+        segments[1] == 'timer') {
+      return const _DeepLinkDestination(
+        '/home/timers',
+        opensOnTop: true,
+      );
+    }
+
     return const _DeepLinkDestination(AppRoutes.home);
   }
 
-  static String _routeForWebuddhistHost(String host) {
+  static _DeepLinkDestination _resolveWebuddhistSchemeLink(String host) {
     switch (host) {
       case 'open':
       case 'home':
-        return AppRoutes.home;
+        return const _DeepLinkDestination(AppRoutes.home);
       case 'practice':
-        return AppRoutes.practice;
+        return const _DeepLinkDestination(AppRoutes.practice);
       case 'texts':
-        return AppRoutes.texts;
+        return const _DeepLinkDestination(AppRoutes.texts);
       case 'more':
-        return AppRoutes.more;
+        return const _DeepLinkDestination(AppRoutes.home, tabIndex: _meTabIndex);
       case 'profile':
-        return AppRoutes.profile;
+        return const _DeepLinkDestination(AppRoutes.profile);
       case 'notifications':
-        return AppRoutes.notifications;
+        return const _DeepLinkDestination(AppRoutes.notifications);
       default:
         _logger.warning('Unknown webuddhist deep link host: $host');
-        return AppRoutes.home;
+        return const _DeepLinkDestination(AppRoutes.home);
     }
   }
 }
+
+/// Bottom nav tab index for the Me screen (matches MainTab.me.index == 3).
+const int _meTabIndex = 3;
 
 class _DeepLinkDestination {
   final String location;
   final Object? extra;
   final bool opensOnTop;
 
+  /// When non-null, the deep-link handler should switch the bottom nav bar to
+  /// this tab index after navigating. Used for tab-based screens that share
+  /// the `/home` route (e.g. the Me tab).
+  final int? tabIndex;
+
   const _DeepLinkDestination(
     this.location, {
     this.extra,
     this.opensOnTop = false,
+    this.tabIndex,
   });
 }

--- a/lib/core/deep_linking/deep_link_url_builder.dart
+++ b/lib/core/deep_linking/deep_link_url_builder.dart
@@ -3,6 +3,10 @@ class DeepLinkUrlBuilder {
 
   static const String _host = 'webuddhist.com';
 
+  static Uri homeLink() {
+    return Uri(scheme: 'https', host: _host, pathSegments: ['open']);
+  }
+
   /// Returns a link that opens the reader at the very first segment —
   /// i.e. no segment/lang params so the app starts from the top.
   static Uri readerLink({required String textId}) {

--- a/lib/core/deep_linking/deep_link_url_builder.dart
+++ b/lib/core/deep_linking/deep_link_url_builder.dart
@@ -3,6 +3,16 @@ class DeepLinkUrlBuilder {
 
   static const String _host = 'webuddhist.com';
 
+  /// Returns a link that opens the reader at the very first segment —
+  /// i.e. no segment/lang params so the app starts from the top.
+  static Uri readerLink({required String textId}) {
+    return Uri(
+      scheme: 'https',
+      host: _host,
+      pathSegments: ['open', 'reader', textId],
+    );
+  }
+
   static Uri readerSegmentLink({
     required String textId,
     required String segmentId,

--- a/lib/core/deep_linking/deep_link_url_builder.dart
+++ b/lib/core/deep_linking/deep_link_url_builder.dart
@@ -34,4 +34,24 @@ class DeepLinkUrlBuilder {
       queryParameters: queryParameters,
     );
   }
+
+  static Uri moreLink() {
+    return Uri(scheme: 'https', host: _host, pathSegments: ['open', 'more']);
+  }
+
+  static Uri malaLink({required String presetId}) {
+    return Uri(
+      scheme: 'https',
+      host: _host,
+      pathSegments: ['open', 'mala', presetId],
+    );
+  }
+
+  static Uri timerLink({required String timerId}) {
+    return Uri(
+      scheme: 'https',
+      host: _host,
+      pathSegments: ['open', 'timer', timerId],
+    );
+  }
 }

--- a/lib/core/deep_linking/deep_link_url_builder.dart
+++ b/lib/core/deep_linking/deep_link_url_builder.dart
@@ -39,6 +39,14 @@ class DeepLinkUrlBuilder {
     return Uri(scheme: 'https', host: _host, pathSegments: ['open', 'more']);
   }
 
+  static Uri groupLink({required String groupId}) {
+    return Uri(
+      scheme: 'https',
+      host: _host,
+      pathSegments: ['open', 'group', groupId],
+    );
+  }
+
   static Uri malaLink({required String presetId}) {
     return Uri(
       scheme: 'https',

--- a/lib/core/services/app_share/app_share_service.dart
+++ b/lib/core/services/app_share/app_share_service.dart
@@ -8,15 +8,8 @@ import 'package:share_plus/share_plus.dart';
 class AppShareService {
   final _logger = AppLogger('AppShareService');
 
-  /// Universal link — opens the app when installed, redirects to the
-  /// correct store (via your hosted /open page) when not installed.
-  static const String _deepLinkUrl = 'https://webuddhist.com/open';
-
   String generateShareMessage() {
-    return '''I'm using WeBuddhist to learn and practice Buddhism. Join me!
-
-👉 $_deepLinkUrl
-''';
+    return "I've been using this app to build a daily Buddhist practice, and thought you'd love it.\n\n${AppConfig.airbridgeTrackingLink}";
   }
 
   Future<void> shareApp() async {
@@ -25,7 +18,7 @@ class AppShareService {
 
       await SharePlus.instance.share(
         ShareParams(
-          text: AppConfig.airbridgeTrackingLink,
+          text: generateShareMessage(),
         ),
       );
 

--- a/lib/features/group_profile/presentation/screens/group_profile_screen.dart
+++ b/lib/features/group_profile/presentation/screens/group_profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/config/router/app_routes.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/features/group_profile/presentation/providers/group_profile_providers.dart';
@@ -62,7 +63,13 @@ class GroupProfileScreen extends ConsumerWidget {
         children: [
           IconButton(
             icon: const Icon(AppAssets.arrowLeft),
-            onPressed: () => context.pop(),
+            onPressed: () {
+              if (context.canPop()) {
+                context.pop();
+              } else {
+                context.go(AppRoutes.home);
+              }
+            },
           ),
           const Spacer(),
           const SizedBox(width: 48, height: 48),

--- a/lib/features/group_profile/presentation/widgets/group_profile_body.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
@@ -16,6 +17,7 @@ import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class GroupProfileBody extends ConsumerStatefulWidget {
@@ -695,6 +697,19 @@ class _GroupFollowButton extends ConsumerWidget {
 
   const _GroupFollowButton({required this.profile, required this.isDark});
 
+  Future<void> _onInvitePressed(BuildContext context) async {
+    final shareUrl = DeepLinkUrlBuilder.groupLink(groupId: profile.id).toString();
+    const shareMessage =
+        "I'd love for you to join our group. Let's practice together on WeBuddhist.";
+    final sharePositionOrigin = getSharePositionOrigin(context: context);
+    await SharePlus.instance.share(
+      ShareParams(
+        text: '$shareMessage\n\n$shareUrl',
+        sharePositionOrigin: sharePositionOrigin,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final followKey = GroupFollowKey(
@@ -780,14 +795,7 @@ class _GroupFollowButton extends ConsumerWidget {
                   const SizedBox(width: 12),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(context.l10n.mala_action_coming_soon),
-                            behavior: SnackBarBehavior.floating,
-                          ),
-                        );
-                      },
+                      onPressed: () => _onInvitePressed(context),
                       style: buttonStyle.copyWith(
                         backgroundColor: WidgetStatePropertyAll(
                           isDark

--- a/lib/features/home/presentation/widgets/home_shortcuts_row.dart
+++ b/lib/features/home/presentation/widgets/home_shortcuts_row.dart
@@ -6,8 +6,6 @@ import 'package:flutter_pecha/features/home/domain/entities/series.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/practice_explore_providers.dart';
 import 'package:flutter_pecha/features/practice/presentation/screens/all_plans_screen.dart';
 import 'package:flutter_pecha/features/practice/presentation/screens/all_recitations_screen.dart';
-import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
-import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -54,21 +52,9 @@ class HomeShortcutsRow extends ConsumerWidget {
     });
   }
 
-  void _navigateToRecitation(BuildContext context, RecitationModel recitation) {
-    final navigationContext = NavigationContext(
-      source: NavigationSource.normal,
-    );
-    context.push('/reader/${recitation.textId}', extra: navigationContext);
-  }
-
   void _onChantsTap(BuildContext context, WidgetRef ref) {
     Navigator.of(context).push(
-      MaterialPageRoute(
-        builder:
-            (_) => AllRecitationsScreen(
-              onTap: (r) => _navigateToRecitation(context, r),
-            ),
-      ),
+      MaterialPageRoute(builder: (_) => const AllRecitationsScreen()),
     );
   }
 

--- a/lib/features/home/presentation/widgets/verse_share_sheet.dart
+++ b/lib/features/home/presentation/widgets/verse_share_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/theme/app_theme.dart';
@@ -82,13 +83,16 @@ Future<void> shareVerseOfDayQuote(
 }) async {
   File? tempFile;
   try {
-    final Uint8List? imageBytes =
-        screenshotController != null
-            ? await screenshotController.capture(
-              delay: const Duration(milliseconds: 100),
-              pixelRatio: 3.0,
-            )
-            : await _captureVerseShareImage(context, verseOfDay);
+    final Uint8List? imageBytes;
+    if (screenshotController != null) {
+      imageBytes = await screenshotController.capture(
+        delay: const Duration(milliseconds: 100),
+        pixelRatio: 3.0,
+      );
+    } else {
+      if (!context.mounted) return;
+      imageBytes = await _captureVerseShareImage(context, verseOfDay);
+    }
 
     if (imageBytes == null || !context.mounted) return;
 
@@ -104,10 +108,12 @@ Future<void> shareVerseOfDayQuote(
       context: context,
       globalKey: shareOriginKey,
     );
+    final shareText = _verseOfDayShareText();
 
     await SharePlus.instance.share(
       ShareParams(
         files: [XFile(tempFile.path)],
+        text: shareText,
         sharePositionOrigin: sharePositionOrigin,
       ),
     );
@@ -128,6 +134,14 @@ Future<void> shareVerseOfDayQuote(
       } catch (_) {}
     }
   }
+}
+
+String _verseOfDayShareText() {
+  final homeLink = DeepLinkUrlBuilder.homeLink().toString();
+
+  return 'I liked this quote from WeBuddhist and wanted to share it with you. '
+      'Read more such insightful quotes on the WeBuddhist App\n\n'
+      '$homeLink';
 }
 
 Future<Uint8List?> _captureVerseShareImage(
@@ -212,7 +226,6 @@ class _VerseShareSheetState extends State<VerseShareSheet> {
     final languageCode = Localizations.localeOf(context).languageCode;
     final locale = Localizations.localeOf(context);
     final shareLabelFontSize = getLocalizedFontSize(AppTextSize.body);
-    final isTibetan = AppFontConfig.isTibetanLanguage(languageCode);
 
     return Container(
       decoration: BoxDecoration(

--- a/lib/features/mala/presentation/widgets/mala_settings_sheet.dart
+++ b/lib/features/mala/presentation/widgets/mala_settings_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/network/connectivity_service.dart' show connectivityNotifierProvider;
 import 'package:flutter_pecha/core/theme/app_colors.dart';
@@ -12,9 +13,11 @@ import 'package:flutter_pecha/features/mala/presentation/providers/mala_settings
 import 'package:flutter_pecha/features/practice/data/datasource/bookmark_remote_datasource.dart';
 import 'package:flutter_pecha/features/practice/presentation/controllers/bookmark_controller.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/bookmark_providers.dart';
+import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_pecha/shared/widgets/app_toggle_switch.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:share_plus/share_plus.dart';
 
 class MalaSettingsSheet extends ConsumerWidget {
   const MalaSettingsSheet({super.key, required this.mantra});
@@ -97,6 +100,12 @@ class MalaSettingsSheet extends ConsumerWidget {
             ),
             Divider(height: 1, color: dividerColor),
             _MalaSettingsTile(
+              icon: AppAssets.readerShare,
+              label: l10n.share,
+              onTap: () => _onShare(context),
+            ),
+            Divider(height: 1, color: dividerColor),
+            _MalaSettingsTile(
               icon: AppAssets.arrowCounterClockwise,
               label: l10n.mala_reset_count,
               labelColor: destructiveColor,
@@ -107,6 +116,21 @@ class MalaSettingsSheet extends ConsumerWidget {
             const SizedBox(height: 8),
           ],
         ),
+      ),
+    );
+  }
+
+  Future<void> _onShare(BuildContext context) async {
+    final navigator = Navigator.of(context);
+    final sharePositionOrigin = getSharePositionOrigin(context: context);
+    final shareUrl = DeepLinkUrlBuilder.malaLink(presetId: mantra.presetId).toString();
+    const shareMessage =
+        "I've been using this digital mala on WeBuddhist and wanted to share it with you. It's an easy way to practice wherever you go.";
+    navigator.pop();
+    await SharePlus.instance.share(
+      ShareParams(
+        text: '$shareMessage\n\n$shareUrl',
+        sharePositionOrigin: sharePositionOrigin,
       ),
     );
   }

--- a/lib/features/more/presentation/widgets/streak_share_sheet.dart
+++ b/lib/features/more/presentation/widgets/streak_share_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/theme/app_theme.dart';
@@ -95,9 +96,14 @@ Future<void> shareStreakQuote(
       globalKey: shareOriginKey,
     );
 
+    final moreLink = DeepLinkUrlBuilder.moreLink().toString();
+    const shareMessage =
+        "I've been building a daily practice habit and wanted to share it with you. It's easier to keep it up with a friend. Join me on WeBuddhist.";
+
     await SharePlus.instance.share(
       ShareParams(
         files: [XFile(tempFile.path)],
+        text: '$shareMessage\n\n$moreLink',
         sharePositionOrigin: sharePositionOrigin,
       ),
     );

--- a/lib/features/plans/services/plan_share_service.dart
+++ b/lib/features/plans/services/plan_share_service.dart
@@ -21,7 +21,7 @@ class PlanShareService {
 
   /// Generate share message with plan details
   String generateShareMessage(String planTitle, String deepLink) {
-    return 'Join me in practicing $planTitle on WeBuddhist.\n\n$deepLink';
+    return "I'm following this Buddhist practice plan and wanted to share it with you. You can join me for free on WeBuddhist.\n\n$deepLink";
   }
 
   /// Share a plan with friends

--- a/lib/features/practice/presentation/screens/all_recitations_screen.dart
+++ b/lib/features/practice/presentation/screens/all_recitations_screen.dart
@@ -3,15 +3,13 @@ import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/widgets/error_state_widget.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/practice_recitations_paginated_provider.dart';
 import 'package:flutter_pecha/features/practice/presentation/screens/recitations_search_screen.dart';
+import 'package:flutter_pecha/features/practice/presentation/utils/recitation_reader_navigation.dart';
 import 'package:flutter_pecha/features/practice/presentation/widgets/practice_chant_list_tile.dart';
-import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 import 'package:flutter_pecha/features/recitation/presentation/widgets/recitation_list_skeleton.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class AllRecitationsScreen extends ConsumerStatefulWidget {
-  const AllRecitationsScreen({super.key, required this.onTap});
-
-  final ValueChanged<RecitationModel> onTap;
+  const AllRecitationsScreen({super.key});
 
   @override
   ConsumerState<AllRecitationsScreen> createState() =>
@@ -43,7 +41,7 @@ class _AllRecitationsScreenState extends ConsumerState<AllRecitationsScreen> {
 
   void _openSearch(BuildContext context) {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => RecitationsSearchScreen(onTap: widget.onTap)),
+      MaterialPageRoute(builder: (_) => const RecitationsSearchScreen()),
     );
   }
 
@@ -111,7 +109,7 @@ class _AllRecitationsScreenState extends ConsumerState<AllRecitationsScreen> {
         final recitation = state.recitations[index];
         return PracticeChantListTile(
           recitation: recitation,
-          onTap: () => widget.onTap(recitation),
+          onTap: () => openRecitationReader(context, recitation),
         );
       },
     );

--- a/lib/features/practice/presentation/screens/recitations_search_screen.dart
+++ b/lib/features/practice/presentation/screens/recitations_search_screen.dart
@@ -1,17 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/features/practice/presentation/utils/recitation_reader_navigation.dart';
 import 'package:flutter_pecha/features/practice/presentation/widgets/practice_chant_list_tile.dart';
-import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 import 'package:flutter_pecha/features/recitation/presentation/providers/recitation_search_provider.dart';
 import 'package:flutter_pecha/features/recitation/presentation/providers/recitations_providers.dart';
 import 'package:flutter_pecha/features/recitation/presentation/widgets/recitation_list_skeleton.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class RecitationsSearchScreen extends ConsumerStatefulWidget {
-  const RecitationsSearchScreen({super.key, required this.onTap});
-
-  final ValueChanged<RecitationModel> onTap;
+  const RecitationsSearchScreen({super.key});
 
   @override
   ConsumerState<RecitationsSearchScreen> createState() =>
@@ -205,7 +203,7 @@ class _RecitationsSearchScreenState
         final recitation = searchState.results[index];
         return PracticeChantListTile(
           recitation: recitation,
-          onTap: () => widget.onTap(recitation),
+          onTap: () => openRecitationReader(context, recitation),
         );
       },
     );

--- a/lib/features/practice/presentation/utils/recitation_reader_navigation.dart
+++ b/lib/features/practice/presentation/utils/recitation_reader_navigation.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
+import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
+import 'package:go_router/go_router.dart';
+
+/// Opens a chant/recitation in the shared reader with practice-context actions
+/// (e.g. "Add to my practices" in the more menu).
+void openRecitationReader(BuildContext context, RecitationModel recitation) {
+  context.push(
+    '/reader/${recitation.textId}',
+    extra: const NavigationContext(source: NavigationSource.recitationList),
+  );
+}

--- a/lib/features/practice/presentation/widgets/practice_chants_section.dart
+++ b/lib/features/practice/presentation/widgets/practice_chants_section.dart
@@ -2,13 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/practice_explore_providers.dart';
 import 'package:flutter_pecha/features/practice/presentation/screens/all_recitations_screen.dart';
+import 'package:flutter_pecha/features/practice/presentation/utils/recitation_reader_navigation.dart';
 import 'package:flutter_pecha/features/practice/presentation/widgets/practice_chant_list_tile.dart';
 import 'package:flutter_pecha/features/practice/presentation/widgets/practice_section_container.dart';
 import 'package:flutter_pecha/features/practice/presentation/widgets/practice_section_skeleton.dart';
-import 'package:flutter_pecha/features/reader/data/models/navigation_context.dart';
-import 'package:flutter_pecha/features/recitation/data/models/recitation_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class PracticeChantsSection extends ConsumerWidget {
   const PracticeChantsSection({super.key});
@@ -38,7 +36,8 @@ class PracticeChantsSection extends ConsumerWidget {
                             .map(
                               (r) => PracticeChantListTile(
                                 recitation: r,
-                                onTap: () => _navigateToRecitation(context, r),
+                                onTap:
+                                    () => openRecitationReader(context, r),
                               ),
                             )
                             .toList(),
@@ -57,21 +56,9 @@ class PracticeChantsSection extends ConsumerWidget {
     );
   }
 
-  void _navigateToRecitation(BuildContext context, RecitationModel recitation) {
-    final navigationContext = NavigationContext(
-      source: NavigationSource.recitationList,
-    );
-    context.push('/reader/${recitation.textId}', extra: navigationContext);
-  }
-
   void _showAllRecitations(BuildContext context) {
     Navigator.of(context).push(
-      MaterialPageRoute(
-        builder:
-            (_) => AllRecitationsScreen(
-              onTap: (r) => _navigateToRecitation(context, r),
-            ),
-      ),
+      MaterialPageRoute(builder: (_) => const AllRecitationsScreen()),
     );
   }
 }

--- a/lib/features/reader/presentation/widgets/reader_actions/segement_action_bar.dart
+++ b/lib/features/reader/presentation/widgets/reader_actions/segement_action_bar.dart
@@ -764,8 +764,13 @@ class _ShareButtonState extends ConsumerState<_ShareButton> {
       if (!mounted) return;
 
       final sharePositionOrigin = getSharePositionOrigin(context: context);
+      const shareMessage =
+          'I liked this passage and wanted to share it with you. You can read the whole quote in context on WeBuddhist.';
       await SharePlus.instance.share(
-        ShareParams(text: shareUrl, sharePositionOrigin: sharePositionOrigin),
+        ShareParams(
+          text: '$shareMessage\n\n$shareUrl',
+          sharePositionOrigin: sharePositionOrigin,
+        ),
       );
       widget.onClose();
     } catch (e) {

--- a/lib/features/reader/presentation/widgets/reader_app_bar/reader_more_bottom_sheet.dart
+++ b/lib/features/reader/presentation/widgets/reader_app_bar/reader_more_bottom_sheet.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/practice/data/datasource/bookmark_remote_datasource.dart';
 import 'package:flutter_pecha/features/practice/presentation/controllers/bookmark_controller.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/bookmark_providers.dart';
 import 'package:flutter_pecha/features/reader/presentation/widgets/reader_app_bar/reader_font_size_bottom_sheet.dart';
 import 'package:flutter_pecha/features/texts/presentation/providers/font_size_notifier.dart';
+import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
 /// Bottom sheet opened from the reader's three-dot (⋮) button.
 ///
@@ -34,6 +37,7 @@ class ReaderMoreBottomSheet extends ConsumerStatefulWidget {
 
 class _ReaderMoreBottomSheetState extends ConsumerState<ReaderMoreBottomSheet> {
   bool _isBookmarking = false;
+  bool _isSharing = false;
 
   BookmarkTarget get _bookmarkTarget => BookmarkTarget(
         type: BookmarkType.text,
@@ -52,6 +56,23 @@ class _ReaderMoreBottomSheetState extends ConsumerState<ReaderMoreBottomSheet> {
       if (mounted && didToggle) nav.pop();
     } finally {
       if (mounted) setState(() => _isBookmarking = false);
+    }
+  }
+
+  Future<void> _share() async {
+    if (_isSharing) return;
+    setState(() => _isSharing = true);
+    try {
+      final shareUrl =
+          DeepLinkUrlBuilder.readerLink(textId: widget.textId).toString();
+      if (!mounted) return;
+      final sharePositionOrigin = getSharePositionOrigin(context: context);
+      await SharePlus.instance.share(
+        ShareParams(text: shareUrl, sharePositionOrigin: sharePositionOrigin),
+      );
+      if (mounted) Navigator.of(context).pop();
+    } finally {
+      if (mounted) setState(() => _isSharing = false);
     }
   }
 
@@ -193,6 +214,27 @@ class _ReaderMoreBottomSheetState extends ConsumerState<ReaderMoreBottomSheet> {
             onTap: () {
               HapticFeedback.lightImpact();
               _toggleBookmark();
+            },
+          ),
+
+          // ── Share ──────────────────────────────────────────────────────
+          _SectionDivider(theme: theme),
+          ListTile(
+            leading:
+                _isSharing
+                    ? SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: theme.colorScheme.onSurface,
+                      ),
+                    )
+                    : Icon(Icons.share, color: theme.colorScheme.onSurface),
+            title: Text('Share', style: theme.textTheme.bodyLarge),
+            onTap: () {
+              HapticFeedback.lightImpact();
+              _share();
             },
           ),
 

--- a/lib/features/reader/presentation/widgets/reader_app_bar/reader_more_bottom_sheet.dart
+++ b/lib/features/reader/presentation/widgets/reader_app_bar/reader_more_bottom_sheet.dart
@@ -67,8 +67,13 @@ class _ReaderMoreBottomSheetState extends ConsumerState<ReaderMoreBottomSheet> {
           DeepLinkUrlBuilder.readerLink(textId: widget.textId).toString();
       if (!mounted) return;
       final sharePositionOrigin = getSharePositionOrigin(context: context);
+      const shareMessage =
+          'I wanted to share this chant with you. You can practice it and find a whole library of other chants and texts on WeBuddhist.';
       await SharePlus.instance.share(
-        ShareParams(text: shareUrl, sharePositionOrigin: sharePositionOrigin),
+        ShareParams(
+          text: '$shareMessage\n\n$shareUrl',
+          sharePositionOrigin: sharePositionOrigin,
+        ),
       );
       if (mounted) Navigator.of(context).pop();
     } finally {

--- a/lib/features/timer/presentation/widgets/timer_more_bottom_sheet.dart
+++ b/lib/features/timer/presentation/widgets/timer_more_bottom_sheet.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/practice/data/datasource/bookmark_remote_datasource.dart';
 import 'package:flutter_pecha/features/practice/presentation/controllers/bookmark_controller.dart';
 import 'package:flutter_pecha/features/practice/presentation/providers/bookmark_providers.dart';
 import 'package:flutter_pecha/features/timer/domain/entities/preset_timer.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
 /// Bottom sheet opened from the three-dot (⋮) button on a [PresetTimerCard].
 ///
@@ -30,11 +32,29 @@ class TimerMoreBottomSheet extends ConsumerStatefulWidget {
 
 class _TimerMoreBottomSheetState extends ConsumerState<TimerMoreBottomSheet> {
   bool _isBookmarking = false;
+  bool _isSharing = false;
 
   BookmarkTarget get _bookmarkTarget => BookmarkTarget(
         type: BookmarkType.timer,
         sourceId: widget.timer.id,
       );
+
+  Future<void> _share() async {
+    if (_isSharing) return;
+    setState(() => _isSharing = true);
+    try {
+      final nav = Navigator.of(context);
+      final shareUrl = DeepLinkUrlBuilder.timerLink(timerId: widget.timer.id).toString();
+      const shareMessage =
+          'I wanted to share this meditation timer from WeBuddhist with you. It makes it easy to build a meditation practice.';
+      nav.pop();
+      await SharePlus.instance.share(
+        ShareParams(text: '$shareMessage\n\n$shareUrl'),
+      );
+    } finally {
+      if (mounted) setState(() => _isSharing = false);
+    }
+  }
 
   Future<void> _toggleBookmark() async {
     if (_isBookmarking) return;
@@ -113,6 +133,27 @@ class _TimerMoreBottomSheetState extends ConsumerState<TimerMoreBottomSheet> {
             onTap: () {
               HapticFeedback.lightImpact();
               _toggleBookmark();
+            },
+          ),
+
+          // ── Share ──────────────────────────────────────────────────────
+          _SectionDivider(theme: theme),
+          ListTile(
+            leading:
+                _isSharing
+                    ? SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: theme.colorScheme.onSurface,
+                      ),
+                    )
+                    : Icon(AppAssets.readerShare, color: theme.colorScheme.onSurface),
+            title: Text(l10n.share, style: theme.textTheme.bodyLarge),
+            onTap: () {
+              HapticFeedback.lightImpact();
+              _share();
             },
           ),
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:flutter_pecha/features/push_notifications/presentation/providers
 import 'package:flutter_pecha/features/home/data/datasource/home_local_datasource.dart';
 import 'package:flutter_pecha/features/home/presentation/providers/use_case_providers.dart';
 import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_pecha/features/home/presentation/screens/main_navigation_screen.dart';
 import 'package:flutter_pecha/features/mala/data/datasources/mala_local_datasource.dart';
 import 'package:flutter_pecha/features/mala/presentation/providers/mala_providers.dart';
 import 'package:flutter_pecha/features/more/data/datasource/user_stats_local_datasource.dart';
@@ -263,6 +264,9 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         AirbridgeDeepLinkService.setRouter(router);
         AppLinksDeepLinkService.instance.setRouter(router);
+        AppLinksDeepLinkService.instance.setTabSetter((int tabIndex) {
+          ref.read(mainNavigationIndexProvider.notifier).state = tabIndex;
+        });
       });
       _hasRegisteredDeepLinkRouters = true;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -1145,18 +1145,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   tibetan_calendar:
     dependency: "direct main"
     description:


### PR DESCRIPTION
feat: add descriptive copy to plan, text, and segment share links

Replace URL-only shares with message + deep link for:
- practice plan invites
- chant/text shares from the reader menu
- passage/segment shares from the reader action bar

This gives recipients context before they tap the link and keeps share
copy consistent across the app.