### PR TITLE
feat: implement sharing functionality for plan day images

### DIFF
--- a/lib/features/plans/presentation/utils/plan_day_share.dart
+++ b/lib/features/plans/presentation/utils/plan_day_share.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/shared/utils/helper_functions.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Downloads the plan day's shareable image and shares it together with the
+/// day completion message and the plan day deep link.
+Future<void> sharePlanDayImage({
+  required BuildContext context,
+  required String shareableImageUrl,
+  required int dayNumber,
+  required String planId,
+  required String planLanguage,
+  GlobalKey? shareButtonKey,
+}) async {
+  final url = shareableImageUrl.trim();
+  if (url.isEmpty) return;
+
+  File? tempFile;
+  try {
+    final uri = Uri.parse(url);
+    final response = await http.get(uri).timeout(const Duration(seconds: 15));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to download share image (${response.statusCode})',
+        uri: uri,
+      );
+    }
+
+    final directory = await getTemporaryDirectory();
+    final extension = _imageExtensionFromUrl(uri);
+    tempFile = File(
+      '${directory.path}/plan_day_${dayNumber}_${DateTime.now().millisecondsSinceEpoch}.$extension',
+    );
+    await tempFile.writeAsBytes(response.bodyBytes);
+
+    if (!context.mounted) return;
+
+    final sharePositionOrigin = getSharePositionOrigin(
+      context: context,
+      globalKey: shareButtonKey,
+    );
+
+    final shareMessage = context.l10n.day_completion_share_message;
+    final planLink =
+        DeepLinkUrlBuilder.planDayLink(
+          planId: planId,
+          dayNumber: dayNumber,
+          language: planLanguage,
+        ).toString();
+
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [XFile(tempFile.path)],
+        text: '$shareMessage\n\n$planLink',
+        sharePositionOrigin: sharePositionOrigin,
+      ),
+    );
+  } catch (_) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.create_image_share_error),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  } finally {
+    if (tempFile != null && await tempFile.exists()) {
+      try {
+        await tempFile.delete();
+      } catch (_) {
+        // Best-effort temp cleanup.
+      }
+    }
+  }
+}
+
+String _imageExtensionFromUrl(Uri uri) {
+  final lastSegment = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : '';
+  final extension =
+      lastSegment.contains('.')
+          ? lastSegment.split('.').last.toLowerCase()
+          : '';
+  switch (extension) {
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'webp':
+      return extension;
+    default:
+      return 'png';
+  }
+}

--- a/lib/features/plans/presentation/widgets/day_completion_bottom_sheet.dart
+++ b/lib/features/plans/presentation/widgets/day_completion_bottom_sheet.dart
@@ -1,14 +1,8 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
-import 'package:flutter_pecha/core/deep_linking/deep_link_url_builder.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
-import 'package:flutter_pecha/shared/utils/helper_functions.dart';
-import 'package:http/http.dart' as http;
-import 'package:path_provider/path_provider.dart';
-import 'package:share_plus/share_plus.dart';
+import 'package:flutter_pecha/features/plans/presentation/utils/plan_day_share.dart';
 
 class DayCompletionBottomSheet extends StatefulWidget {
   final int dayNumber;
@@ -211,84 +205,19 @@ class _DayCompletionBottomSheetState extends State<DayCompletionBottomSheet> {
 
     setState(() => _isSharing = true);
 
-    File? tempFile;
     try {
-      final uri = Uri.parse(url);
-      final response = await http.get(uri);
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        throw HttpException(
-          'Failed to download share image (${response.statusCode})',
-          uri: uri,
-        );
-      }
-
-      final directory = await getTemporaryDirectory();
-      final extension = _imageExtensionFromUrl(uri);
-      tempFile = File(
-        '${directory.path}/plan_day_${widget.dayNumber}_${DateTime.now().millisecondsSinceEpoch}.$extension',
-      );
-      await tempFile.writeAsBytes(response.bodyBytes);
-
-      if (!mounted) return;
-
-      final sharePositionOrigin = getSharePositionOrigin(
+      await sharePlanDayImage(
         context: context,
-        globalKey: _shareButtonKey,
-      );
-
-      final shareMessage = context.l10n.day_completion_share_message;
-      final planLink = DeepLinkUrlBuilder.planDayLink(
-        planId: widget.planId,
+        shareableImageUrl: url,
         dayNumber: widget.dayNumber,
-        language: widget.planLanguage,
-      ).toString();
-
-      await SharePlus.instance.share(
-        ShareParams(
-          files: [XFile(tempFile.path)],
-          text: '$shareMessage\n\n$planLink',
-          sharePositionOrigin: sharePositionOrigin,
-        ),
+        planId: widget.planId,
+        planLanguage: widget.planLanguage,
+        shareButtonKey: _shareButtonKey,
       );
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.create_image_share_error),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
     } finally {
-      if (tempFile != null && await tempFile.exists()) {
-        try {
-          await tempFile.delete();
-        } catch (_) {
-          // Best-effort temp cleanup.
-        }
-      }
-
       if (mounted) {
         setState(() => _isSharing = false);
       }
-    }
-  }
-
-  String _imageExtensionFromUrl(Uri uri) {
-    final lastSegment =
-        uri.pathSegments.isNotEmpty ? uri.pathSegments.last : '';
-    final extension =
-        lastSegment.contains('.')
-            ? lastSegment.split('.').last.toLowerCase()
-            : '';
-    switch (extension) {
-      case 'jpg':
-      case 'jpeg':
-      case 'png':
-      case 'webp':
-        return extension;
-      default:
-        return 'png';
     }
   }
 

--- a/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
+++ b/lib/features/plans/presentation/widgets/plan_track/plan_details.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/analytics/analytics_events.dart';
 import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/core/config/router/app_routes.dart';
 import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
@@ -23,6 +24,7 @@ import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.d
 import 'package:flutter_pecha/features/plans/data/utils/series_plan_utils.dart';
 import 'package:flutter_pecha/features/plans/data/models/user/user_tasks_dto.dart';
 import 'package:flutter_pecha/features/plans/domain/subtask_navigation.dart';
+import 'package:flutter_pecha/features/plans/presentation/utils/plan_day_share.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_navigation/plan_navigator.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/plans/data/models/response/user_plan_day_detail_response.dart';
@@ -60,6 +62,8 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
   final Set<String> _togglingTaskIds = {};
   final Map<int, bool> _dayCompletionTracker = {};
   final Map<String, bool> _optimisticCompletions = {};
+  final GlobalKey _shareButtonKey = GlobalKey();
+  bool _isSharing = false;
 
   @override
   void initState() {
@@ -215,7 +219,14 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
     return AppBar(
       leading: IconButton(
         icon: const Icon(AppAssets.arrowLeft),
-        onPressed: () => context.pop(),
+        onPressed: () {
+          if (context.canPop()) {
+            context.pop();
+          } else {
+            // Opened via deep link with no route beneath — go home.
+            context.go(AppRoutes.home);
+          }
+        },
       ),
       title: Text(widget.plan.title, style: TextStyle(fontSize: 20)),
       elevation: 0,
@@ -711,38 +722,101 @@ class _PlanDetailsState extends ConsumerState<PlanDetails> {
         tasks.isNotEmpty &&
         tasks.any(PlanSubtaskNavigation.isUserTaskNavigable);
 
+    final shareableImageUrl = dayData?.shareableImageUrl?.trim();
+    final showShareButton =
+        dayData != null &&
+        dayData.isCompleted &&
+        shareableImageUrl != null &&
+        shareableImageUrl.isNotEmpty;
+
+    final buttonStyle = FilledButton.styleFrom(
+      backgroundColor: Theme.of(context).colorScheme.onSurface,
+      foregroundColor: Theme.of(context).colorScheme.surface,
+      disabledBackgroundColor: Theme.of(
+        context,
+      ).colorScheme.onSurface.withValues(alpha: 0.5),
+      disabledForegroundColor: Theme.of(
+        context,
+      ).colorScheme.surface.withValues(alpha: 0.85),
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+    );
+
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: SizedBox(
           width: double.infinity,
-          child: FilledButton(
-            onPressed:
-                hasReadableContent
-                    ? () => _startReading(tasks, audioUrl: audioUrl)
-                    : null,
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.onSurface,
-              foregroundColor: Theme.of(context).colorScheme.surface,
-              disabledBackgroundColor: Theme.of(
-                context,
-              ).colorScheme.onSurface.withValues(alpha: 0.5),
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-              ),
-            ),
-            child: Text(
-              localizations.start_reading,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                letterSpacing: -0.3,
-              ),
-            ),
-          ),
+          child:
+              showShareButton
+                  ? FilledButton.icon(
+                    key: _shareButtonKey,
+                    onPressed:
+                        _isSharing
+                            ? null
+                            : () =>
+                                _shareDay(shareableImageUrl, dayData.dayNumber),
+                    style: buttonStyle,
+                    icon:
+                        _isSharing
+                            ? SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.surface.withValues(alpha: 0.85),
+                              ),
+                            )
+                            : const Icon(AppAssets.readerShare, size: 22),
+                    label: Text(
+                      localizations.share,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: -0.3,
+                      ),
+                    ),
+                  )
+                  : FilledButton(
+                    onPressed:
+                        hasReadableContent
+                            ? () => _startReading(tasks, audioUrl: audioUrl)
+                            : null,
+                    style: buttonStyle,
+                    child: Text(
+                      localizations.start_reading,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: -0.3,
+                      ),
+                    ),
+                  ),
         ),
       ),
     );
+  }
+
+  Future<void> _shareDay(String shareableImageUrl, int dayNumber) async {
+    if (_isSharing) return;
+
+    setState(() => _isSharing = true);
+
+    try {
+      await sharePlanDayImage(
+        context: context,
+        shareableImageUrl: shareableImageUrl,
+        dayNumber: dayNumber,
+        planId: widget.plan.id,
+        planLanguage: widget.plan.language,
+        shareButtonKey: _shareButtonKey,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSharing = false);
+      }
+    }
   }
 }

--- a/test/features/plans/plan_details_share_button_test.dart
+++ b/test/features/plans/plan_details_share_button_test.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/analytics/analytics_service.dart';
+import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
+import 'package:flutter_pecha/core/config/router/app_routes.dart';
+import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/error/failures.dart';
+import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
+import 'package:flutter_pecha/features/home/presentation/providers/series_provider.dart';
+import 'package:flutter_pecha/features/plans/data/models/plan_days_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/response/user_plan_day_detail_response.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_plans_model.dart';
+import 'package:flutter_pecha/features/plans/data/models/user/user_tasks_dto.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/plan_days_providers.dart';
+import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/plans/presentation/widgets/plan_track/plan_details.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:go_router/go_router.dart';
+
+/// No-op analytics so PlanDetails' initState tracking is inert in tests.
+class _FakeAnalyticsService implements AnalyticsService {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> identify({
+    required String userId,
+    Map<String, Object?>? properties,
+  }) async {}
+
+  @override
+  Future<void> reset() async {}
+
+  @override
+  Future<void> track(String event, {Map<String, Object?>? properties}) async {}
+
+  @override
+  Future<void> setSuperProperties(Map<String, Object?> properties) async {}
+
+  @override
+  NavigatorObserver get routeObserver => NavigatorObserver();
+}
+
+UserPlansModel _makePlan() => UserPlansModel(
+  id: 'plan-1',
+  title: 'Chapter 1: Benefits of Bodhicitta',
+  description: 'Test plan',
+  language: 'en',
+  difficultyLevel: null,
+  startedAt: DateTime(2026, 7, 1),
+  totalDays: 14,
+  tags: null,
+);
+
+UserPlanDayDetailResponse _makeDay({
+  required bool isCompleted,
+  String? shareableImageUrl,
+}) => UserPlanDayDetailResponse(
+  id: 'day-1',
+  dayNumber: 1,
+  tasks: [
+    UserTasksDto(
+      id: 'task-1',
+      title: 'Introduction',
+      estimatedTime: null,
+      displayOrder: 1,
+      isCompleted: isCompleted,
+      subTasks: const [],
+    ),
+  ],
+  isCompleted: isCompleted,
+  shareableImageUrl: shareableImageUrl,
+);
+
+List<Override> _overridesFor(UserPlanDayDetailResponse day) => [
+  analyticsServiceProvider.overrideWithValue(_FakeAnalyticsService()),
+  userPlanDayContentFutureProvider.overrideWith(
+    (ref, params) => Stream.value(Right(day)),
+  ),
+  userPlanDaysCompletionStatusProvider.overrideWith(
+    (ref, planId) => Stream.value(Right({1: day.isCompleted})),
+  ),
+  planDaysByPlanIdFutureProvider.overrideWith(
+    (ref, planId) => Stream.value(const Right(<PlanDaysModel>[])),
+  ),
+  seriesListFutureProvider.overrideWith(
+    (ref) => Stream.value(const Left(NetworkFailure('test'))),
+  ),
+  userSeriesEnrollmentsProvider.overrideWith((ref) => Stream.value(<String>{})),
+];
+
+Future<void> _pumpDetails(
+  WidgetTester tester,
+  UserPlanDayDetailResponse day,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: _overridesFor(day),
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: PlanDetails(
+          plan: _makePlan(),
+          selectedDay: 1,
+          startDate: DateTime(2026, 7, 1),
+        ),
+      ),
+    ),
+  );
+  // Let the overridden streams emit and the UI settle.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+/// FilledButton.icon builds a private FilledButton subclass, which
+/// find.byType/widgetWithText (exact runtimeType match) would miss.
+Finder _buttonWith(String label) => find.ancestor(
+  of: find.text(label),
+  matching: find.byWidgetPredicate((w) => w is FilledButton),
+);
+
+FilledButton _bottomButton(WidgetTester tester, String label) =>
+    tester.widget<FilledButton>(_buttonWith(label));
+
+void main() {
+  group('bottom button swaps between Practice now and Share', () {
+    testWidgets('incomplete day shows Practice now', (tester) async {
+      await _pumpDetails(
+        tester,
+        _makeDay(
+          isCompleted: false,
+          shareableImageUrl: 'https://example.com/img.png',
+        ),
+      );
+
+      expect(_buttonWith('Practice now'), findsOneWidget);
+      expect(_buttonWith('Share'), findsNothing);
+    });
+
+    testWidgets('completed day with shareable image shows Share', (
+      tester,
+    ) async {
+      await _pumpDetails(
+        tester,
+        _makeDay(
+          isCompleted: true,
+          shareableImageUrl: 'https://example.com/img.png',
+        ),
+      );
+
+      expect(_buttonWith('Share'), findsOneWidget);
+      expect(_buttonWith('Practice now'), findsNothing);
+      expect(_bottomButton(tester, 'Share').onPressed, isNotNull);
+    });
+
+    testWidgets('completed day without shareable image keeps Practice now', (
+      tester,
+    ) async {
+      await _pumpDetails(
+        tester,
+        _makeDay(isCompleted: true, shareableImageUrl: null),
+      );
+
+      expect(_buttonWith('Practice now'), findsOneWidget);
+      expect(_buttonWith('Share'), findsNothing);
+    });
+
+    testWidgets('whitespace-only shareable image keeps Practice now', (
+      tester,
+    ) async {
+      await _pumpDetails(
+        tester,
+        _makeDay(isCompleted: true, shareableImageUrl: '   '),
+      );
+
+      expect(_buttonWith('Practice now'), findsOneWidget);
+      expect(_buttonWith('Share'), findsNothing);
+    });
+
+    testWidgets(
+      'tapping Share surfaces the error and re-enables the button when the '
+      'download fails (test env blocks HTTP)',
+      (tester) async {
+        await _pumpDetails(
+          tester,
+          _makeDay(
+            isCompleted: true,
+            shareableImageUrl: 'https://example.com/img.png',
+          ),
+        );
+
+        await tester.tap(find.text('Share'));
+        await tester.pump();
+        await tester.pump();
+
+        // Flutter's test HTTP client rejects the request, so the failure
+        // path must show the error snackbar and reset the button.
+        expect(find.text('Unable to share. Please try again'), findsOneWidget);
+        expect(_bottomButton(tester, 'Share').onPressed, isNotNull);
+
+        // Drain the snackbar's dismiss timer.
+        await tester.pump(const Duration(seconds: 20));
+      },
+    );
+  });
+
+  group('back button', () {
+    GoRouter buildRouter(String initialLocation) => GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: AppRoutes.home,
+          builder:
+              (context, state) =>
+                  const Scaffold(body: Center(child: Text('HOME MARKER'))),
+        ),
+        GoRoute(
+          path: '/details',
+          builder:
+              (context, state) => PlanDetails(
+                plan: _makePlan(),
+                selectedDay: 1,
+                startDate: DateTime(2026, 7, 1),
+              ),
+        ),
+      ],
+    );
+
+    Future<void> pumpRouter(WidgetTester tester, GoRouter router) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _overridesFor(
+            _makeDay(isCompleted: false, shareableImageUrl: null),
+          ),
+          child: MaterialApp.router(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    testWidgets('pops back to the previous screen when pushed', (tester) async {
+      final router = buildRouter(AppRoutes.home);
+      await pumpRouter(tester, router);
+      expect(find.text('HOME MARKER'), findsOneWidget);
+
+      router.push('/details');
+      await tester.pumpAndSettle();
+      expect(find.byIcon(AppAssets.arrowLeft), findsOneWidget);
+
+      await tester.tap(find.byIcon(AppAssets.arrowLeft));
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME MARKER'), findsOneWidget);
+    });
+
+    testWidgets('goes home when there is nothing to pop (deep link entry)', (
+      tester,
+    ) async {
+      final router = buildRouter('/details');
+      await pumpRouter(tester, router);
+      expect(find.text('HOME MARKER'), findsNothing);
+
+      await tester.tap(find.byIcon(AppAssets.arrowLeft));
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME MARKER'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
- Added a new utility function `sharePlanDayImage` to handle the downloading and sharing of plan day images along with a completion message and deep link.
- Refactored the `DayCompletionBottomSheet` and `PlanDetails` widgets to utilize the new sharing functionality, improving code organization and reducing duplication.
- Introduced tests for the share button functionality to ensure proper behavior under various conditions.