### PR TITLE
bug home screen stats count

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -24,6 +24,8 @@ import 'package:flutter_pecha/features/home/presentation/widgets/verse_of_day_sk
 import 'package:flutter_pecha/features/notifications/application/notification_sync_engine.dart';
 import 'package:flutter_pecha/features/plans/data/utils/plan_utils.dart';
 import 'package:flutter_pecha/features/plans/presentation/providers/user_plans_provider.dart';
+import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
+import 'package:flutter_pecha/features/practice/presentation/providers/routine_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
@@ -260,6 +262,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Widget _buildMyPracticesSection() {
     final routineInfoAsync = ref.watch(routineInfoFutureProvider);
+    final routineData = ref.watch(routineProvider);
+    final hasLocalRoutine = routineData.blocks.isNotEmpty;
 
     return routineInfoAsync.when(
       data: (infoEither) {
@@ -268,7 +272,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             return const SizedBox.shrink();
           }
           return MyPracticesStatsCard(
-            routineInfo: info,
+            planCount: hasLocalRoutine
+                ? routineData.uniqueItemCount(RoutineItemType.series)
+                : info.seriesCount,
+            chantCount: hasLocalRoutine
+                ? routineData.uniqueItemCount(RoutineItemType.recitation)
+                : info.recitationCount,
             onTap: () => context.pushNamed('my-practices'),
           );
         });

--- a/lib/features/home/presentation/widgets/my_practices_stats_card.dart
+++ b/lib/features/home/presentation/widgets/my_practices_stats_card.dart
@@ -2,17 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
-import 'package:flutter_pecha/features/home/domain/entities/routine_info.dart';
 import 'package:flutter_pecha/shared/utils/helper_functions.dart';
 
 class MyPracticesStatsCard extends StatelessWidget {
   const MyPracticesStatsCard({
     super.key,
-    required this.routineInfo,
+    required this.planCount,
+    required this.chantCount,
     this.onTap,
   });
 
-  final RoutineInfo routineInfo;
+  final int planCount;
+  final int chantCount;
   final VoidCallback? onTap;
 
   static const _borderRadius = 20.0;
@@ -68,14 +69,14 @@ class MyPracticesStatsCard extends StatelessWidget {
                     Expanded(
                       child: _StatItem(
                         icon: AppAssets.homeList,
-                        count: routineInfo.seriesCount,
+                        count: planCount,
                         labelBuilder: l10n.home_plans_count,
                       ),
                     ),
                     Expanded(
                       child: _StatItem(
                         icon: AppAssets.bookOpenText,
-                        count: routineInfo.recitationCount,
+                        count: chantCount,
                         labelBuilder: l10n.home_recitation_count,
                       ),
                     ),

--- a/lib/features/practice/data/models/routine_model.dart
+++ b/lib/features/practice/data/models/routine_model.dart
@@ -285,6 +285,15 @@ class RoutineData {
   /// Whether the maximum block limit has been reached.
   bool get isAtMaxBlocks => blocks.length >= maxBlocks;
 
+  /// Distinct sources of [type] across all blocks. The same plan added to
+  /// several time blocks is one plan, not one per block.
+  int uniqueItemCount(RoutineItemType type) => blocks
+      .expand((b) => b.items)
+      .where((i) => i.type == type)
+      .map((i) => i.id)
+      .toSet()
+      .length;
+
   /// Returns a new RoutineData with blocks sorted by time ascending.
   RoutineData get sortedByTime {
     final sorted = List<RoutineBlock>.from(blocks)

--- a/test/features/practice/routine_unique_item_count_test.dart
+++ b/test/features/practice/routine_unique_item_count_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/practice/data/models/routine_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  RoutineItem series(String id) => RoutineItem(
+    id: id,
+    title: id,
+    type: RoutineItemType.series,
+  );
+
+  RoutineItem chant(String id) => RoutineItem(
+    id: id,
+    title: id,
+    type: RoutineItemType.recitation,
+  );
+
+  RoutineBlock block(List<RoutineItem> items, {int hour = 6, int minute = 0}) {
+    return RoutineBlock(
+      time: TimeOfDay(hour: hour, minute: minute),
+      items: items,
+    );
+  }
+
+  test('one plan across multiple time blocks counts as 1', () {
+    final data = RoutineData(
+      blocks: [
+        block([series('bodhisattva')], hour: 6, minute: 6),
+        block([series('bodhisattva')], hour: 6, minute: 16),
+        block([series('bodhisattva')], hour: 11, minute: 21),
+        block([series('bodhisattva')], hour: 12, minute: 7),
+        block([series('bodhisattva')], hour: 18, minute: 23),
+      ],
+    );
+
+    expect(data.uniqueItemCount(RoutineItemType.series), 1);
+    expect(data.uniqueItemCount(RoutineItemType.recitation), 0);
+  });
+
+  test('two distinct plans count as 2', () {
+    final data = RoutineData(
+      blocks: [
+        block([series('plan-a')], hour: 6),
+        block([series('plan-b')], hour: 7),
+        block([series('plan-a')], hour: 8),
+      ],
+    );
+
+    expect(data.uniqueItemCount(RoutineItemType.series), 2);
+  });
+
+  test('empty routine counts as 0', () {
+    const data = RoutineData();
+    expect(data.uniqueItemCount(RoutineItemType.series), 0);
+    expect(data.uniqueItemCount(RoutineItemType.recitation), 0);
+  });
+
+  test('chants are deduped separately from plans', () {
+    final data = RoutineData(
+      blocks: [
+        block([series('plan-a'), chant('chant-a')], hour: 6),
+        block([series('plan-a'), chant('chant-a')], hour: 7),
+        block([chant('chant-b')], hour: 8),
+      ],
+    );
+
+    expect(data.uniqueItemCount(RoutineItemType.series), 1);
+    expect(data.uniqueItemCount(RoutineItemType.recitation), 2);
+  });
+}


### PR DESCRIPTION
- Added routine model and provider to the home screen to display unique plan and chant counts.
- Updated MyPracticesStatsCard to accept planCount and chantCount instead of routineInfo.
- Implemented uniqueItemCount method in RoutineData to count distinct items across blocks.
- Added unit tests for uniqueItemCount functionality to ensure accurate counting of plans and chants.
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/392cf57a-30f6-4639-b561-3a131ec0f712" />
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/c78bafc0-a3e1-42c5-9288-5419a4624cca" />
