### PR TITLE
Fix/maala

### DIFF
--- a/lib/features/mala/presentation/providers/mala_counter_notifier.dart
+++ b/lib/features/mala/presentation/providers/mala_counter_notifier.dart
@@ -473,15 +473,15 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
     if (userId == null || userId.isEmpty) return false;
 
     state = state.copyWith(isResetting: true);
+    // Invalidate before await: clearSession runs inside resetAccumulator, and a
+    // late timed-out GET must not rewrite Hive between clear and return.
+    _detailApplyGeneration++;
     try {
       await _sync.resetAccumulator(
         _presetId,
         deleteAccumulator: _deleteUserAccumulator,
       );
       if (!mounted) return false;
-      // Invalidate any in-flight late seed apply from a timed-out GET that still
-      // carries the pre-reset accumulator (would resurrect the old total).
-      _detailApplyGeneration++;
       final localState = _local.read(userId, _presetId);
       state = state.copyWith(
         total: 0,

--- a/lib/features/mala/presentation/providers/mala_counter_notifier.dart
+++ b/lib/features/mala/presentation/providers/mala_counter_notifier.dart
@@ -125,6 +125,10 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
   /// can persist taps without re-resolving.
   String? _userId;
 
+  /// Bumped when a new seed starts or a reset succeeds so in-flight late detail
+  /// applies from a timed-out seed cannot resurrect a cleared session.
+  int _detailApplyGeneration = 0;
+
   String get _presetId => _mantra.presetId;
 
   /// Lifetime total for [GroupAccumulationsSheet]: API `total_counted` baseline
@@ -166,6 +170,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
       return;
     }
     _userId = userId;
+    final applyGeneration = ++_detailApplyGeneration;
 
     final localState = _local.read(userId, _presetId);
     final fallbackImageUrl = localState.beadImageUrl ?? _mantra.beadImageUrl;
@@ -209,6 +214,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
             userId: userId,
             result: lateResult,
             fallbackImageUrl: fallbackImageUrl,
+            applyGeneration: applyGeneration,
           );
           if (lateUrl != null) {
             unawaited(
@@ -229,6 +235,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
         userId: userId,
         result: raced,
         fallbackImageUrl: fallbackImageUrl,
+        applyGeneration: applyGeneration,
       );
     }
 
@@ -246,12 +253,16 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
 
   /// Applies a detail API result. Never sets [MalaCounterState.isSeeding] true.
   ///
-  /// Returns the detail bead image URL when present (for artwork refresh).
+  /// Returns the detail bead image URL when present (for artwork refresh), or
+  /// null when [applyGeneration] is stale (e.g. after reset) or on failure.
   String? _applyDetailResult({
     required String userId,
     required Either<Failure, MalaCount> result,
     required String? fallbackImageUrl,
+    required int applyGeneration,
   }) {
+    if (applyGeneration != _detailApplyGeneration) return null;
+
     String? detailBeadImageUrl;
     result.fold(
       (failure) {
@@ -468,6 +479,9 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
         deleteAccumulator: _deleteUserAccumulator,
       );
       if (!mounted) return false;
+      // Invalidate any in-flight late seed apply from a timed-out GET that still
+      // carries the pre-reset accumulator (would resurrect the old total).
+      _detailApplyGeneration++;
       final localState = _local.read(userId, _presetId);
       state = state.copyWith(
         total: 0,

--- a/lib/features/mala/presentation/providers/mala_counter_notifier.dart
+++ b/lib/features/mala/presentation/providers/mala_counter_notifier.dart
@@ -37,7 +37,7 @@ class MalaCounterState {
   final String? beadImageUrl;
   final Uint8List? beadImageBytes;
 
-  /// True until local seed finishes. Network seed continues in the background.
+  /// True until local + network seed attempt finishes.
   final bool isSeeding;
 
   /// User id could not be resolved; counting cannot be persisted safely.
@@ -141,7 +141,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
 
   static Future<List<int>> _emptyImageDownload(String _) async => const [];
 
-  /// Seed local state first, then reconcile remote state when available.
+  /// Seed from local Hive, then reconcile with the detail API before undimming.
   Future<void> seed() async {
     state = state.copyWith(isSeeding: true, seedFailed: false);
 
@@ -156,10 +156,12 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
 
     final localState = _local.read(userId, _presetId);
     final fallbackImageUrl = localState.beadImageUrl ?? _mantra.beadImageUrl;
+    // Keep isSeeding true until the detail API returns so the UI does not paint
+    // a stale local total (e.g. "88") before reconcile.
     state = state.copyWith(
       total: localState.total,
       totalCounted: localState.totalCounted,
-      isSeeding: false,
+      isSeeding: true,
       seedFailed: false,
       beadImageUrl: fallbackImageUrl,
       beadImageBytes: localState.beadImageBytes,
@@ -172,7 +174,15 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
     result.fold(
       (failure) {
         _logger.warning('Seed failed: ${failure.message}');
-        // Local counting stays enabled; dirty counts retry via sync manager.
+        // Offline / API error: fall back to local and enable counting.
+        state = state.copyWith(
+          total: localState.total,
+          totalCounted: localState.totalCounted,
+          isSeeding: false,
+          seedFailed: false,
+          beadImageUrl: fallbackImageUrl,
+          beadImageBytes: localState.beadImageBytes,
+        );
         unawaited(_sync.flush(SyncReason.launch));
       },
       (detail) {
@@ -184,26 +194,26 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
         final serverTotal = detail.total;
         final serverAccId = detail.accumulatorId;
 
-        final localState = _local.read(userId, _presetId);
+        final latestLocal = _local.read(userId, _presetId);
         // Reconcile with the server only when an active accumulator exists.
         // Without one, ignore a stale current_count so a post-reset re-entry
         // cannot resurrect the old on-screen tally.
         final total =
             serverAccId != null
-                ? max(localState.total, serverTotal)
-                : localState.total;
+                ? max(latestLocal.total, serverTotal)
+                : latestLocal.total;
         final syncedTotal = serverAccId != null ? serverTotal : 0;
 
-        final beadImageUrl = detail.beadImageUrl ?? localState.beadImageUrl;
-        final totalCounted = max(detail.totalCounted, localState.totalCounted);
+        final beadImageUrl = detail.beadImageUrl ?? latestLocal.beadImageUrl;
+        final totalCounted = max(detail.totalCounted, latestLocal.totalCounted);
         _local.write(
           userId,
           _presetId,
-          localState.copyWith(
+          latestLocal.copyWith(
             total: total,
             syncedTotal: syncedTotal,
             totalCounted: totalCounted,
-            accumulatorId: serverAccId ?? localState.accumulatorId,
+            accumulatorId: serverAccId ?? latestLocal.accumulatorId,
             beadImageUrl: beadImageUrl,
           ),
         );
@@ -214,7 +224,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
           isSeeding: false,
           seedFailed: false,
           beadImageUrl: beadImageUrl,
-          beadImageBytes: localState.beadImageBytes,
+          beadImageBytes: latestLocal.beadImageBytes,
         );
 
         // Push any offline tail captured before this seed.

--- a/lib/features/mala/presentation/providers/mala_counter_notifier.dart
+++ b/lib/features/mala/presentation/providers/mala_counter_notifier.dart
@@ -5,14 +5,17 @@ import 'dart:math';
 import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/analytics/analytics_events.dart';
 import 'package:flutter_pecha/core/analytics/analytics_service.dart';
+import 'package:flutter_pecha/core/error/failures.dart';
 import 'package:flutter_pecha/core/utils/app_logger.dart';
 import 'package:flutter_pecha/core/utils/network_image_utils.dart';
 import 'package:flutter_pecha/features/mala/data/datasources/mala_local_datasource.dart';
+import 'package:flutter_pecha/features/mala/domain/entities/mala_count.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/mantra.dart';
 import 'package:flutter_pecha/features/mala/domain/usecases/mala_usecases.dart';
 import 'package:flutter_pecha/features/mala/presentation/providers/mala_sync_manager.dart';
 import 'package:flutter_pecha/features/mala/presentation/services/mala_sound_player.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fpdart/fpdart.dart';
 
 class MalaCounterState {
   const MalaCounterState({
@@ -37,7 +40,7 @@ class MalaCounterState {
   final String? beadImageUrl;
   final Uint8List? beadImageBytes;
 
-  /// True until local + network seed attempt finishes.
+  /// True until seed settles (detail API, failure, or seed network timeout).
   final bool isSeeding;
 
   /// User id could not be resolved; counting cannot be persisted safely.
@@ -87,6 +90,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
     required Future<String?> Function() currentUserId,
     AnalyticsService? analytics,
     MalaSoundPlayer? sound,
+    Duration? seedNetworkTimeout,
   }) : _mantra = mantra,
        _local = local,
        _getAccumulatorDetail = getAccumulatorDetail,
@@ -96,9 +100,13 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
        _currentUserId = currentUserId,
        _analytics = analytics,
        _sound = sound,
+       _seedNetworkTimeout =
+           seedNetworkTimeout ?? _defaultSeedNetworkTimeout,
        super(MalaCounterState(beadsPerRound: mantra.beadsPerRound)) {
     seed();
   }
+
+  static const _defaultSeedNetworkTimeout = Duration(seconds: 3);
 
   final Mantra _mantra;
   final MalaLocalDataSource _local;
@@ -109,6 +117,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
   final Future<String?> Function() _currentUserId;
   final AnalyticsService? _analytics;
   final MalaSoundPlayer? _sound;
+  final Duration _seedNetworkTimeout;
 
   final _logger = AppLogger('MalaCounterNotifier');
 
@@ -141,7 +150,11 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
 
   static Future<List<int>> _emptyImageDownload(String _) async => const [];
 
-  /// Seed from local Hive, then reconcile with the detail API before undimming.
+  /// Seed from local Hive, then briefly wait on the detail API before undimming.
+  ///
+  /// Races the network call against [_seedNetworkTimeout] so offline/slow
+  /// connections fall back to local counting quickly. A late detail response
+  /// still reconciles in the background without re-blocking taps.
   Future<void> seed() async {
     state = state.copyWith(isSeeding: true, seedFailed: false);
 
@@ -156,8 +169,8 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
 
     final localState = _local.read(userId, _presetId);
     final fallbackImageUrl = localState.beadImageUrl ?? _mantra.beadImageUrl;
-    // Keep isSeeding true until the detail API returns so the UI does not paint
-    // a stale local total (e.g. "88") before reconcile.
+    // Keep isSeeding true until detail returns, fails, or the seed timeout fires
+    // so the UI does not paint a stale local total before the first settle.
     state = state.copyWith(
       total: localState.total,
       totalCounted: localState.totalCounted,
@@ -167,20 +180,90 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
       beadImageBytes: localState.beadImageBytes,
     );
 
-    final result = await _getAccumulatorDetail(_presetId);
+    final detailFuture = _getAccumulatorDetail(_presetId);
+    final raced = await Future.any<Either<Failure, MalaCount>?>([
+      detailFuture.then<Either<Failure, MalaCount>?>((r) => r),
+      Future<Either<Failure, MalaCount>?>.delayed(
+        _seedNetworkTimeout,
+        () => null,
+      ),
+    ]);
     if (!mounted) return; // screen left mid-seed
 
+    String? detailBeadImageUrl;
+    if (raced == null) {
+      // Timeout: unblock local counting; reconcile when detail eventually lands.
+      final timedOutLocal = _local.read(userId, _presetId);
+      state = state.copyWith(
+        total: timedOutLocal.total,
+        totalCounted: timedOutLocal.totalCounted,
+        isSeeding: false,
+        seedFailed: false,
+        beadImageUrl: fallbackImageUrl,
+        beadImageBytes: timedOutLocal.beadImageBytes,
+      );
+      unawaited(
+        detailFuture.then((lateResult) {
+          if (!mounted) return;
+          final lateUrl = _applyDetailResult(
+            userId: userId,
+            result: lateResult,
+            fallbackImageUrl: fallbackImageUrl,
+          );
+          if (lateUrl != null) {
+            unawaited(
+              _refreshBeadImage(
+                userId,
+                urlCandidates: [
+                  lateUrl,
+                  if (fallbackImageUrl != null) fallbackImageUrl,
+                ],
+                refetchDetailOnFailure: false,
+              ),
+            );
+          }
+        }),
+      );
+    } else {
+      detailBeadImageUrl = _applyDetailResult(
+        userId: userId,
+        result: raced,
+        fallbackImageUrl: fallbackImageUrl,
+      );
+    }
+
+    unawaited(
+      _refreshBeadImage(
+        userId,
+        urlCandidates: [
+          if (detailBeadImageUrl != null) detailBeadImageUrl!,
+          if (fallbackImageUrl != null) fallbackImageUrl,
+        ],
+        refetchDetailOnFailure: detailBeadImageUrl == null,
+      ),
+    );
+  }
+
+  /// Applies a detail API result. Never sets [MalaCounterState.isSeeding] true.
+  ///
+  /// Returns the detail bead image URL when present (for artwork refresh).
+  String? _applyDetailResult({
+    required String userId,
+    required Either<Failure, MalaCount> result,
+    required String? fallbackImageUrl,
+  }) {
     String? detailBeadImageUrl;
     result.fold(
       (failure) {
         _logger.warning('Seed failed: ${failure.message}');
+        final localState = _local.read(userId, _presetId);
         // Offline / API error: fall back to local and enable counting.
         state = state.copyWith(
           total: localState.total,
           totalCounted: localState.totalCounted,
           isSeeding: false,
           seedFailed: false,
-          beadImageUrl: fallbackImageUrl,
+          beadImageUrl: fallbackImageUrl ?? localState.beadImageUrl,
           beadImageBytes: localState.beadImageBytes,
         );
         unawaited(_sync.flush(SyncReason.launch));
@@ -231,17 +314,7 @@ class MalaCounterNotifier extends StateNotifier<MalaCounterState> {
         if (total > syncedTotal) unawaited(_sync.flush(SyncReason.launch));
       },
     );
-
-    unawaited(
-      _refreshBeadImage(
-        userId,
-        urlCandidates: [
-          if (detailBeadImageUrl != null) detailBeadImageUrl!,
-          if (fallbackImageUrl != null) fallbackImageUrl,
-        ],
-        refetchDetailOnFailure: detailBeadImageUrl == null,
-      ),
-    );
+    return detailBeadImageUrl;
   }
 
   /// Downloads bead artwork via [MalaRemoteDataSource.fetchImageBytes]

--- a/lib/features/mala/presentation/screens/mala_screen.dart
+++ b/lib/features/mala/presentation/screens/mala_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/utils/tibetan_numerals.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/accumulator_group.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/mantra.dart';
-import 'package:flutter_pecha/features/mala/domain/entities/mala_accumulation_selection.dart';
 import 'package:flutter_pecha/features/mala/presentation/providers/accumulator_groups_provider.dart';
 import 'package:flutter_pecha/features/mala/presentation/providers/group_accumulation_counts_provider.dart';
 import 'package:flutter_pecha/features/mala/presentation/providers/mala_accumulation_selection_provider.dart';
@@ -173,12 +172,15 @@ class _MalaScreenState extends ConsumerState<MalaScreen> {
       next.whenData(groupCountsNotifier.mergeFromServerCounts);
     });
 
-    final displayTotal = _displayTotal(
-      selection: selection,
-      personalTotal: counter.total,
-      groups: groups,
-      groupCountsNotifier: groupCountsNotifier,
-    );
+    final groupId = selection.groupAccumulatorId;
+    final showCountSkeleton = counter.isSeeding && !counter.seedFailed;
+    // While seeding, keep beads at 0 so a stale Hive total does not light the arc.
+    final displayTotal =
+        showCountSkeleton
+            ? 0
+            : groupId == null
+            ? counter.total
+            : groupCountsNotifier.countFor(groupId);
     final beadsPerRound = counter.beadsPerRound;
     final displayBeadInRound = displayTotal % beadsPerRound;
     final displayRounds = displayTotal ~/ beadsPerRound;
@@ -195,10 +197,10 @@ class _MalaScreenState extends ConsumerState<MalaScreen> {
         );
         return;
       }
-      final groupId = selection.groupAccumulatorId;
-      if (groupId == null || groups.isEmpty) return;
+      final selectedGroupId = selection.groupAccumulatorId;
+      if (selectedGroupId == null || groups.isEmpty) return;
       groupCountsNotifier.increment(
-        groupAccumulatorId: groupId,
+        groupAccumulatorId: selectedGroupId,
         groups: groups,
         soundEnabled: settings.soundEnabled,
         vibrationEnabled: settings.vibrationEnabled,
@@ -241,12 +243,14 @@ class _MalaScreenState extends ConsumerState<MalaScreen> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                _CounterBlock(
-                  beadInRound: displayBeadInRound,
-                  beadsPerRound: beadsPerRound,
-                  rounds: displayRounds,
-                  dimmed: counter.isSeeding,
-                ),
+                if (showCountSkeleton)
+                  const MalaCountSkeleton()
+                else
+                  _CounterBlock(
+                    beadInRound: displayBeadInRound,
+                    beadsPerRound: beadsPerRound,
+                    rounds: displayRounds,
+                  ),
                 const SizedBox(height: 8),
                 Expanded(
                   flex: 42,
@@ -260,7 +264,8 @@ class _MalaScreenState extends ConsumerState<MalaScreen> {
                           child:
                               counter.seedFailed
                                   ? _ErrorView(
-                                    message: context.l10n.mala_count_load_error,
+                                    message:
+                                        context.l10n.mala_count_load_error,
                                     onRetry: notifier.seed,
                                   )
                                   : MalaBeads(
@@ -305,16 +310,6 @@ class _MalaScreenState extends ConsumerState<MalaScreen> {
         .applyNavigationIntent(groupId);
   }
 
-  int _displayTotal({
-    required MalaAccumulationSelection selection,
-    required int personalTotal,
-    required List<AccumulatorGroup> groups,
-    required GroupAccumulationCountsNotifier groupCountsNotifier,
-  }) {
-    final groupId = selection.groupAccumulatorId;
-    if (groupId == null || groups.isEmpty) return personalTotal;
-    return groupCountsNotifier.countFor(groupId, groups);
-  }
 }
 
 class _CounterBlock extends StatelessWidget {
@@ -322,13 +317,11 @@ class _CounterBlock extends StatelessWidget {
     required this.beadInRound,
     required this.beadsPerRound,
     required this.rounds,
-    required this.dimmed,
   });
 
   final int beadInRound;
   final int beadsPerRound;
   final int rounds;
-  final bool dimmed;
 
   @override
   Widget build(BuildContext context) {
@@ -343,9 +336,7 @@ class _CounterBlock extends StatelessWidget {
         useTibetan
             ? toTibetanDigits(l10n.mala_rounds_count(rounds))
             : l10n.mala_rounds_count(rounds);
-    final color = theme.colorScheme.onSurface.withValues(
-      alpha: dimmed ? 0.35 : 1.0,
-    );
+    final color = theme.colorScheme.onSurface;
     return Semantics(
       label: l10n.mala_counter_semantics(
         beadInRound,
@@ -367,7 +358,7 @@ class _CounterBlock extends StatelessWidget {
           Text(
             roundsLabel,
             style: theme.textTheme.titleLarge?.copyWith(
-              color: color.withValues(alpha: dimmed ? 0.35 : 0.7),
+              color: color.withValues(alpha: 0.7),
             ),
           ),
         ],

--- a/lib/features/mala/presentation/screens/mala_screen.dart
+++ b/lib/features/mala/presentation/screens/mala_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_pecha/core/analytics/analytics_providers.dart';
 import 'package:flutter_pecha/core/core.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/utils/tibetan_numerals.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/accumulator_group.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/mantra.dart';
 import 'package:flutter_pecha/features/mala/domain/entities/mala_accumulation_selection.dart';
@@ -333,7 +334,15 @@ class _CounterBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    final roundsLabel = l10n.mala_rounds_count(rounds);
+    final useTibetan = context.isTibetanLocale;
+    final beadLabel =
+        useTibetan
+            ? '${toTibetanDigits(beadInRound)}/${toTibetanDigits(beadsPerRound)}'
+            : '$beadInRound/$beadsPerRound';
+    final roundsLabel =
+        useTibetan
+            ? toTibetanDigits(l10n.mala_rounds_count(rounds))
+            : l10n.mala_rounds_count(rounds);
     final color = theme.colorScheme.onSurface.withValues(
       alpha: dimmed ? 0.35 : 1.0,
     );
@@ -348,7 +357,7 @@ class _CounterBlock extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            '$beadInRound/$beadsPerRound',
+            beadLabel,
             style: theme.textTheme.displaySmall?.copyWith(
               fontWeight: FontWeight.w700,
               color: color,

--- a/lib/features/mala/presentation/widgets/add_mala_rounds_dialog.dart
+++ b/lib/features/mala/presentation/widgets/add_mala_rounds_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/utils/tibetan_numerals.dart';
 
 /// Dialog for adding mala rounds completed outside the app.
 ///
@@ -99,7 +100,9 @@ class _AddMalaRoundsDialogState extends State<_AddMalaRoundsDialog> {
                     ),
                   ),
                   child: Text(
-                    '$_rounds',
+                    context.isTibetanLocale
+                        ? toTibetanDigits(_rounds)
+                        : '$_rounds',
                     style: theme.textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/lib/features/mala/presentation/widgets/mala_skeleton.dart
+++ b/lib/features/mala/presentation/widgets/mala_skeleton.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
-/// Skeleton shown while the catalogue loads or a mantra is seeding.
+/// Skeleton shown while the catalogue loads.
 ///
 /// Mirrors the loaded [MalaScreen] body (rendered below the app bar): a 40%
 /// mantra-switcher block with side chevrons and centered text, above a 60%
@@ -21,10 +21,66 @@ class MalaSkeleton extends StatelessWidget {
             // Mantra + transliteration switcher: 40% of the space below the
             // header, centered between the chevrons.
             Expanded(flex: 40, child: _SwitcherSkeleton()),
-            // Counter + bead arc: the remaining 60%.
-            Expanded(flex: 60, child: _CounterAndBeadsSkeleton()),
+            // Counter lines + bead arc: the remaining 60%.
+            Expanded(
+              flex: 60,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _MalaCounterLinesSkeleton(),
+                  SizedBox(height: 16),
+                  Expanded(child: _BeadArcSkeleton()),
+                  SizedBox(height: 24),
+                ],
+              ),
+            ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Horizontal-line skeleton for the mala counter while the count is seeding.
+///
+/// Count only — does not include the bead arc. Wraps its own [Skeletonizer]
+/// for use on the loaded [MalaScreen].
+class MalaCountSkeleton extends StatelessWidget {
+  const MalaCountSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Skeletonizer(
+      enabled: true,
+      child: _MalaCounterLinesSkeleton(),
+    );
+  }
+}
+
+/// Two left-aligned horizontal bones matching [_CounterBlock] (n/108 + rounds).
+class _MalaCounterLinesSkeleton extends StatelessWidget {
+  const _MalaCounterLinesSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Bone(
+            width: 120,
+            height: 40,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          const SizedBox(height: 8),
+          Bone(
+            width: 90,
+            height: 24,
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ],
       ),
     );
   }
@@ -49,14 +105,22 @@ class _SwitcherSkeleton extends StatelessWidget {
             ).colorScheme.onSurface.withValues(alpha: 0.25),
           ),
         ),
-        const Expanded(
+        Expanded(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
             children: [
-              _Bone(height: 32, width: 200),
-              SizedBox(height: 16),
-              _Bone(height: 20, width: 140),
+              Bone(
+                width: 200,
+                height: 32,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              const SizedBox(height: 16),
+              Bone(
+                width: 140,
+                height: 20,
+                borderRadius: BorderRadius.circular(8),
+              ),
             ],
           ),
         ),
@@ -74,40 +138,15 @@ class _SwitcherSkeleton extends StatelessWidget {
   }
 }
 
-/// Left-aligned counter (big "n/108" + rounds line) above the bead arc.
-class _CounterAndBeadsSkeleton extends StatelessWidget {
-  const _CounterAndBeadsSkeleton();
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: const [
-        // Counter block (left-aligned), matching _CounterBlock.
-        Align(
-          alignment: Alignment.centerLeft,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _Bone(height: 40, width: 120),
-              SizedBox(height: 8),
-              _Bone(height: 24, width: 90),
-            ],
-          ),
-        ),
-        SizedBox(height: 16),
-        // Bead arc.
-        Expanded(child: _BeadArcSkeleton()),
-        SizedBox(height: 24),
-      ],
-    );
-  }
-}
-
 /// A diagonal strand of bead-sized circles approximating the bead arc.
+///
+/// Uses package [Bone.circle] (not custom Containers) so Skeletonizer paints
+/// cleanly without zebra warning stripes.
 class _BeadArcSkeleton extends StatelessWidget {
   const _BeadArcSkeleton();
+
+  static const _count = 7;
+  static const _size = 40.0;
 
   @override
   Widget build(BuildContext context) {
@@ -115,60 +154,27 @@ class _BeadArcSkeleton extends StatelessWidget {
       builder: (context, constraints) {
         final width = constraints.maxWidth;
         final height = constraints.maxHeight;
-        // Bead diameter ≈ 15% of width (matches _radiusFactor = 0.075).
-        final diameter = (width * 0.15).clamp(24.0, 64.0);
-        const count = 7;
+        final diameter = _size.clamp(24.0, width * 0.15);
 
         return Stack(
           children: [
-            for (var i = 0; i < count; i++)
+            for (var i = 0; i < _count; i++)
               Builder(
                 builder: (context) {
                   // Strand runs from bottom-left up to top-right.
-                  final t = count == 1 ? 0.0 : i / (count - 1);
+                  final t = _count == 1 ? 0.0 : i / (_count - 1);
                   final left = (width - diameter) * t;
                   final top = (height - diameter) * (1 - t);
                   return Positioned(
                     left: left,
                     top: top,
-                    child: _Bone(
-                      height: diameter,
-                      width: diameter,
-                      shape: BoxShape.circle,
-                    ),
+                    child: Bone.circle(size: diameter),
                   );
                 },
               ),
           ],
         );
       },
-    );
-  }
-}
-
-/// A single skeleton placeholder block.
-class _Bone extends StatelessWidget {
-  const _Bone({
-    required this.height,
-    required this.width,
-    this.shape = BoxShape.rectangle,
-  });
-
-  final double height;
-  final double width;
-  final BoxShape shape;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: height,
-      width: width,
-      decoration: BoxDecoration(
-        color: Colors.grey,
-        shape: shape,
-        borderRadius:
-            shape == BoxShape.rectangle ? BorderRadius.circular(8) : null,
-      ),
     );
   }
 }

--- a/lib/features/mala/presentation/widgets/mantra_switcher.dart
+++ b/lib/features/mala/presentation/widgets/mantra_switcher.dart
@@ -129,8 +129,9 @@ class _MantraSwitcherState extends State<MantraSwitcher> {
 }
 
 /// One carousel page: Tibetan script (when present) above the transliteration,
-/// both centered within the page.
-class _MantraPage extends StatelessWidget {
+/// both centered within the page. Long content scrolls vertically with a
+/// visible scrollbar when it overflows.
+class _MantraPage extends StatefulWidget {
   const _MantraPage({
     required this.tibetan,
     required this.tibetanFontFamily,
@@ -144,39 +145,70 @@ class _MantraPage extends StatelessWidget {
   final ThemeData theme;
 
   @override
+  State<_MantraPage> createState() => _MantraPageState();
+}
+
+class _MantraPageState extends State<_MantraPage> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (tibetan != null) ...[
-              Semantics(
-                label: context.l10n.mala_mantra_label,
-                child: Text(
-                  tibetan!,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.headlineMedium?.copyWith(
-                    fontFamily: tibetanFontFamily,
-                    height: 1.4,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Scrollbar(
+          controller: _scrollController,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 20,
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (widget.tibetan != null) ...[
+                        Semantics(
+                          label: context.l10n.mala_mantra_label,
+                          child: Text(
+                            widget.tibetan!,
+                            textAlign: TextAlign.center,
+                            style: widget.theme.textTheme.headlineMedium
+                                ?.copyWith(
+                                  fontFamily: widget.tibetanFontFamily,
+                                  height: 1.4,
+                                ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                      ],
+                      Text(
+                        widget.transliteration,
+                        textAlign: TextAlign.center,
+                        style: widget.theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.3,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),
-              const SizedBox(height: 16),
-            ],
-            Text(
-              transliteration,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.3,
-              ),
             ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/features/mala/mala_counter_notifier_test.dart
+++ b/test/features/mala/mala_counter_notifier_test.dart
@@ -80,6 +80,48 @@ void main() {
     notifier.dispose();
   });
 
+  test('seed keeps isSeeding true until detail API completes', () async {
+    await local.write(
+      userId,
+      'chenrezig',
+      const LocalMalaState(total: 88, syncedTotal: 88, accumulatorId: 'acc-1'),
+    );
+    final gate = Completer<Either<Failure, MalaCount>>();
+    when(getDetail(any)).thenAnswer((_) => gate.future);
+
+    final notifier = buildNotifier();
+    await Future.delayed(Duration.zero);
+
+    expect(notifier.state.isSeeding, isTrue);
+    expect(notifier.state.total, 88);
+
+    gate.complete(const Right(MalaCount(accumulatorId: 'acc-1', total: 12)));
+    await Future.delayed(Duration.zero);
+
+    expect(notifier.state.isSeeding, isFalse);
+    expect(notifier.state.total, 88); // max(local, server)
+    notifier.dispose();
+  });
+
+  test('seed falls back to local total when detail API fails', () async {
+    await local.write(
+      userId,
+      'chenrezig',
+      const LocalMalaState(total: 88, syncedTotal: 80, accumulatorId: 'acc-1'),
+    );
+    when(getDetail(any)).thenAnswer(
+      (_) async => const Left(UnknownFailure('network')),
+    );
+
+    final notifier = buildNotifier();
+    await Future.delayed(Duration.zero);
+
+    expect(notifier.state.isSeeding, isFalse);
+    expect(notifier.state.total, 88);
+    verify(sync.flush(SyncReason.launch)).called(1);
+    notifier.dispose();
+  });
+
   test('seed preserves local offline taps and pushes them', () async {
     // Local is ahead of the server (offline taps captured earlier).
     await local.write(

--- a/test/features/mala/mala_counter_notifier_test.dart
+++ b/test/features/mala/mala_counter_notifier_test.dart
@@ -38,13 +38,15 @@ void main() {
     mantra: MantraText(id: 'm1', text: 'ༀ་མ་ཎི་པདྨེ་ཧཱུྃ', pronunciation: 'Om Mani Padme Hum'),
   );
 
-  MalaCounterNotifier buildNotifier() => MalaCounterNotifier(
+  MalaCounterNotifier buildNotifier({Duration? seedNetworkTimeout}) =>
+      MalaCounterNotifier(
         mantra: mantra,
         local: local,
         getAccumulatorDetail: getDetail,
         deleteUserAccumulator: delete,
         sync: sync,
         currentUserId: () async => userId,
+        seedNetworkTimeout: seedNetworkTimeout,
       );
 
   setUp(() async {
@@ -89,7 +91,10 @@ void main() {
     final gate = Completer<Either<Failure, MalaCount>>();
     when(getDetail(any)).thenAnswer((_) => gate.future);
 
-    final notifier = buildNotifier();
+    // Long timeout so the test observes API-first settle, not the race fallback.
+    final notifier = buildNotifier(
+      seedNetworkTimeout: const Duration(seconds: 30),
+    );
     await Future.delayed(Duration.zero);
 
     expect(notifier.state.isSeeding, isTrue);
@@ -100,6 +105,35 @@ void main() {
 
     expect(notifier.state.isSeeding, isFalse);
     expect(notifier.state.total, 88); // max(local, server)
+    notifier.dispose();
+  });
+
+  test('seed falls back to local after network timeout then late-reconciles',
+      () async {
+    await local.write(
+      userId,
+      'chenrezig',
+      const LocalMalaState(total: 88, syncedTotal: 88, accumulatorId: 'acc-1'),
+    );
+    final gate = Completer<Either<Failure, MalaCount>>();
+    when(getDetail(any)).thenAnswer((_) => gate.future);
+
+    final notifier = buildNotifier(
+      seedNetworkTimeout: const Duration(milliseconds: 40),
+    );
+    await Future.delayed(Duration.zero);
+    expect(notifier.state.isSeeding, isTrue);
+
+    await Future.delayed(const Duration(milliseconds: 60));
+    expect(notifier.state.isSeeding, isFalse);
+    expect(notifier.state.total, 88);
+
+    // Late API is ahead of the timed-out local snapshot.
+    gate.complete(const Right(MalaCount(accumulatorId: 'acc-1', total: 120)));
+    await Future.delayed(Duration.zero);
+
+    expect(notifier.state.isSeeding, isFalse);
+    expect(notifier.state.total, 120);
     notifier.dispose();
   });
 

--- a/test/features/mala/mala_counter_notifier_test.dart
+++ b/test/features/mala/mala_counter_notifier_test.dart
@@ -137,6 +137,46 @@ void main() {
     notifier.dispose();
   });
 
+  test('late seed detail after reset does not resurrect cleared count', () async {
+    await local.write(
+      userId,
+      'chenrezig',
+      const LocalMalaState(total: 88, syncedTotal: 88, accumulatorId: 'acc-1'),
+    );
+    final gate = Completer<Either<Failure, MalaCount>>();
+    when(getDetail(any)).thenAnswer((_) => gate.future);
+    when(
+      sync.resetAccumulator(
+        any,
+        deleteAccumulator: anyNamed('deleteAccumulator'),
+      ),
+    ).thenAnswer((_) async {
+      await local.clearSession(userId, 'chenrezig');
+    });
+
+    final notifier = buildNotifier(
+      seedNetworkTimeout: const Duration(milliseconds: 40),
+    );
+    await Future.delayed(Duration.zero);
+    await Future.delayed(const Duration(milliseconds: 60));
+    expect(notifier.state.isSeeding, isFalse);
+    expect(notifier.state.total, 88);
+
+    final ok = await notifier.resetCount();
+    expect(ok, isTrue);
+    expect(notifier.state.total, 0);
+    expect(local.read(userId, 'chenrezig').accumulatorId, isNull);
+
+    // Pre-reset GET finally returns — must not overwrite the cleared session.
+    gate.complete(const Right(MalaCount(accumulatorId: 'acc-1', total: 88)));
+    await Future.delayed(Duration.zero);
+
+    expect(notifier.state.total, 0);
+    expect(local.read(userId, 'chenrezig').total, 0);
+    expect(local.read(userId, 'chenrezig').accumulatorId, isNull);
+    notifier.dispose();
+  });
+
   test('seed falls back to local total when detail API fails', () async {
     await local.write(
       userId,

--- a/test/features/mala/mala_counter_notifier_test.dart
+++ b/test/features/mala/mala_counter_notifier_test.dart
@@ -143,15 +143,23 @@ void main() {
       'chenrezig',
       const LocalMalaState(total: 88, syncedTotal: 88, accumulatorId: 'acc-1'),
     );
-    final gate = Completer<Either<Failure, MalaCount>>();
-    when(getDetail(any)).thenAnswer((_) => gate.future);
+    final detailGate = Completer<Either<Failure, MalaCount>>();
+    final resetContinue = Completer<void>();
+    when(getDetail(any)).thenAnswer((_) => detailGate.future);
     when(
       sync.resetAccumulator(
         any,
         deleteAccumulator: anyNamed('deleteAccumulator'),
       ),
     ).thenAnswer((_) async {
+      // clearSession happens before resetAccumulator returns (real sync path).
       await local.clearSession(userId, 'chenrezig');
+      // Late pre-reset GET lands in this window — must not rewrite Hive.
+      detailGate.complete(
+        const Right(MalaCount(accumulatorId: 'acc-1', total: 88)),
+      );
+      await Future.delayed(Duration.zero);
+      await resetContinue.future;
     });
 
     final notifier = buildNotifier(
@@ -162,15 +170,14 @@ void main() {
     expect(notifier.state.isSeeding, isFalse);
     expect(notifier.state.total, 88);
 
-    final ok = await notifier.resetCount();
-    expect(ok, isTrue);
-    expect(notifier.state.total, 0);
+    final resetFuture = notifier.resetCount();
+    await Future.delayed(Duration.zero);
+    expect(local.read(userId, 'chenrezig').total, 0);
     expect(local.read(userId, 'chenrezig').accumulatorId, isNull);
 
-    // Pre-reset GET finally returns — must not overwrite the cleared session.
-    gate.complete(const Right(MalaCount(accumulatorId: 'acc-1', total: 88)));
-    await Future.delayed(Duration.zero);
-
+    resetContinue.complete();
+    final ok = await resetFuture;
+    expect(ok, isTrue);
     expect(notifier.state.total, 0);
     expect(local.read(userId, 'chenrezig').total, 0);
     expect(local.read(userId, 'chenrezig').accumulatorId, isNull);


### PR DESCRIPTION
- Adds generation-based invalidation so pre-reset detail responses cannot restore cleared state.
- Replaces the dimmed counter with a focused loading skeleton during initial reconciliation.
- Adds Tibetan numeral rendering and scroll support for long mantra content.
- Extends notifier tests for timeout fallback, late reconciliation, failed detail requests, and reset races.

> [!NOTE]
> For localization informed to update tolgee 


https://github.com/user-attachments/assets/88d34c39-4bf3-4f3e-9a00-186ce6bb7b9f


<img width="270" height="603" alt="Image" src="https://github.com/user-attachments/assets/5a47751c-2aa0-4896-b278-af600be8f45c" />