### PR TITLE
Fix: Bugs in Connect Page

### DIFF
--- a/lib/core/l10n/app_bo.arb
+++ b/lib/core/l10n/app_bo.arb
@@ -844,6 +844,7 @@
   "connect_tab_feed": "གསར་འགྱུར།",
   "connect_tab_events": "བྱེད་སྒོ།",
   "connect_tab_posts": "སྤེལ་བ།",
+  "connect_tab_practices": "ཉམས་ལེན།",
   "connect_tab_groups": "ཚོགས་པ།",
   "connect_segment_my": "ངའི།",
   "connect_segment_discover": "འཚོལ་སྙེག",
@@ -851,6 +852,7 @@
   "connect_empty_discover_events": "འཚོལ་རྒྱུའི་བྱེད་སྒོ་མི་འདུག",
   "connect_empty_discover_feed": "འཚོལ་རྒྱུ་གང་ཡང་མི་འདུག",
   "connect_empty_discover_groups": "འཚོལ་རྒྱུའི་ཚོགས་པ་མི་འདུག",
+  "connect_empty_discover_practices": "འཚོལ་རྒྱུའི་ཉམས་ལེན་མི་འདུག",
   "connect_all_groups": "ཚོགས་པ་ཡོངས།",
   "connect_my_empty_feed_title": "ཁྱེད་ཀྱི་ཚོགས་པ་ཁག་ཁུ་སིམ་མེ་རེད་འདུག",
   "connect_my_empty_events_title": "འབྱུང་འགྱུར་གྱི་བྱེད་སྒོ་མི་འདུག",
@@ -863,6 +865,9 @@
   "connect_my_empty_feed_browse": "ཚོགས་པ་གཞན་གྱིས་སྤེལ་བ་ལ་གཟིགས།",
   "connect_my_empty_events_browse": "ཐམས་ཅད་ཞུགས་ཆོག་པའི་བྱེད་སྒོ་ལ་གཟིགས།",
   "connect_my_empty_posts_browse": "སྤེལ་བ་གཞན་ལ་གཟིགས།",
+  "connect_my_empty_practices_title": "ད་དུང་ཉམས་ལེན་མི་འདུག",
+  "connect_my_empty_practices_subtitle": "ཁྱེད་ཀྱི་ཚོགས་པ་ཁག་གིས་ཉམས་ལེན་གང་ཡང་མ་བྱས་འདུག ཚོགས་པ་གཞན་གྱིས་གང་འདོན་བཞིན་པར་གཟིགས།",
+  "connect_my_empty_practices_browse": "ཉམས་ལེན་གཞན་ལ་གཟིགས།",
   "connect_comment_replying_to": "@{handle} ལ་ལན་འདེབས་བཞིན་པ།",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -271,6 +271,7 @@
   "connect_tab_feed": "Feed",
   "connect_tab_events": "Events",
   "connect_tab_posts": "Posts",
+  "connect_tab_practices": "Practices",
   "connect_tab_groups": "Groups",
   "connect_segment_my": "My",
   "connect_segment_discover": "Discover",
@@ -278,6 +279,7 @@
   "connect_empty_discover_events": "No events to discover",
   "connect_empty_discover_feed": "Nothing to discover",
   "connect_empty_discover_groups": "No groups to discover",
+  "connect_empty_discover_practices": "No practices to discover",
   "connect_all_groups": "All groups",
   "connect_my_empty_feed_title": "Your groups have been quiet",
   "connect_my_empty_events_title": "No upcoming events",
@@ -290,6 +292,9 @@
   "connect_my_empty_feed_browse": "See what other groups share",
   "connect_my_empty_events_browse": "Browse open events",
   "connect_my_empty_posts_browse": "Browse other posts",
+  "connect_my_empty_practices_title": "No practices yet",
+  "connect_my_empty_practices_subtitle": "Your groups have not started any practices. See what other groups are offering.",
+  "connect_my_empty_practices_browse": "Browse other practices",
   "connect_comment_replying_to": "Replying to @{handle}",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -908,6 +908,7 @@
   "connect_tab_feed": "फ़ीड",
   "connect_tab_events": "कार्यक्रम",
   "connect_tab_posts": "पोस्ट",
+  "connect_tab_practices": "Practices",
   "connect_tab_groups": "Groups",
   "connect_segment_my": "मेरा",
   "connect_segment_discover": "खोजें",
@@ -915,6 +916,7 @@
   "connect_empty_discover_events": "खोजने के लिए कोई कार्यक्रम नहीं",
   "connect_empty_discover_feed": "खोजने के लिए कुछ नहीं",
   "connect_empty_discover_groups": "खोजने के लिए कोई समूह नहीं",
+  "connect_empty_discover_practices": "खोजने के लिए कोई अभ्यास नहीं",
   "connect_all_groups": "सभी समूह",
   "connect_my_empty_feed_title": "आपके समूह शांत रहे हैं",
   "connect_my_empty_events_title": "कोई आगामी कार्यक्रम नहीं",
@@ -927,6 +929,9 @@
   "connect_my_empty_feed_browse": "देखें अन्य समूह क्या साझा कर रहे हैं",
   "connect_my_empty_events_browse": "खुले कार्यक्रम देखें",
   "connect_my_empty_posts_browse": "अन्य पोस्ट देखें",
+  "connect_my_empty_practices_title": "अभी कोई अभ्यास नहीं",
+  "connect_my_empty_practices_subtitle": "आपके समूहों ने कोई अभ्यास शुरू नहीं किया है। देखें अन्य समूह क्या प्रस्ताव कर रहे हैं।",
+  "connect_my_empty_practices_browse": "अन्य अभ्यास देखें",
   "connect_comment_replying_to": "@{handle} को उत्तर दे रहे हैं",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/app_mn.arb
+++ b/lib/core/l10n/app_mn.arb
@@ -908,6 +908,7 @@
   "connect_tab_feed": "Мэдээ",
   "connect_tab_events": "Арга хэмжээ",
   "connect_tab_posts": "Нийтлэл",
+  "connect_tab_practices": "Practices",
   "connect_tab_groups": "Groups",
   "connect_segment_my": "Миний",
   "connect_segment_discover": "Судлах",
@@ -915,6 +916,7 @@
   "connect_empty_discover_events": "Судлах арга хэмжээ алга",
   "connect_empty_discover_feed": "Судлах зүйл алга",
   "connect_empty_discover_groups": "Судлах бүлэг алга",
+  "connect_empty_discover_practices": "Судлах дадлага алга",
   "connect_all_groups": "Бүх бүлэг",
   "connect_my_empty_feed_title": "Таны бүлгүүд чимээгүй байна",
   "connect_my_empty_events_title": "Товлосон арга хэмжээ алга",
@@ -927,6 +929,9 @@
   "connect_my_empty_feed_browse": "Бусад бүлгийн хуваалцсныг үзэх",
   "connect_my_empty_events_browse": "Нээлттэй арга хэмжээг үзэх",
   "connect_my_empty_posts_browse": "Бусад нийтлэлийг үзэх",
+  "connect_my_empty_practices_title": "Одоогоор дадлага алга",
+  "connect_my_empty_practices_subtitle": "Таны бүлгүүд ямар ч дадлага эхлүүлээгүй байна. Бусад бүлгүүд юу санал болгож байгааг үзээрэй.",
+  "connect_my_empty_practices_browse": "Бусад дадлагыг үзэх",
   "connect_comment_replying_to": "@{handle}-д хариулж байна",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/app_ne.arb
+++ b/lib/core/l10n/app_ne.arb
@@ -908,6 +908,7 @@
   "connect_tab_feed": "फिड",
   "connect_tab_events": "कार्यक्रम",
   "connect_tab_posts": "पोस्ट",
+  "connect_tab_practices": "Practices",
   "connect_tab_groups": "Groups",
   "connect_segment_my": "मेरो",
   "connect_segment_discover": "अन्वेषण",
@@ -915,6 +916,7 @@
   "connect_empty_discover_events": "अन्वेषण गर्न कुनै कार्यक्रम छैन",
   "connect_empty_discover_feed": "अन्वेषण गर्न केही छैन",
   "connect_empty_discover_groups": "अन्वेषण गर्न कुनै समूह छैन",
+  "connect_empty_discover_practices": "अन्वेषण गर्न कुनै अभ्यास छैन",
   "connect_all_groups": "सबै समूह",
   "connect_my_empty_feed_title": "तपाईंका समूहहरू शान्त छन्",
   "connect_my_empty_events_title": "कुनै आगामी कार्यक्रम छैन",
@@ -927,6 +929,9 @@
   "connect_my_empty_feed_browse": "अन्य समूहहरूले के साझा गर्छन् हेर्नुहोस्",
   "connect_my_empty_events_browse": "खुला कार्यक्रमहरू हेर्नुहोस्",
   "connect_my_empty_posts_browse": "अन्य पोस्टहरू हेर्नुहोस्",
+  "connect_my_empty_practices_title": "अहिलेसम्म कुनै अभ्यास छैन",
+  "connect_my_empty_practices_subtitle": "तपाईंका समूहहरूले कुनै अभ्यास सुरु गरेका छैनन्। अन्य समूहहरूले के प्रस्ताव गरिरहेका छन् हेर्नुहोस्।",
+  "connect_my_empty_practices_browse": "अन्य अभ्यासहरू हेर्नुहोस्",
   "connect_comment_replying_to": "@{handle} लाई जवाफ दिँदै",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -842,6 +842,7 @@
   "connect_tab_feed": "動態",
   "connect_tab_events": "活動",
   "connect_tab_posts": "貼文",
+  "connect_tab_practices": "修持",
   "connect_tab_groups": "Groups",
   "connect_segment_my": "我的",
   "connect_segment_discover": "探索",
@@ -849,6 +850,7 @@
   "connect_empty_discover_events": "沒有可探索的活動",
   "connect_empty_discover_feed": "沒有可探索的內容",
   "connect_empty_discover_groups": "沒有可探索的社群",
+  "connect_empty_discover_practices": "沒有可探索的修持",
   "connect_all_groups": "所有社群",
   "connect_my_empty_feed_title": "你的社群最近很安靜",
   "connect_my_empty_events_title": "沒有即將舉行的活動",
@@ -861,6 +863,9 @@
   "connect_my_empty_feed_browse": "看看其他社群分享什麼",
   "connect_my_empty_events_browse": "瀏覽開放活動",
   "connect_my_empty_posts_browse": "瀏覽其他貼文",
+  "connect_my_empty_practices_title": "尚無修持",
+  "connect_my_empty_practices_subtitle": "你的社群還沒有開始任何修持。看看其他社群提供什麼。",
+  "connect_my_empty_practices_browse": "瀏覽其他修持",
   "connect_comment_replying_to": "回覆 @{handle}",
   "@connect_comment_replying_to": {
     "placeholders": {

--- a/lib/core/l10n/generated/app_localizations.dart
+++ b/lib/core/l10n/generated/app_localizations.dart
@@ -1384,6 +1384,12 @@ abstract class AppLocalizations {
   /// **'Posts'**
   String get connect_tab_posts;
 
+  /// No description provided for @connect_tab_practices.
+  ///
+  /// In en, this message translates to:
+  /// **'Practices'**
+  String get connect_tab_practices;
+
   /// No description provided for @connect_tab_groups.
   ///
   /// In en, this message translates to:
@@ -1425,6 +1431,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No groups to discover'**
   String get connect_empty_discover_groups;
+
+  /// No description provided for @connect_empty_discover_practices.
+  ///
+  /// In en, this message translates to:
+  /// **'No practices to discover'**
+  String get connect_empty_discover_practices;
 
   /// No description provided for @connect_all_groups.
   ///
@@ -1497,6 +1509,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Browse other posts'**
   String get connect_my_empty_posts_browse;
+
+  /// No description provided for @connect_my_empty_practices_title.
+  ///
+  /// In en, this message translates to:
+  /// **'No practices yet'**
+  String get connect_my_empty_practices_title;
+
+  /// No description provided for @connect_my_empty_practices_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Your groups have not started any practices. See what other groups are offering.'**
+  String get connect_my_empty_practices_subtitle;
+
+  /// No description provided for @connect_my_empty_practices_browse.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse other practices'**
+  String get connect_my_empty_practices_browse;
 
   /// No description provided for @connect_comment_replying_to.
   ///

--- a/lib/core/l10n/generated/app_localizations_bo.dart
+++ b/lib/core/l10n/generated/app_localizations_bo.dart
@@ -719,6 +719,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get connect_tab_posts => 'སྤེལ་བ།';
 
   @override
+  String get connect_tab_practices => 'ཉམས་ལེན།';
+
+  @override
   String get connect_tab_groups => 'ཚོགས་པ།';
 
   @override
@@ -738,6 +741,9 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => 'འཚོལ་རྒྱུའི་ཚོགས་པ་མི་འདུག';
+
+  @override
+  String get connect_empty_discover_practices => 'འཚོལ་རྒྱུའི་ཉམས་ལེན་མི་འདུག';
 
   @override
   String get connect_all_groups => 'ཚོགས་པ་ཡོངས།';
@@ -781,6 +787,16 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => 'སྤེལ་བ་གཞན་ལ་གཟིགས།';
+
+  @override
+  String get connect_my_empty_practices_title => 'ད་དུང་ཉམས་ལེན་མི་འདུག';
+
+  @override
+  String get connect_my_empty_practices_subtitle =>
+      'ཁྱེད་ཀྱི་ཚོགས་པ་ཁག་གིས་ཉམས་ལེན་གང་ཡང་མ་བྱས་འདུག ཚོགས་པ་གཞན་གྱིས་གང་འདོན་བཞིན་པར་གཟིགས།';
+
+  @override
+  String get connect_my_empty_practices_browse => 'ཉམས་ལེན་གཞན་ལ་གཟིགས།';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/generated/app_localizations_en.dart
+++ b/lib/core/l10n/generated/app_localizations_en.dart
@@ -709,6 +709,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connect_tab_posts => 'Posts';
 
   @override
+  String get connect_tab_practices => 'Practices';
+
+  @override
   String get connect_tab_groups => 'Groups';
 
   @override
@@ -728,6 +731,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => 'No groups to discover';
+
+  @override
+  String get connect_empty_discover_practices => 'No practices to discover';
 
   @override
   String get connect_all_groups => 'All groups';
@@ -768,6 +774,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => 'Browse other posts';
+
+  @override
+  String get connect_my_empty_practices_title => 'No practices yet';
+
+  @override
+  String get connect_my_empty_practices_subtitle =>
+      'Your groups have not started any practices. See what other groups are offering.';
+
+  @override
+  String get connect_my_empty_practices_browse => 'Browse other practices';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/generated/app_localizations_hi.dart
+++ b/lib/core/l10n/generated/app_localizations_hi.dart
@@ -714,6 +714,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get connect_tab_posts => 'पोस्ट';
 
   @override
+  String get connect_tab_practices => 'Practices';
+
+  @override
   String get connect_tab_groups => 'Groups';
 
   @override
@@ -733,6 +736,9 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => 'खोजने के लिए कोई समूह नहीं';
+
+  @override
+  String get connect_empty_discover_practices => 'खोजने के लिए कोई अभ्यास नहीं';
 
   @override
   String get connect_all_groups => 'सभी समूह';
@@ -774,6 +780,16 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => 'अन्य पोस्ट देखें';
+
+  @override
+  String get connect_my_empty_practices_title => 'अभी कोई अभ्यास नहीं';
+
+  @override
+  String get connect_my_empty_practices_subtitle =>
+      'आपके समूहों ने कोई अभ्यास शुरू नहीं किया है। देखें अन्य समूह क्या प्रस्ताव कर रहे हैं।';
+
+  @override
+  String get connect_my_empty_practices_browse => 'अन्य अभ्यास देखें';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/generated/app_localizations_mn.dart
+++ b/lib/core/l10n/generated/app_localizations_mn.dart
@@ -715,6 +715,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get connect_tab_posts => 'Нийтлэл';
 
   @override
+  String get connect_tab_practices => 'Practices';
+
+  @override
   String get connect_tab_groups => 'Groups';
 
   @override
@@ -734,6 +737,9 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => 'Судлах бүлэг алга';
+
+  @override
+  String get connect_empty_discover_practices => 'Судлах дадлага алга';
 
   @override
   String get connect_all_groups => 'Бүх бүлэг';
@@ -774,6 +780,16 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => 'Бусад нийтлэлийг үзэх';
+
+  @override
+  String get connect_my_empty_practices_title => 'Одоогоор дадлага алга';
+
+  @override
+  String get connect_my_empty_practices_subtitle =>
+      'Таны бүлгүүд ямар ч дадлага эхлүүлээгүй байна. Бусад бүлгүүд юу санал болгож байгааг үзээрэй.';
+
+  @override
+  String get connect_my_empty_practices_browse => 'Бусад дадлагыг үзэх';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/generated/app_localizations_ne.dart
+++ b/lib/core/l10n/generated/app_localizations_ne.dart
@@ -721,6 +721,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get connect_tab_posts => 'पोस्ट';
 
   @override
+  String get connect_tab_practices => 'Practices';
+
+  @override
   String get connect_tab_groups => 'Groups';
 
   @override
@@ -740,6 +743,9 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => 'अन्वेषण गर्न कुनै समूह छैन';
+
+  @override
+  String get connect_empty_discover_practices => 'अन्वेषण गर्न कुनै अभ्यास छैन';
 
   @override
   String get connect_all_groups => 'सबै समूह';
@@ -781,6 +787,16 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => 'अन्य पोस्टहरू हेर्नुहोस्';
+
+  @override
+  String get connect_my_empty_practices_title => 'अहिलेसम्म कुनै अभ्यास छैन';
+
+  @override
+  String get connect_my_empty_practices_subtitle =>
+      'तपाईंका समूहहरूले कुनै अभ्यास सुरु गरेका छैनन्। अन्य समूहहरूले के प्रस्ताव गरिरहेका छन् हेर्नुहोस्।';
+
+  @override
+  String get connect_my_empty_practices_browse => 'अन्य अभ्यासहरू हेर्नुहोस्';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/generated/app_localizations_zh.dart
+++ b/lib/core/l10n/generated/app_localizations_zh.dart
@@ -673,6 +673,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get connect_tab_posts => '貼文';
 
   @override
+  String get connect_tab_practices => '修持';
+
+  @override
   String get connect_tab_groups => 'Groups';
 
   @override
@@ -692,6 +695,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get connect_empty_discover_groups => '沒有可探索的社群';
+
+  @override
+  String get connect_empty_discover_practices => '沒有可探索的修持';
 
   @override
   String get connect_all_groups => '所有社群';
@@ -728,6 +734,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get connect_my_empty_posts_browse => '瀏覽其他貼文';
+
+  @override
+  String get connect_my_empty_practices_title => '尚無修持';
+
+  @override
+  String get connect_my_empty_practices_subtitle => '你的社群還沒有開始任何修持。看看其他社群提供什麼。';
+
+  @override
+  String get connect_my_empty_practices_browse => '瀏覽其他修持';
 
   @override
   String connect_comment_replying_to(String handle) {

--- a/lib/core/l10n/tolgee/tolgee_app_localizations.g.dart
+++ b/lib/core/l10n/tolgee/tolgee_app_localizations.g.dart
@@ -1390,6 +1390,13 @@ class TolgeeAppLocalizations extends AppLocalizations {
   );
 
   @override
+  String get connect_tab_practices => TolgeeBridge.get(
+    localeName,
+    'connect_tab_practices',
+    () => _fallback.connect_tab_practices,
+  );
+
+  @override
   String get connect_tab_groups => TolgeeBridge.get(
     localeName,
     'connect_tab_groups',
@@ -1439,6 +1446,13 @@ class TolgeeAppLocalizations extends AppLocalizations {
   );
 
   @override
+  String get connect_empty_discover_practices => TolgeeBridge.get(
+    localeName,
+    'connect_empty_discover_practices',
+    () => _fallback.connect_empty_discover_practices,
+  );
+
+  @override
   String get connect_all_groups => TolgeeBridge.get(
     localeName,
     'connect_all_groups',
@@ -1464,6 +1478,13 @@ class TolgeeAppLocalizations extends AppLocalizations {
     localeName,
     'connect_my_empty_posts_title',
     () => _fallback.connect_my_empty_posts_title,
+  );
+
+  @override
+  String get connect_my_empty_practices_title => TolgeeBridge.get(
+    localeName,
+    'connect_my_empty_practices_title',
+    () => _fallback.connect_my_empty_practices_title,
   );
 
   @override
@@ -1495,6 +1516,13 @@ class TolgeeAppLocalizations extends AppLocalizations {
   );
 
   @override
+  String get connect_my_empty_practices_subtitle => TolgeeBridge.get(
+    localeName,
+    'connect_my_empty_practices_subtitle',
+    () => _fallback.connect_my_empty_practices_subtitle,
+  );
+
+  @override
   String get connect_my_empty_groups_subtitle => TolgeeBridge.get(
     localeName,
     'connect_my_empty_groups_subtitle',
@@ -1520,6 +1548,13 @@ class TolgeeAppLocalizations extends AppLocalizations {
     localeName,
     'connect_my_empty_posts_browse',
     () => _fallback.connect_my_empty_posts_browse,
+  );
+
+  @override
+  String get connect_my_empty_practices_browse => TolgeeBridge.get(
+    localeName,
+    'connect_my_empty_practices_browse',
+    () => _fallback.connect_my_empty_practices_browse,
   );
 
   @override

--- a/lib/features/connect/data/models/connect_feed_model.dart
+++ b/lib/features/connect/data/models/connect_feed_model.dart
@@ -39,10 +39,19 @@ class ConnectFeedItemModel {
 
     ConnectPost? post;
     if (json['post'] is Map<String, dynamic>) {
-      post =
-          ConnectPostModel.fromJson(
-            json['post'] as Map<String, dynamic>,
-          ).toEntity();
+      final postJson = Map<String, dynamic>.from(
+        json['post'] as Map<String, dynamic>,
+      );
+      final wrapperGroupName = json['group_name'] as String?;
+      if ((postJson['group_name'] as String?)?.isEmpty ?? true) {
+        if (wrapperGroupName != null && wrapperGroupName.isNotEmpty) {
+          postJson['group_name'] = wrapperGroupName;
+        }
+      }
+      if (postJson['group_avatar_url'] == null) {
+        postJson['group_avatar_url'] = json['group_avatar_url'];
+      }
+      post = ConnectPostModel.fromJson(postJson).toEntity();
     }
 
     GroupEvent? event;

--- a/lib/features/connect/data/models/connect_feed_model.dart
+++ b/lib/features/connect/data/models/connect_feed_model.dart
@@ -47,9 +47,21 @@ class ConnectFeedItemModel {
 
     GroupEvent? event;
     if (json['event'] is Map<String, dynamic>) {
+      final eventJson = Map<String, dynamic>.from(
+        json['event'] as Map<String, dynamic>,
+      );
+      final wrapperGroupName = json['group_name'] as String?;
+      if ((eventJson['group_name'] as String?)?.isEmpty ?? true) {
+        if (wrapperGroupName != null && wrapperGroupName.isNotEmpty) {
+          eventJson['group_name'] = wrapperGroupName;
+        }
+      }
+      if (eventJson['group_avatar_url'] == null) {
+        eventJson['group_avatar_url'] = json['group_avatar_url'];
+      }
       event =
           GroupEventModel.fromJson(
-            json['event'] as Map<String, dynamic>,
+            eventJson,
             language: language,
           ).toEntity();
     }

--- a/lib/features/connect/data/models/connect_post_model.dart
+++ b/lib/features/connect/data/models/connect_post_model.dart
@@ -87,6 +87,8 @@ class ConnectPostLinkModel {
 class ConnectPostModel {
   final String id;
   final String groupId;
+  final String groupName;
+  final String? groupAvatarUrl;
   final String caption;
   final String status;
   final DateTime? publishedAt;
@@ -103,6 +105,8 @@ class ConnectPostModel {
   const ConnectPostModel({
     required this.id,
     required this.groupId,
+    this.groupName = '',
+    this.groupAvatarUrl,
     required this.caption,
     required this.status,
     this.publishedAt,
@@ -124,6 +128,8 @@ class ConnectPostModel {
     return ConnectPostModel(
       id: json['id'] as String? ?? '',
       groupId: json['group_id'] as String? ?? '',
+      groupName: json['group_name'] as String? ?? '',
+      groupAvatarUrl: json['group_avatar_url'] as String?,
       caption: json['caption'] as String? ?? '',
       status: json['status'] as String? ?? '',
       publishedAt: _parseDateTime(json['published_at']),
@@ -153,6 +159,8 @@ class ConnectPostModel {
     return ConnectPost(
       id: id,
       groupId: groupId,
+      groupName: groupName,
+      groupAvatarUrl: groupAvatarUrl,
       caption: caption,
       status: status,
       publishedAt: publishedAt,

--- a/lib/features/connect/domain/entities/connect_post.dart
+++ b/lib/features/connect/domain/entities/connect_post.dart
@@ -41,6 +41,8 @@ class ConnectPostLink {
 class ConnectPost {
   final String id;
   final String groupId;
+  final String groupName;
+  final String? groupAvatarUrl;
   final String caption;
   final String status;
   final DateTime? publishedAt;
@@ -57,6 +59,8 @@ class ConnectPost {
   const ConnectPost({
     required this.id,
     required this.groupId,
+    this.groupName = '',
+    this.groupAvatarUrl,
     required this.caption,
     required this.status,
     this.publishedAt,
@@ -79,6 +83,8 @@ class ConnectPost {
     return ConnectPost(
       id: id,
       groupId: groupId,
+      groupName: groupName,
+      groupAvatarUrl: groupAvatarUrl,
       caption: caption,
       status: status,
       publishedAt: publishedAt,

--- a/lib/features/connect/presentation/providers/connect_practices_providers.dart
+++ b/lib/features/connect/presentation/providers/connect_practices_providers.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_pecha/core/config/locale/locale_notifier.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_practice.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/providers/group_profile_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ConnectPracticesState {
+  final List<GroupPractice> practices;
+  final bool isLoading;
+  final bool isLoadingMore;
+  final String? error;
+  final bool hasMore;
+  final int skip;
+  final bool hasLoaded;
+
+  const ConnectPracticesState({
+    this.practices = const [],
+    this.isLoading = false,
+    this.isLoadingMore = false,
+    this.error,
+    this.hasMore = true,
+    this.skip = 0,
+    this.hasLoaded = false,
+  });
+
+  ConnectPracticesState copyWith({
+    List<GroupPractice>? practices,
+    bool? isLoading,
+    bool? isLoadingMore,
+    String? error,
+    bool? hasMore,
+    int? skip,
+    bool? hasLoaded,
+    bool clearError = false,
+  }) {
+    return ConnectPracticesState(
+      practices: practices ?? this.practices,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      error: clearError ? null : error ?? this.error,
+      hasMore: hasMore ?? this.hasMore,
+      skip: skip ?? this.skip,
+      hasLoaded: hasLoaded ?? this.hasLoaded,
+    );
+  }
+}
+
+class ConnectPracticesNotifier extends StateNotifier<ConnectPracticesState> {
+  ConnectPracticesNotifier({
+    required this.ref,
+    required this.includeUnfollowed,
+    required this.language,
+  }) : super(const ConnectPracticesState());
+
+  final Ref ref;
+  final bool includeUnfollowed;
+  final String language;
+  static const int _limit = 20;
+  bool _loadRequested = false;
+
+  void ensureLoaded() {
+    if (_loadRequested) return;
+    _loadRequested = true;
+    loadInitial();
+  }
+
+  Future<void> loadInitial() async {
+    if (state.isLoading) return;
+
+    final authState = ref.read(authProvider);
+    if (!includeUnfollowed && (authState.isGuest || !authState.isLoggedIn)) {
+      state = const ConnectPracticesState(hasMore: false, hasLoaded: true);
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, clearError: true);
+
+    final result = await ref.read(groupProfileRepositoryProvider).getConnectPractices(
+      includeUnfollowed: includeUnfollowed,
+      language: language,
+      skip: 0,
+      limit: _limit,
+    );
+
+    if (!mounted) return;
+
+    result.fold(
+      (failure) {
+        state = state.copyWith(
+          isLoading: false,
+          error: failure.message,
+          hasLoaded: true,
+        );
+      },
+      (page) {
+        state = state.copyWith(
+          practices: page.practices,
+          isLoading: false,
+          hasMore: page.hasMore,
+          skip: page.practices.length,
+          hasLoaded: true,
+          clearError: true,
+        );
+      },
+    );
+  }
+
+  Future<void> loadMore() async {
+    if (state.isLoadingMore || !state.hasMore || state.isLoading) return;
+
+    state = state.copyWith(isLoadingMore: true, clearError: true);
+
+    final result = await ref.read(groupProfileRepositoryProvider).getConnectPractices(
+      includeUnfollowed: includeUnfollowed,
+      language: language,
+      skip: state.skip,
+      limit: _limit,
+    );
+
+    if (!mounted) return;
+
+    result.fold(
+      (failure) {
+        state = state.copyWith(isLoadingMore: false, error: failure.message);
+      },
+      (page) {
+        state = state.copyWith(
+          practices: [...state.practices, ...page.practices],
+          isLoadingMore: false,
+          hasMore: page.hasMore,
+          skip: state.skip + page.practices.length,
+          clearError: true,
+        );
+      },
+    );
+  }
+
+  Future<void> refresh() async {
+    _loadRequested = false;
+    state = const ConnectPracticesState();
+    ensureLoaded();
+  }
+
+  void retry() {
+    if (state.practices.isEmpty) {
+      _loadRequested = false;
+      ensureLoaded();
+    } else {
+      loadMore();
+    }
+  }
+}
+
+final myConnectPracticesProvider =
+    StateNotifierProvider.autoDispose<
+      ConnectPracticesNotifier,
+      ConnectPracticesState
+    >((ref) {
+      final language = ref.watch(contentLanguageProvider);
+      return ConnectPracticesNotifier(
+        ref: ref,
+        includeUnfollowed: false,
+        language: language,
+      );
+    });
+
+final discoverConnectPracticesProvider =
+    StateNotifierProvider.autoDispose<
+      ConnectPracticesNotifier,
+      ConnectPracticesState
+    >((ref) {
+      final language = ref.watch(contentLanguageProvider);
+      return ConnectPracticesNotifier(
+        ref: ref,
+        includeUnfollowed: true,
+        language: language,
+      );
+    });

--- a/lib/features/connect/presentation/screens/connect_post_detail_screen.dart
+++ b/lib/features/connect/presentation/screens/connect_post_detail_screen.dart
@@ -19,7 +19,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
 
-class ConnectPostDetailScreen extends ConsumerStatefulWidget {
+class ConnectPostDetailScreen extends ConsumerWidget {
   const ConnectPostDetailScreen({
     super.key,
     required this.postId,
@@ -32,31 +32,75 @@ class ConnectPostDetailScreen extends ConsumerStatefulWidget {
   final bool includeUnfollowed;
 
   @override
-  ConsumerState<ConnectPostDetailScreen> createState() =>
-      _ConnectPostDetailScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      backgroundColor:
+          isDark ? AppColors.scaffoldBackgroundDark : AppColors.surfaceLight,
+      body: SafeArea(
+        bottom: false,
+        child: ConnectPostDetailPanel(
+          postId: postId,
+          initialPost: initialPost,
+          includeUnfollowed: includeUnfollowed,
+          showTopBar: true,
+        ),
+      ),
+    );
+  }
 }
 
-class _ConnectPostDetailScreenState
-    extends ConsumerState<ConnectPostDetailScreen> {
+class ConnectPostDetailPanel extends ConsumerStatefulWidget {
+  const ConnectPostDetailPanel({
+    super.key,
+    required this.postId,
+    this.initialPost,
+    this.includeUnfollowed = false,
+    this.scrollController,
+    this.showTopBar = false,
+    this.showPostPreview = true,
+  });
+
+  final String postId;
+  final ConnectPost? initialPost;
+  final bool includeUnfollowed;
+  final ScrollController? scrollController;
+  final bool showTopBar;
+  final bool showPostPreview;
+
+  @override
+  ConsumerState<ConnectPostDetailPanel> createState() =>
+      _ConnectPostDetailPanelState();
+}
+
+class _ConnectPostDetailPanelState extends ConsumerState<ConnectPostDetailPanel> {
+  late final ScrollController _scrollController;
+  late final bool _ownsScrollController;
   late ConnectPost _post;
   final ConnectOptimisticLikeState _likeState = ConnectOptimisticLikeState();
   bool _captionExpanded = false;
   ConnectPostComment? _replyTarget;
   final TextEditingController _commentController = TextEditingController();
   final FocusNode _commentFocusNode = FocusNode();
-  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
     _post = widget.initialPost ?? _emptyPost(widget.postId);
+    _ownsScrollController = widget.scrollController == null;
+    _scrollController = widget.scrollController ?? ScrollController();
     _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
     _scrollController.removeListener(_onScroll);
-    _scrollController.dispose();
+    if (_ownsScrollController) {
+      _scrollController.dispose();
+    }
     _commentController.dispose();
     _commentFocusNode.dispose();
     super.dispose();
@@ -209,37 +253,29 @@ class _ConnectPostDetailScreenState
     final commentCount =
         commentsState.total > 0 ? commentsState.total : _post.commentCount;
 
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      backgroundColor:
-          isDark ? AppColors.scaffoldBackgroundDark : AppColors.surfaceLight,
-      body: SafeArea(
-        bottom: false,
-        child: Column(
-          children: [
-            _buildTopBar(context, isDark),
-            Expanded(
-              child: MediaQuery.removeViewInsets(
-                context: context,
-                removeBottom: true,
-                child: _buildBody(context, isDark, commentsState, commentCount),
-              ),
-            ),
-            ConnectCommentComposer(
-              controller: _commentController,
-              focusNode: _commentFocusNode,
-              isSubmitting: isSubmittingComment,
-              onSubmit: _submitComment,
-              replyHandle: _replyTarget?.user.mentionHandle,
-              onClearReply: _clearReply,
-            ),
-          ],
+    return Column(
+      children: [
+        if (widget.showTopBar) _buildTopBar(context),
+        Expanded(
+          child: MediaQuery.removeViewInsets(
+            context: context,
+            removeBottom: true,
+            child: _buildBody(context, isDark, commentsState, commentCount),
+          ),
         ),
-      ),
+        ConnectCommentComposer(
+          controller: _commentController,
+          focusNode: _commentFocusNode,
+          isSubmitting: isSubmittingComment,
+          onSubmit: _submitComment,
+          replyHandle: _replyTarget?.user.mentionHandle,
+          onClearReply: _clearReply,
+        ),
+      ],
     );
   }
 
-  Widget _buildTopBar(BuildContext context, bool isDark) {
+  Widget _buildTopBar(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 4, 8, 0),
       child: Row(
@@ -283,10 +319,17 @@ class _ConnectPostDetailScreenState
 
     return ListView(
       controller: _scrollController,
-      padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+      padding: EdgeInsets.fromLTRB(
+        20,
+        widget.showPostPreview ? 0 : 8,
+        20,
+        16,
+      ),
       children: [
-        _buildPostCard(context, isDark, commentCount),
-        const SizedBox(height: 24),
+        if (widget.showPostPreview) ...[
+          _buildPostCard(context, isDark, commentCount),
+          const SizedBox(height: 24),
+        ],
         Text(
           context.l10n.connect_post_comments_count(commentCount),
           style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700),

--- a/lib/features/connect/presentation/screens/connect_post_detail_screen.dart
+++ b/lib/features/connect/presentation/screens/connect_post_detail_screen.dart
@@ -345,8 +345,8 @@ class _ConnectPostDetailScreenState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _PostAuthorRow(
-            name: _post.creatorName,
-            avatarUrl: _post.creatorImageUrl,
+            name: _post.groupName,
+            avatarUrl: _post.groupAvatarUrl,
             isDark: isDark,
           ),
           if (caption.isNotEmpty) ...[
@@ -426,7 +426,7 @@ class _PostAuthorRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final displayName =
-        name.trim().isNotEmpty ? name.trim() : context.l10n.author;
+        name.trim().isNotEmpty ? name.trim() : context.l10n.connect_group_fallback_title;
 
     return Row(
       children: [

--- a/lib/features/connect/presentation/screens/connect_screen.dart
+++ b/lib/features/connect/presentation/screens/connect_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_pecha/features/connect/presentation/widgets/connect_even
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_feed_tab.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_groups_tab.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_posts_tab.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_practices_tab.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/followed_groups_row.dart';
 import 'package:flutter_pecha/shared/widgets/main_tab_app_bar.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,7 +27,7 @@ class _ConnectScreenState extends ConsumerState<ConnectScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 4, vsync: this);
+    _tabController = TabController(length: 5, vsync: this);
     _tabController.addListener(_onTabChanged);
   }
 
@@ -110,10 +111,11 @@ class _ConnectScreenState extends ConsumerState<ConnectScreen>
                   isActive: activeTabIndex == 1,
                 ),
                 ConnectPostsTab(isActive: activeTabIndex == 2),
+                ConnectPracticesTab(isActive: activeTabIndex == 3),
                 ConnectGroupsTab(
                   myGroups: displayedMyGroups,
                   onRefresh: _onGroupsRefresh,
-                  isActive: activeTabIndex == 3,
+                  isActive: activeTabIndex == 4,
                 ),
               ],
             ),
@@ -167,6 +169,7 @@ class _ConnectMainTabBar extends StatelessWidget {
           Tab(text: context.l10n.connect_tab_feed),
           Tab(text: context.l10n.connect_tab_events),
           Tab(text: context.l10n.connect_tab_posts),
+          Tab(text: context.l10n.connect_tab_practices),
           Tab(text: context.l10n.connect_tab_groups),
         ],
       ),

--- a/lib/features/connect/presentation/screens/connect_screen.dart
+++ b/lib/features/connect/presentation/screens/connect_screen.dart
@@ -112,7 +112,6 @@ class _ConnectScreenState extends ConsumerState<ConnectScreen>
                 ConnectPostsTab(isActive: activeTabIndex == 2),
                 ConnectGroupsTab(
                   myGroups: displayedMyGroups,
-                  myGroupsLoading: myGroupsLoading,
                   onRefresh: _onGroupsRefresh,
                   isActive: activeTabIndex == 3,
                 ),

--- a/lib/features/connect/presentation/screens/connect_screen.dart
+++ b/lib/features/connect/presentation/screens/connect_screen.dart
@@ -148,15 +148,14 @@ class _ConnectMainTabBar extends StatelessWidget {
       ),
       child: TabBar(
         controller: controller,
-        isScrollable: true,
-        tabAlignment: TabAlignment.start,
+        tabAlignment: TabAlignment.fill,
         labelColor: labelColor,
         unselectedLabelColor: unselectedColor,
         indicatorColor: labelColor,
         indicatorWeight: 2,
         indicatorSize: TabBarIndicatorSize.label,
         dividerColor: Colors.transparent,
-        labelPadding: const EdgeInsets.symmetric(horizontal: 20),
+        labelPadding: const EdgeInsets.symmetric(horizontal: 8),
         labelStyle: const TextStyle(
           fontSize: 15,
           fontWeight: FontWeight.w700,

--- a/lib/features/connect/presentation/utils/connect_event_attendance_utils.dart
+++ b/lib/features/connect/presentation/utils/connect_event_attendance_utils.dart
@@ -6,6 +6,15 @@ import 'package:flutter_pecha/features/group_profile/presentation/providers/grou
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 
+/// Returns true when the event has already ended (or its start is in the past
+/// when no end date is available). Events without dates are treated as upcoming.
+bool isGroupEventPast(GroupEvent event, {DateTime? now}) {
+  final current = now ?? DateTime.now();
+  final reference = event.endDate ?? event.startDate;
+  if (reference == null) return false;
+  return reference.toLocal().isBefore(current);
+}
+
 bool isUserInGroup(WidgetRef ref, String groupId) {
   if (groupId.isEmpty) return true;
 

--- a/lib/features/connect/presentation/widgets/connect_event_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_event_card.dart
@@ -15,14 +15,9 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 class ConnectEventCard extends ConsumerStatefulWidget {
-  const ConnectEventCard({
-    super.key,
-    required this.event,
-    this.groupLocations = const {},
-  });
+  const ConnectEventCard({super.key, required this.event});
 
   final GroupEvent event;
-  final Map<String, String> groupLocations;
 
   @override
   ConsumerState<ConnectEventCard> createState() => _ConnectEventCardState();
@@ -48,12 +43,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
         event.title.trim().isNotEmpty
             ? event.title.trim()
             : context.l10n.connect_event_fallback_title;
-    final detailsLine = _formatDetailsLine(
-      context,
-      event,
-      participantCount,
-      ref,
-    );
+    final detailsLine = _formatDetailsLine(context, event, participantCount);
 
     return Material(
       color: cardColor,
@@ -119,9 +109,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
                   Row(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      Expanded(
-                        child: _EventGroupLabel(event: event),
-                      ),
+                      Expanded(child: _EventGroupLabel(event: event)),
                       if (!isPast) ...[
                         const SizedBox(width: 12),
                         GestureDetector(
@@ -156,7 +144,6 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
     BuildContext context,
     GroupEvent event,
     int participantCount,
-    WidgetRef ref,
   ) {
     final parts = <String>[];
 
@@ -166,10 +153,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
       parts.add(DateFormat('EEE d MMM', locale).format(start));
     }
 
-    final location = _resolveLocation(event.groupId, ref, context);
-    if (location != null && location.isNotEmpty) {
-      parts.add(location);
-    }
+    parts.add(_eventLocationLabel(context, event));
 
     if (participantCount > 0) {
       parts.add(
@@ -181,21 +165,13 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
     return parts.join(' · ');
   }
 
-  String? _resolveLocation(String groupId, WidgetRef ref, BuildContext context) {
-    final cached = widget.groupLocations[groupId];
-    if (cached != null && cached.isNotEmpty) return cached;
-    if (groupId.isEmpty) return null;
-
-    final groupEither = ref.watch(groupProfileProvider(groupId)).valueOrNull;
-    return groupEither?.fold(
-      (_) => null,
-      (profile) {
-        if (profile.tags.isNotEmpty) return profile.tags.first;
-        final subtitle = profile.subTitle?.trim();
-        if (subtitle != null && subtitle.isNotEmpty) return subtitle;
-        return context.l10n.connect_online;
-      },
-    );
+  String _eventLocationLabel(BuildContext context, GroupEvent event) {
+    final locationId = event.locationId?.trim();
+    if (locationId != null && locationId.isNotEmpty) {
+      final name = event.location?.name.trim();
+      if (name != null && name.isNotEmpty) return name;
+    }
+    return context.l10n.connect_online;
   }
 
   Future<void> _toggleAttendance(GroupEvent event, bool isAttending) async {
@@ -212,7 +188,10 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
     final result =
         isAttending
             ? await repository.leaveGroupEvent(event.id)
-            : await joinGroupEventEnsuringGroupMembership(ref: ref, event: event);
+            : await joinGroupEventEnsuringGroupMembership(
+              ref: ref,
+              event: event,
+            );
     if (!mounted) return;
     setState(() => _isSubmitting = false);
 
@@ -251,8 +230,9 @@ class _EventGroupLabel extends StatelessWidget {
     final avatarUrl = event.groupAvatarUrl?.trim();
     final placeholderColor =
         isDark ? AppColors.surfaceVariantDark : AppColors.grey100;
+    final groupId = event.groupId.trim();
 
-    return Row(
+    final content = Row(
       children: [
         ClipOval(
           child: SizedBox(
@@ -291,6 +271,14 @@ class _EventGroupLabel extends StatelessWidget {
         ),
       ],
     );
+
+    if (groupId.isEmpty) return content;
+
+    return GestureDetector(
+      onTap: () => context.push('/home/group/$groupId'),
+      behavior: HitTestBehavior.opaque,
+      child: content,
+    );
   }
 }
 
@@ -308,66 +296,63 @@ class _AttendButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 14),
-          decoration: BoxDecoration(
-            color:
-                isAttending
-                    ? (isDark ? AppColors.surfaceVariantDark : AppColors.grey100)
-                    : (isDark ? AppColors.surfaceWhite : AppColors.textPrimary),
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (isAttending) ...[
-                Icon(
-                  AppAssets.check,
-                  size: 14,
-                  color:
-                      isDark
-                          ? AppColors.textPrimaryDark
-                          : AppColors.textPrimary,
-                ),
-                const SizedBox(width: 4),
-              ],
-              if (isSubmitting)
-                SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color:
-                        isAttending
-                            ? (isDark
-                                ? AppColors.textPrimaryDark
-                                : AppColors.textPrimary)
-                            : (isDark
-                                ? AppColors.textPrimary
-                                : AppColors.surfaceWhite),
-                  ),
-                )
-              else
-                Text(
-                  isAttending
-                      ? context.l10n.connect_event_attending
-                      : context.l10n.connect_event_attend,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color:
-                        isAttending
-                            ? (isDark
-                                ? AppColors.textPrimaryDark
-                                : AppColors.textPrimary)
-                            : (isDark
-                                ? AppColors.textPrimary
-                                : AppColors.surfaceWhite),
-                  ),
-                ),
-            ],
-          ),
+      duration: const Duration(milliseconds: 150),
+      height: 32,
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      decoration: BoxDecoration(
+        color:
+            isAttending
+                ? (isDark ? AppColors.surfaceVariantDark : AppColors.grey100)
+                : (isDark ? AppColors.surfaceWhite : AppColors.textPrimary),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isAttending) ...[
+            Icon(
+              AppAssets.check,
+              size: 14,
+              color: isDark ? AppColors.textPrimaryDark : AppColors.textPrimary,
+            ),
+            const SizedBox(width: 4),
+          ],
+          if (isSubmitting)
+            SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color:
+                    isAttending
+                        ? (isDark
+                            ? AppColors.textPrimaryDark
+                            : AppColors.textPrimary)
+                        : (isDark
+                            ? AppColors.textPrimary
+                            : AppColors.surfaceWhite),
+              ),
+            )
+          else
+            Text(
+              isAttending
+                  ? context.l10n.connect_event_attending
+                  : context.l10n.connect_event_attend,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color:
+                    isAttending
+                        ? (isDark
+                            ? AppColors.textPrimaryDark
+                            : AppColors.textPrimary)
+                        : (isDark
+                            ? AppColors.textPrimary
+                            : AppColors.surfaceWhite),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/connect/presentation/widgets/connect_event_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_event_card.dart
@@ -44,6 +44,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
         isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
     final event = widget.event;
     final isAttending = _attendingOverride ?? event.isJoined;
+    final isPast = isGroupEventPast(event);
     final participantCount = _participantCount(event, isAttending);
     final title =
         event.title.trim().isNotEmpty
@@ -126,16 +127,18 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
                           groupNames: widget.groupNames,
                         ),
                       ),
-                      const SizedBox(width: 12),
-                      GestureDetector(
-                        onTap: () => _toggleAttendance(event, isAttending),
-                        behavior: HitTestBehavior.opaque,
-                        child: _AttendButton(
-                          isAttending: isAttending,
-                          isSubmitting: _isSubmitting,
-                          isDark: isDark,
+                      if (!isPast) ...[
+                        const SizedBox(width: 12),
+                        GestureDetector(
+                          onTap: () => _toggleAttendance(event, isAttending),
+                          behavior: HitTestBehavior.opaque,
+                          child: _AttendButton(
+                            isAttending: isAttending,
+                            isSubmitting: _isSubmitting,
+                            isDark: isDark,
+                          ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                 ],
@@ -201,7 +204,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
   }
 
   Future<void> _toggleAttendance(GroupEvent event, bool isAttending) async {
-    if (_isSubmitting) return;
+    if (_isSubmitting || isGroupEventPast(event)) return;
 
     final authState = ref.read(authProvider);
     if (authState.isGuest || !authState.isLoggedIn) {

--- a/lib/features/connect/presentation/widgets/connect_event_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_event_card.dart
@@ -3,12 +3,12 @@ import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/intl_format_locale.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/core/widgets/responsive_cover_image.dart';
 import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
 import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
 import 'package:flutter_pecha/features/connect/presentation/utils/connect_event_attendance_utils.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_event.dart';
-import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
 import 'package:flutter_pecha/features/group_profile/presentation/providers/group_profile_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -18,12 +18,10 @@ class ConnectEventCard extends ConsumerStatefulWidget {
   const ConnectEventCard({
     super.key,
     required this.event,
-    this.groupNames = const {},
     this.groupLocations = const {},
   });
 
   final GroupEvent event;
-  final Map<String, String> groupNames;
   final Map<String, String> groupLocations;
 
   @override
@@ -122,10 +120,7 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Expanded(
-                        child: _EventGroupLabel(
-                          groupId: event.groupId,
-                          groupNames: widget.groupNames,
-                        ),
+                        child: _EventGroupLabel(event: event),
                       ),
                       if (!isPast) ...[
                         const SizedBox(width: 12),
@@ -238,65 +233,63 @@ class _ConnectEventCardState extends ConsumerState<ConnectEventCard> {
   }
 }
 
-class _EventGroupLabel extends ConsumerWidget {
-  const _EventGroupLabel({
-    required this.groupId,
-    required this.groupNames,
-  });
+class _EventGroupLabel extends StatelessWidget {
+  const _EventGroupLabel({required this.event});
 
-  final String groupId;
-  final Map<String, String> groupNames;
+  final GroupEvent event;
 
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final cachedName = groupNames[groupId];
-    if (cachedName != null && cachedName.isNotEmpty) {
-      return _GroupNameText(name: cachedName);
-    }
-
-    if (groupId.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    final groupAsync = ref.watch(groupProfileProvider(groupId));
-    return groupAsync.when(
-      data:
-          (either) => either.fold(
-            (_) => const SizedBox.shrink(),
-            (profile) => _GroupNameText(
-              name: _groupLabel(profile, context),
-            ),
-          ),
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
-    );
-  }
-
-  String _groupLabel(GroupProfile profile, BuildContext context) {
-    return profile.title.trim().isNotEmpty
-        ? profile.title.trim()
-        : context.l10n.connect_group_fallback_title;
-  }
-}
-
-class _GroupNameText extends StatelessWidget {
-  const _GroupNameText({required this.name});
-
-  final String name;
+  static const double _avatarSize = 24;
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final name = event.groupName?.trim();
+    if (name == null || name.isEmpty) {
+      return const SizedBox.shrink();
+    }
 
-    return Text(
-      name,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: TextStyle(
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-        color: isDark ? AppColors.textPrimaryDark : AppColors.primaryDark,
-      ),
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final avatarUrl = event.groupAvatarUrl?.trim();
+    final placeholderColor =
+        isDark ? AppColors.surfaceVariantDark : AppColors.grey100;
+
+    return Row(
+      children: [
+        ClipOval(
+          child: SizedBox(
+            width: _avatarSize,
+            height: _avatarSize,
+            child:
+                avatarUrl != null && avatarUrl.isNotEmpty
+                    ? CachedNetworkImageWidget(
+                      imageUrl: avatarUrl,
+                      fit: BoxFit.cover,
+                      width: _avatarSize,
+                      height: _avatarSize,
+                    )
+                    : ColoredBox(
+                      color: placeholderColor,
+                      child: Icon(
+                        AppAssets.usersThree,
+                        size: 14,
+                        color: isDark ? AppColors.grey500 : AppColors.grey600,
+                      ),
+                    ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: isDark ? AppColors.textPrimaryDark : AppColors.primaryDark,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/connect/presentation/widgets/connect_event_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_event_card.dart
@@ -286,14 +286,16 @@ class _GroupNameText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Text(
       name,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      style: const TextStyle(
+      style: TextStyle(
         fontSize: 14,
         fontWeight: FontWeight.w600,
-        color: AppColors.primaryDark,
+        color: isDark ? AppColors.textPrimaryDark : AppColors.primaryDark,
       ),
     );
   }

--- a/lib/features/connect/presentation/widgets/connect_events_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_events_tab.dart
@@ -26,11 +26,6 @@ class ConnectEventsTab extends ConsumerStatefulWidget {
 
 class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
     with ConnectLazyMyDiscoverTabMixin<ConnectEventsTab> {
-  Map<String, String> _groupLocations(BuildContext context) => {
-    for (final group in widget.myGroups)
-      group.id: _locationForGroup(group, context),
-  };
-
   @override
   bool readTabActive(ConnectEventsTab widget) => widget.isActive;
 
@@ -44,13 +39,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
     }
   }
 
-  String _locationForGroup(GroupProfile group, BuildContext context) {
-    if (group.tags.isNotEmpty) return group.tags.first;
-    final subtitle = group.subTitle?.trim();
-    if (subtitle != null && subtitle.isNotEmpty) return subtitle;
-    return context.l10n.connect_online;
-  }
-
   @override
   Widget build(BuildContext context) {
     // Watch both providers unconditionally so they stay alive across
@@ -58,7 +46,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
     // when to actually fetch.
     final myState = ref.watch(myConnectEventsProvider);
     final discoverState = ref.watch(discoverConnectEventsProvider);
-    final groupLocations = _groupLocations(context);
 
     return ConnectMyDiscoverTabGate(
       myHasLoaded: myState.hasLoaded,
@@ -88,7 +75,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
           itemBuilder:
               (context, index) => ConnectEventCard(
                 event: myState.events[index],
-                groupLocations: groupLocations,
               ),
         );
       },
@@ -107,7 +93,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
           itemBuilder:
               (context, index) => ConnectEventCard(
                 event: discoverState.events[index],
-                groupLocations: groupLocations,
               ),
         );
       },

--- a/lib/features/connect/presentation/widgets/connect_events_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_events_tab.dart
@@ -3,7 +3,7 @@ import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_events_providers.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_event_card.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_lazy_segment_mixin.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_empty_state.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
@@ -64,7 +64,10 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
     final discoverState = ref.watch(discoverConnectEventsProvider);
     final groupLocations = _groupLocations(context);
 
-    return ConnectMyDiscoverTab(
+    return ConnectMyDiscoverTabGate(
+      myHasLoaded: myState.hasLoaded,
+      myIsEmpty: myState.events.isEmpty,
+      myHasError: myState.error != null,
       onSegmentChanged: handleSegmentChanged,
       onMyRefresh: () => ref.read(myConnectEventsProvider.notifier).refresh(),
       onDiscoverRefresh:

--- a/lib/features/connect/presentation/widgets/connect_events_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_events_tab.dart
@@ -26,10 +26,6 @@ class ConnectEventsTab extends ConsumerStatefulWidget {
 
 class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
     with ConnectLazyMyDiscoverTabMixin<ConnectEventsTab> {
-  Map<String, String> get _groupNames => {
-    for (final group in widget.myGroups) group.id: group.title,
-  };
-
   Map<String, String> _groupLocations(BuildContext context) => {
     for (final group in widget.myGroups)
       group.id: _locationForGroup(group, context),
@@ -92,7 +88,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
           itemBuilder:
               (context, index) => ConnectEventCard(
                 event: myState.events[index],
-                groupNames: _groupNames,
                 groupLocations: groupLocations,
               ),
         );
@@ -112,7 +107,6 @@ class _ConnectEventsTabState extends ConsumerState<ConnectEventsTab>
           itemBuilder:
               (context, index) => ConnectEventCard(
                 event: discoverState.events[index],
-                groupNames: _groupNames,
                 groupLocations: groupLocations,
               ),
         );

--- a/lib/features/connect/presentation/widgets/connect_feed_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_feed_tab.dart
@@ -28,18 +28,6 @@ class ConnectFeedTab extends ConsumerStatefulWidget {
 
 class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     with ConnectLazyMyDiscoverTabMixin<ConnectFeedTab> {
-  String _locationForGroup(GroupProfile group, BuildContext context) {
-    if (group.tags.isNotEmpty) return group.tags.first;
-    final subtitle = group.subTitle?.trim();
-    if (subtitle != null && subtitle.isNotEmpty) return subtitle;
-    return context.l10n.connect_online;
-  }
-
-  Map<String, String> _groupLocations(BuildContext context) => {
-    for (final group in widget.myGroups)
-      group.id: _locationForGroup(group, context),
-  };
-
   @override
   bool readTabActive(ConnectFeedTab widget) => widget.isActive;
 
@@ -60,7 +48,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     // when to actually fetch.
     final myState = ref.watch(myConnectFeedProvider);
     final discoverState = ref.watch(discoverConnectFeedProvider);
-    final groupLocations = _groupLocations(context);
 
     return ConnectMyDiscoverTabGate(
       myHasLoaded: myState.hasLoaded,
@@ -92,7 +79,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
                 context,
                 myState.items[index],
                 includeUnfollowed: false,
-                groupLocations: groupLocations,
               ),
         );
       },
@@ -112,7 +98,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
                 context,
                 discoverState.items[index],
                 includeUnfollowed: true,
-                groupLocations: groupLocations,
               ),
         );
       },
@@ -123,7 +108,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     BuildContext context,
     ConnectFeedItem item, {
     required bool includeUnfollowed,
-    required Map<String, String> groupLocations,
   }) {
     if (item.type == ConnectFeedItemType.post && item.post != null) {
       return ConnectPostCard(
@@ -134,10 +118,7 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     }
 
     if (item.type == ConnectFeedItemType.event && item.event != null) {
-      return ConnectEventCard(
-        event: item.event!,
-        groupLocations: groupLocations,
-      );
+      return ConnectEventCard(event: item.event!);
     }
 
     return const SizedBox.shrink();

--- a/lib/features/connect/presentation/widgets/connect_feed_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_feed_tab.dart
@@ -4,7 +4,7 @@ import 'package:flutter_pecha/features/connect/domain/entities/connect_feed_item
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_feed_providers.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_event_card.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_lazy_segment_mixin.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_empty_state.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_post_card.dart';
@@ -66,7 +66,10 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     final discoverState = ref.watch(discoverConnectFeedProvider);
     final groupLocations = _groupLocations(context);
 
-    return ConnectMyDiscoverTab(
+    return ConnectMyDiscoverTabGate(
+      myHasLoaded: myState.hasLoaded,
+      myIsEmpty: myState.items.isEmpty,
+      myHasError: myState.error != null,
       onSegmentChanged: handleSegmentChanged,
       onMyRefresh: () => ref.read(myConnectFeedProvider.notifier).refresh(),
       onDiscoverRefresh:

--- a/lib/features/connect/presentation/widgets/connect_feed_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_feed_tab.dart
@@ -28,10 +28,6 @@ class ConnectFeedTab extends ConsumerStatefulWidget {
 
 class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     with ConnectLazyMyDiscoverTabMixin<ConnectFeedTab> {
-  Map<String, String> get _groupNames => {
-    for (final group in widget.myGroups) group.id: group.title,
-  };
-
   String _locationForGroup(GroupProfile group, BuildContext context) {
     if (group.tags.isNotEmpty) return group.tags.first;
     final subtitle = group.subTitle?.trim();
@@ -129,11 +125,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     required bool includeUnfollowed,
     required Map<String, String> groupLocations,
   }) {
-    final groupNames = {
-      ..._groupNames,
-      if (item.groupName.isNotEmpty) item.groupId: item.groupName,
-    };
-
     if (item.type == ConnectFeedItemType.post && item.post != null) {
       return ConnectPostCard(
         post: item.post!,
@@ -145,7 +136,6 @@ class _ConnectFeedTabState extends ConsumerState<ConnectFeedTab>
     if (item.type == ConnectFeedItemType.event && item.event != null) {
       return ConnectEventCard(
         event: item.event!,
-        groupNames: groupNames,
         groupLocations: groupLocations,
       );
     }

--- a/lib/features/connect/presentation/widgets/connect_groups_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_groups_tab.dart
@@ -2,26 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/font_config.dart';
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_providers.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_lazy_segment_mixin.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_empty_state.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/discover_group_card.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Groups tab content with My / Discover sub-tabs.
+/// Groups tab content showing discover groups.
 class ConnectGroupsTab extends ConsumerStatefulWidget {
   const ConnectGroupsTab({
     super.key,
     required this.myGroups,
-    required this.myGroupsLoading,
     required this.onRefresh,
     this.isActive = true,
   });
 
   final List<GroupProfile> myGroups;
-  final bool myGroupsLoading;
   final Future<void> Function() onRefresh;
   final bool isActive;
 
@@ -29,15 +24,49 @@ class ConnectGroupsTab extends ConsumerStatefulWidget {
   ConsumerState<ConnectGroupsTab> createState() => _ConnectGroupsTabState();
 }
 
-class _ConnectGroupsTabState extends ConsumerState<ConnectGroupsTab>
-    with ConnectLazyMyDiscoverTabMixin<ConnectGroupsTab> {
-  @override
-  bool readTabActive(ConnectGroupsTab widget) => widget.isActive;
+class _ConnectGroupsTabState extends ConsumerState<ConnectGroupsTab> {
+  static const _paginationThreshold = 200.0;
+
+  final ScrollController _scrollController = ScrollController();
 
   @override
-  void loadActiveSegment() {
-    if (!isTabActive || selectedSegment != 1) return;
-    ref.read(discoverGroupsProvider.notifier).ensureLoaded();
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    if (widget.isActive) {
+      _scheduleLoad();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant ConnectGroupsTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isActive && widget.isActive) {
+      _scheduleLoad();
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scheduleLoad() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !widget.isActive) return;
+      ref.read(discoverGroupsProvider.notifier).ensureLoaded();
+    });
+  }
+
+  void _onScroll() {
+    if (!widget.isActive || !_scrollController.hasClients) return;
+    if (_scrollController.position.pixels <
+        _scrollController.position.maxScrollExtent - _paginationThreshold) {
+      return;
+    }
+    ref.read(discoverGroupsProvider.notifier).loadMore();
   }
 
   List<GroupProfile> _discoverGroups(DiscoverGroupsState discoverState) {
@@ -50,70 +79,41 @@ class _ConnectGroupsTabState extends ConsumerState<ConnectGroupsTab>
 
   @override
   Widget build(BuildContext context) {
-    // Watch unconditionally so it stays alive across My/Discover segment
-    // switches; only `loadActiveSegment()` decides when to actually fetch.
     final discoverState = ref.watch(discoverGroupsProvider);
     final discoverGroups = _discoverGroups(discoverState);
 
-    return ConnectMyDiscoverTab(
-      onSegmentChanged: handleSegmentChanged,
-      onMyRefresh: widget.onRefresh,
-      onDiscoverRefresh: widget.onRefresh,
-      onDiscoverLoadMore:
-          isTabActive && selectedSegment == 1
-              ? () => ref.read(discoverGroupsProvider.notifier).loadMore()
-              : null,
-      myBuilder: (context, _, switchToDiscover) {
-        return ConnectPaginatedListView(
-          items: widget.myGroups,
-          isLoading: widget.myGroupsLoading,
-          isLoadingMore: false,
-          error: null,
-          hasMore: false,
-          onRetry: () {},
-          separatorHeight: 12,
-          myEmptyState: ConnectMyEmptyState(
-            type: ConnectMyEmptyStateType.groups,
-            onBrowseTap: switchToDiscover,
-          ),
-          itemBuilder:
-              (context, index) => DiscoverGroupCard(
-                group: widget.myGroups[index],
-              ),
-        );
-      },
-      discoverBuilder: (context, scrollController, _) {
-        return ConnectPaginatedListView(
-          items: discoverGroups,
-          isLoading: discoverState.isLoading,
-          isLoadingMore: discoverState.isLoadingMore,
-          error: discoverState.error,
-          hasMore: discoverState.hasMore,
-          hasLoaded: discoverState.hasLoaded,
-          scrollController: scrollController,
-          onRetry: () => ref.read(discoverGroupsProvider.notifier).retry(),
-          emptyDiscoverMessage: context.l10n.connect_empty_discover_groups,
-          separatorHeight: 12,
-          leadingItemCount: 1,
-          leadingItemBuilder:
-              (context) => Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: Text(
-                  context.l10n.connect_all_groups,
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    fontSize: 18,
-                    height: AppFontConfig.tibetanCompactLineHeight,
-                  ),
+    return RefreshIndicator(
+      onRefresh: widget.onRefresh,
+      child: ConnectPaginatedListView(
+        items: discoverGroups,
+        isLoading: discoverState.isLoading,
+        isLoadingMore: discoverState.isLoadingMore,
+        error: discoverState.error,
+        hasMore: discoverState.hasMore,
+        hasLoaded: discoverState.hasLoaded,
+        scrollController: _scrollController,
+        onRetry: () => ref.read(discoverGroupsProvider.notifier).retry(),
+        emptyDiscoverMessage: context.l10n.connect_empty_discover_groups,
+        separatorHeight: 12,
+        leadingItemCount: 1,
+        leadingItemBuilder:
+            (context) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                context.l10n.connect_all_groups,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 18,
+                  height: AppFontConfig.tibetanCompactLineHeight,
                 ),
               ),
-          itemBuilder:
-              (context, index) => DiscoverGroupCard(
-                group: discoverGroups[index],
-                showJoinButton: true,
-              ),
-        );
-      },
+            ),
+        itemBuilder:
+            (context, index) => DiscoverGroupCard(
+              group: discoverGroups[index],
+              showJoinButton: true,
+            ),
+      ),
     );
   }
 }

--- a/lib/features/connect/presentation/widgets/connect_groups_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_groups_tab.dart
@@ -79,7 +79,6 @@ class _ConnectGroupsTabState extends ConsumerState<ConnectGroupsTab>
           itemBuilder:
               (context, index) => DiscoverGroupCard(
                 group: widget.myGroups[index],
-                showOpenButton: true,
               ),
         );
       },

--- a/lib/features/connect/presentation/widgets/connect_groups_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_groups_tab.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
-import 'package:flutter_pecha/core/theme/font_config.dart';
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_providers.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/discover_group_card.dart';
@@ -95,19 +94,7 @@ class _ConnectGroupsTabState extends ConsumerState<ConnectGroupsTab> {
         onRetry: () => ref.read(discoverGroupsProvider.notifier).retry(),
         emptyDiscoverMessage: context.l10n.connect_empty_discover_groups,
         separatorHeight: 12,
-        leadingItemCount: 1,
-        leadingItemBuilder:
-            (context) => Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: Text(
-                context.l10n.connect_all_groups,
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w700,
-                  fontSize: 18,
-                  height: AppFontConfig.tibetanCompactLineHeight,
-                ),
-              ),
-            ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
         itemBuilder:
             (context, index) => DiscoverGroupCard(
               group: discoverGroups[index],

--- a/lib/features/connect/presentation/widgets/connect_my_discover_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_my_discover_tab.dart
@@ -14,6 +14,7 @@ typedef ConnectSegmentChildBuilder =
 class ConnectMyDiscoverTab extends StatefulWidget {
   const ConnectMyDiscoverTab({
     super.key,
+    this.initialSegment = 0,
     required this.myBuilder,
     required this.discoverBuilder,
     this.onMyRefresh,
@@ -23,6 +24,7 @@ class ConnectMyDiscoverTab extends StatefulWidget {
     this.onSegmentChanged,
   });
 
+  final int initialSegment;
   final ConnectSegmentChildBuilder myBuilder;
   final ConnectSegmentChildBuilder discoverBuilder;
   final Future<void> Function()? onMyRefresh;
@@ -38,13 +40,14 @@ class ConnectMyDiscoverTab extends StatefulWidget {
 class _ConnectMyDiscoverTabState extends State<ConnectMyDiscoverTab> {
   static const _paginationThreshold = 200.0;
 
-  int _selectedSegment = 0;
+  late int _selectedSegment;
   final ScrollController _myScrollController = ScrollController();
   final ScrollController _discoverScrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
+    _selectedSegment = widget.initialSegment.clamp(0, 1);
     if (widget.onMyLoadMore != null) {
       _myScrollController.addListener(_onMyScroll);
     }
@@ -52,6 +55,7 @@ class _ConnectMyDiscoverTabState extends State<ConnectMyDiscoverTab> {
       _discoverScrollController.addListener(_onDiscoverScroll);
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       widget.onSegmentChanged?.call(_selectedSegment);
     });
   }

--- a/lib/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart
+++ b/lib/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab.dart';
+
+/// Waits for the first My-segment fetch to settle, then mounts
+/// [ConnectMyDiscoverTab] on the correct segment with no switch animation.
+class ConnectMyDiscoverTabGate extends StatefulWidget {
+  const ConnectMyDiscoverTabGate({
+    super.key,
+    required this.myHasLoaded,
+    required this.myIsEmpty,
+    required this.myHasError,
+    required this.onSegmentChanged,
+    required this.myBuilder,
+    required this.discoverBuilder,
+    this.onMyRefresh,
+    this.onDiscoverRefresh,
+    this.onMyLoadMore,
+    this.onDiscoverLoadMore,
+  });
+
+  final bool myHasLoaded;
+  final bool myIsEmpty;
+  final bool myHasError;
+  final ValueChanged<int> onSegmentChanged;
+  final ConnectSegmentChildBuilder myBuilder;
+  final ConnectSegmentChildBuilder discoverBuilder;
+  final Future<void> Function()? onMyRefresh;
+  final Future<void> Function()? onDiscoverRefresh;
+  final VoidCallback? onMyLoadMore;
+  final VoidCallback? onDiscoverLoadMore;
+
+  @override
+  State<ConnectMyDiscoverTabGate> createState() =>
+      _ConnectMyDiscoverTabGateState();
+}
+
+class _ConnectMyDiscoverTabGateState extends State<ConnectMyDiscoverTabGate> {
+  bool _ready = false;
+  int _initialSegment = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _maybeReveal();
+  }
+
+  @override
+  void didUpdateWidget(ConnectMyDiscoverTabGate oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _maybeReveal();
+  }
+
+  void _maybeReveal() {
+    if (_ready || !widget.myHasLoaded) return;
+    _ready = true;
+    _initialSegment = !widget.myHasError && widget.myIsEmpty ? 1 : 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_ready) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return ConnectMyDiscoverTab(
+      initialSegment: _initialSegment,
+      onSegmentChanged: widget.onSegmentChanged,
+      onMyRefresh: widget.onMyRefresh,
+      onDiscoverRefresh: widget.onDiscoverRefresh,
+      onMyLoadMore: widget.onMyLoadMore,
+      onDiscoverLoadMore: widget.onDiscoverLoadMore,
+      myBuilder: widget.myBuilder,
+      discoverBuilder: widget.discoverBuilder,
+    );
+  }
+}

--- a/lib/features/connect/presentation/widgets/connect_my_empty_state.dart
+++ b/lib/features/connect/presentation/widgets/connect_my_empty_state.dart
@@ -4,7 +4,7 @@ import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/l10n/generated/app_localizations.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
 
-enum ConnectMyEmptyStateType { feed, events, posts, groups }
+enum ConnectMyEmptyStateType { feed, events, posts, practices, groups }
 
 /// Empty state shown in Connect tabs when the My segment has no content.
 class ConnectMyEmptyState extends StatelessWidget {
@@ -89,6 +89,7 @@ class ConnectMyEmptyState extends StatelessWidget {
     ConnectMyEmptyStateType.feed => l10n.connect_my_empty_feed_title,
     ConnectMyEmptyStateType.events => l10n.connect_my_empty_events_title,
     ConnectMyEmptyStateType.posts => l10n.connect_my_empty_posts_title,
+    ConnectMyEmptyStateType.practices => l10n.connect_my_empty_practices_title,
     ConnectMyEmptyStateType.groups => l10n.connect_my_empty_groups_title,
   };
 
@@ -96,6 +97,7 @@ class ConnectMyEmptyState extends StatelessWidget {
     ConnectMyEmptyStateType.feed => l10n.connect_my_empty_feed_subtitle,
     ConnectMyEmptyStateType.events => l10n.connect_my_empty_events_subtitle,
     ConnectMyEmptyStateType.posts => l10n.connect_my_empty_posts_subtitle,
+    ConnectMyEmptyStateType.practices => l10n.connect_my_empty_practices_subtitle,
     ConnectMyEmptyStateType.groups => l10n.connect_my_empty_groups_subtitle,
   };
 
@@ -103,6 +105,7 @@ class ConnectMyEmptyState extends StatelessWidget {
     ConnectMyEmptyStateType.feed => l10n.connect_my_empty_feed_browse,
     ConnectMyEmptyStateType.events => l10n.connect_my_empty_events_browse,
     ConnectMyEmptyStateType.posts => l10n.connect_my_empty_posts_browse,
+    ConnectMyEmptyStateType.practices => l10n.connect_my_empty_practices_browse,
     ConnectMyEmptyStateType.groups => l10n.discover_groups,
   };
 }

--- a/lib/features/connect/presentation/widgets/connect_post_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_post_card.dart
@@ -45,7 +45,6 @@ class _ConnectPostCardState extends ConsumerState<ConnectPostCard> {
     final isDark = theme.brightness == Brightness.dark;
     final cardColor =
         isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
-    final borderColor = isDark ? AppColors.grey800 : AppColors.grey300;
     final post = widget.post;
     final caption = post.caption.trim();
     final imageMedia =
@@ -62,7 +61,6 @@ class _ConnectPostCardState extends ConsumerState<ConnectPostCard> {
           decoration: BoxDecoration(
             color: cardColor,
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: borderColor),
           ),
           clipBehavior: Clip.antiAlias,
           child: Padding(
@@ -164,9 +162,9 @@ class _ConnectPostCardState extends ConsumerState<ConnectPostCard> {
 
     if (!result.isSuccess) {
       setState(() => _likeState.revert(wasLiked));
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(result.errorMessage!)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.errorMessage!)));
       return;
     }
 
@@ -205,7 +203,9 @@ class _AuthorRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final displayName =
-        name.trim().isNotEmpty ? name.trim() : context.l10n.connect_group_fallback_title;
+        name.trim().isNotEmpty
+            ? name.trim()
+            : context.l10n.connect_group_fallback_title;
 
     return Row(
       children: [

--- a/lib/features/connect/presentation/widgets/connect_post_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_post_card.dart
@@ -8,9 +8,9 @@ import 'package:flutter_pecha/features/auth/presentation/providers/state_provide
 import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
 import 'package:flutter_pecha/features/connect/domain/entities/connect_post.dart';
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_post_like_actions.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_post_detail_drawer.dart';
 import 'package:flutter_pecha/features/connect/presentation/utils/connect_like_utils.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
 
 class ConnectPostCard extends ConsumerStatefulWidget {
@@ -127,12 +127,11 @@ class _ConnectPostCardState extends ConsumerState<ConnectPostCard> {
   }
 
   void _openDetail() {
-    context.push(
-      '/home/posts/${widget.post.id}',
-      extra: {
-        'post': widget.post,
-        'includeUnfollowed': widget.includeUnfollowed,
-      },
+    ConnectPostDetailDrawer.show(
+      context,
+      postId: widget.post.id,
+      initialPost: widget.post,
+      includeUnfollowed: widget.includeUnfollowed,
     );
   }
 

--- a/lib/features/connect/presentation/widgets/connect_post_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_post_card.dart
@@ -71,8 +71,8 @@ class _ConnectPostCardState extends ConsumerState<ConnectPostCard> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _AuthorRow(
-                  name: post.creatorName,
-                  avatarUrl: post.creatorImageUrl,
+                  name: post.groupName,
+                  avatarUrl: post.groupAvatarUrl,
                   isDark: isDark,
                 ),
                 if (caption.isNotEmpty) ...[
@@ -204,7 +204,8 @@ class _AuthorRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayName = name.trim().isNotEmpty ? name.trim() : context.l10n.author;
+    final displayName =
+        name.trim().isNotEmpty ? name.trim() : context.l10n.connect_group_fallback_title;
 
     return Row(
       children: [

--- a/lib/features/connect/presentation/widgets/connect_post_detail_drawer.dart
+++ b/lib/features/connect/presentation/widgets/connect_post_detail_drawer.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/features/connect/domain/entities/connect_post.dart';
+import 'package:flutter_pecha/features/connect/presentation/screens/connect_post_detail_screen.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ConnectPostDetailDrawer extends ConsumerWidget {
+  const ConnectPostDetailDrawer({
+    super.key,
+    required this.postId,
+    this.initialPost,
+    this.includeUnfollowed = false,
+  });
+
+  final String postId;
+  final ConnectPost? initialPost;
+  final bool includeUnfollowed;
+
+  static const double _initialSize = 0.88;
+  static const double _minSize = 0.45;
+  static const double _maxSize = 0.96;
+
+  static Future<void> show(
+    BuildContext context, {
+    required String postId,
+    ConnectPost? initialPost,
+    bool includeUnfollowed = false,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      isDismissible: true,
+      enableDrag: true,
+      barrierColor: Colors.black.withValues(alpha: 0.42),
+      builder:
+          (_) => ConnectPostDetailDrawer(
+            postId: postId,
+            initialPost: initialPost,
+            includeUnfollowed: includeUnfollowed,
+          ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return DraggableScrollableSheet(
+      initialChildSize: _initialSize,
+      minChildSize: _minSize,
+      maxChildSize: _maxSize,
+      snap: true,
+      snapSizes: const [_minSize, _initialSize, _maxSize],
+      snapAnimationDuration: const Duration(milliseconds: 180),
+      builder: (context, scrollController) {
+        return ClipRRect(
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          child: Material(
+            color: Theme.of(context).scaffoldBackgroundColor,
+            elevation: 12,
+            shadowColor: Colors.black.withValues(alpha: 0.18),
+            child: Column(
+              children: [
+                _buildHeader(context),
+                Expanded(
+                  child: ConnectPostDetailPanel(
+                    postId: postId,
+                    initialPost: initialPost,
+                    includeUnfollowed: includeUnfollowed,
+                    scrollController: scrollController,
+                    showPostPreview: false,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return SizedBox(
+      height: 44,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Semantics(
+            label: context.l10n.drag_to_resize,
+            child: Center(
+              child: Container(
+                width: 44,
+                height: 5,
+                decoration: BoxDecoration(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.26),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 4,
+            child: IconButton(
+              icon: const Icon(AppAssets.x),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/connect/presentation/widgets/connect_posts_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_posts_tab.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/features/connect/presentation/providers/connect_posts_providers.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_lazy_segment_mixin.dart';
-import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_empty_state.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
 import 'package:flutter_pecha/features/connect/presentation/widgets/connect_post_card.dart';
@@ -44,7 +44,10 @@ class _ConnectPostsTabState extends ConsumerState<ConnectPostsTab>
     final myState = ref.watch(myConnectPostsProvider);
     final discoverState = ref.watch(discoverConnectPostsProvider);
 
-    return ConnectMyDiscoverTab(
+    return ConnectMyDiscoverTabGate(
+      myHasLoaded: myState.hasLoaded,
+      myIsEmpty: myState.posts.isEmpty,
+      myHasError: myState.error != null,
       onSegmentChanged: handleSegmentChanged,
       onMyRefresh: () => ref.read(myConnectPostsProvider.notifier).refresh(),
       onDiscoverRefresh:

--- a/lib/features/connect/presentation/widgets/connect_practice_card.dart
+++ b/lib/features/connect/presentation/widgets/connect_practice_card.dart
@@ -1,0 +1,687 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/constants/app_assets.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
+import 'package:flutter_pecha/core/widgets/responsive_cover_image.dart';
+import 'package:flutter_pecha/features/auth/presentation/providers/state_providers.dart';
+import 'package:flutter_pecha/features/auth/presentation/widgets/login_drawer.dart';
+import 'package:flutter_pecha/features/connect/presentation/providers/connect_practices_providers.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_accumulator.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_practice.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/providers/group_accumulator_providers.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/providers/group_profile_providers.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/widgets/group_accumulator_card.dart';
+import 'package:flutter_pecha/features/plans/data/utils/plan_date_format.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class ConnectPracticeCard extends ConsumerStatefulWidget {
+  const ConnectPracticeCard({super.key, required this.practice});
+
+  final GroupPractice practice;
+
+  @override
+  ConsumerState<ConnectPracticeCard> createState() =>
+      _ConnectPracticeCardState();
+}
+
+class _ConnectPracticeCardState extends ConsumerState<ConnectPracticeCard> {
+  bool _isEnrollingSeries = false;
+  String? _joiningAccumulatorId;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final lineHeight = theme.textTheme.bodyMedium?.height;
+    final practice = widget.practice;
+
+    return switch (practice.type) {
+      GroupPracticeType.series when practice.series != null =>
+        _buildSeriesCard(practice, practice.series!, isDark, lineHeight),
+      GroupPracticeType.accumulator when practice.accumulator != null =>
+        _buildAccumulatorCard(
+          practice,
+          practice.accumulator!,
+          isDark,
+          lineHeight,
+        ),
+      GroupPracticeType.plan when practice.plan != null =>
+        _buildPlanCard(practice, practice.plan!, isDark, lineHeight),
+      GroupPracticeType.collection when practice.collection != null =>
+        _buildCollectionCard(practice, practice.collection!, isDark, lineHeight),
+      _ => const SizedBox.shrink(),
+    };
+  }
+
+  Widget _buildSeriesCard(
+    GroupPractice practice,
+    GroupProfileSeries series,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    final dateRange = PlanDateFormat.formatRangeOrNull(
+      series.startDate,
+      series.endDate,
+    );
+    final isEnrolled = practice.isJoined || series.isGroupEnrolled == true;
+    final showPracticeOverlay = !isEnrolled;
+    final cardColor =
+        isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
+
+    return Material(
+      color: cardColor,
+      elevation: isDark ? 0 : 1,
+      shadowColor: Colors.black.withValues(alpha: 0.08),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap:
+            _isEnrollingSeries
+                ? null
+                : () => _navigateToSeriesDetail(practice, series, isEnrolled),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              height: 140,
+              width: double.infinity,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  series.image != null && !series.image!.isEmpty
+                      ? ResponsiveCoverImage(
+                        image: series.image,
+                        fit: BoxFit.cover,
+                      )
+                      : ColoredBox(
+                        color:
+                            isDark
+                                ? AppColors.surfaceVariantDark
+                                : AppColors.grey100,
+                        child: Icon(
+                          AppAssets.bookOpenText,
+                          size: 40,
+                          color: isDark ? AppColors.grey500 : AppColors.grey600,
+                        ),
+                      ),
+                  if (showPracticeOverlay)
+                    Container(
+                      color: Colors.black.withValues(alpha: 0.55),
+                      alignment: Alignment.center,
+                      child:
+                          _isEnrollingSeries
+                              ? const SizedBox(
+                                width: 24,
+                                height: 24,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                              : GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                onTap:
+                                    () => _onPracticeWithUsTap(practice, series),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 24,
+                                    vertical: 12,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white,
+                                    borderRadius: BorderRadius.circular(999),
+                                  ),
+                                  child: Text(
+                                    context.l10n.group_practice_with_us,
+                                    style: const TextStyle(
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.w700,
+                                      color: AppColors.textPrimary,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                    ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    series.title,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      height: lineHeight,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (dateRange != null ||
+                      series.enrolledCount > 0 ||
+                      _hasGroupLabel(practice)) ...[
+                    const SizedBox(height: 4),
+                    _ConnectPracticeMetaRow(
+                      practice: practice,
+                      isDark: isDark,
+                      lineHeight: lineHeight,
+                      dateText: dateRange,
+                      joinCount: series.enrolledCount,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAccumulatorCard(
+    GroupPractice practice,
+    GroupAccumulator accumulator,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    final groupId = practice.groupId ?? accumulator.groupId;
+    final localJoinedIds = ref.watch(groupAccumulatorJoinCacheProvider(groupId));
+    final hasJoined =
+        practice.isJoined ||
+        accumulatorHasJoined(
+          accumulator,
+          localJoinedIds: localJoinedIds,
+        );
+
+    return GroupAccumulatorCard(
+      accumulator: accumulator,
+      hasJoined: hasJoined,
+      isDark: isDark,
+      lineHeight: lineHeight,
+      isJoining: _joiningAccumulatorId == accumulator.id,
+      groupName: practice.groupName,
+      groupAvatarUrl: practice.groupAvatarUrl,
+      groupId: practice.groupId,
+      onTap: () => _navigateToAccumulatorDetail(accumulator.id, practice),
+      onJoinTap: () => _onJoinAccumulatorTap(practice, accumulator),
+    );
+  }
+
+  Widget _buildPlanCard(
+    GroupPractice practice,
+    GroupPracticePlan plan,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    final cardColor =
+        isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
+    final dateRange = PlanDateFormat.formatRangeOrNull(plan.startDate, null);
+    final details = [
+      if (dateRange != null) dateRange,
+      if (plan.totalDays > 0) context.l10n.days_count(plan.totalDays),
+    ].join(' · ');
+
+    return Material(
+      color: cardColor,
+      elevation: isDark ? 0 : 1,
+      shadowColor: Colors.black.withValues(alpha: 0.08),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => _navigateToPlanDetail(practice, plan),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              height: 140,
+              width: double.infinity,
+              child:
+                  plan.imageUrl != null && plan.imageUrl!.isNotEmpty
+                      ? CachedNetworkImageWidget(
+                        imageUrl: plan.imageUrl!,
+                        fit: BoxFit.cover,
+                      )
+                      : ColoredBox(
+                        color:
+                            isDark
+                                ? AppColors.surfaceVariantDark
+                                : AppColors.grey100,
+                        child: Icon(
+                          AppAssets.bookOpenText,
+                          size: 40,
+                          color: isDark ? AppColors.grey500 : AppColors.grey600,
+                        ),
+                      ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    plan.title,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      height: lineHeight,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (details.isNotEmpty || _hasGroupLabel(practice)) ...[
+                    const SizedBox(height: 4),
+                    _ConnectPracticeMetaRow(
+                      practice: practice,
+                      isDark: isDark,
+                      lineHeight: lineHeight,
+                      dateText: details.isNotEmpty ? details : null,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCollectionCard(
+    GroupPractice practice,
+    GroupPracticeCollection collection,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    final cardColor =
+        isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
+    final itemCountLabel =
+        collection.itemCount > 0
+            ? context.l10n.home_recitation_count(collection.itemCount)
+            : null;
+
+    return Material(
+      color: cardColor,
+      elevation: isDark ? 0 : 1,
+      shadowColor: Colors.black.withValues(alpha: 0.08),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 140,
+            width: double.infinity,
+            child:
+                collection.imageUrl != null && collection.imageUrl!.isNotEmpty
+                    ? CachedNetworkImageWidget(
+                      imageUrl: collection.imageUrl!,
+                      fit: BoxFit.cover,
+                    )
+                    : ColoredBox(
+                      color:
+                          isDark
+                              ? AppColors.surfaceVariantDark
+                              : AppColors.grey100,
+                      child: Icon(
+                        AppAssets.bookOpenText,
+                        size: 40,
+                        color: isDark ? AppColors.grey500 : AppColors.grey600,
+                      ),
+                    ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  collection.name,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    height: lineHeight,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (itemCountLabel != null || _hasGroupLabel(practice)) ...[
+                  const SizedBox(height: 4),
+                  _ConnectPracticeMetaRow(
+                    practice: practice,
+                    isDark: isDark,
+                    lineHeight: lineHeight,
+                    dateText: itemCountLabel,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _hasGroupLabel(GroupPractice practice) {
+    return practice.groupId != null &&
+        (practice.groupName?.trim().isNotEmpty ?? false);
+  }
+
+  void _navigateToSeriesDetail(
+    GroupPractice practice,
+    GroupProfileSeries series,
+    bool isEnrolled,
+  ) {
+    if (isEnrolled) {
+      context.push('/home/series/${series.id}');
+      return;
+    }
+
+    context.push(
+      '/home/series/${series.id}',
+      extra: {
+        if (practice.groupId != null) 'groupId': practice.groupId,
+        'groupType': GroupType.community,
+        'isGroupEnrolled': false,
+      },
+    );
+  }
+
+  Future<void> _onPracticeWithUsTap(
+    GroupPractice practice,
+    GroupProfileSeries series,
+  ) async {
+    final authState = ref.read(authProvider);
+    if (authState.isGuest || !authState.isLoggedIn) {
+      LoginDrawer.show(context, ref);
+      return;
+    }
+
+    final groupId = practice.groupId;
+    if (groupId == null) return;
+
+    setState(() => _isEnrollingSeries = true);
+    final ok = await enrollSeriesThroughGroup(
+      ref: ref,
+      seriesId: series.id,
+      groupId: groupId,
+      groupType: GroupType.community,
+    );
+
+    if (!mounted) return;
+    setState(() => _isEnrollingSeries = false);
+
+    if (!ok) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.series_enroll_error),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
+
+    ref.read(myConnectPracticesProvider.notifier).refresh();
+    ref.read(discoverConnectPracticesProvider.notifier).refresh();
+    context.push('/home/series/${series.id}');
+  }
+
+  void _navigateToAccumulatorDetail(
+    String accumulatorId,
+    GroupPractice practice,
+  ) {
+    context.push(
+      '/home/group-accumulator/$accumulatorId',
+      extra: {
+        'groupTitle':
+            practice.groupName?.trim().isNotEmpty == true
+                ? practice.groupName
+                : null,
+      },
+    );
+  }
+
+  Future<void> _onJoinAccumulatorTap(
+    GroupPractice practice,
+    GroupAccumulator accumulator,
+  ) async {
+    final authState = ref.read(authProvider);
+    if (authState.isGuest || !authState.isLoggedIn) {
+      LoginDrawer.show(context, ref);
+      return;
+    }
+
+    final groupId = practice.groupId ?? accumulator.groupId;
+    if (groupId.isEmpty) return;
+
+    setState(() => _joiningAccumulatorId = accumulator.id);
+    final ok = await joinGroupAccumulator(
+      ref: ref,
+      accumulatorId: accumulator.id,
+      groupId: groupId,
+      awaitRefresh: false,
+    );
+
+    if (!mounted) return;
+    setState(() => _joiningAccumulatorId = null);
+
+    if (ok) {
+      ref.read(myConnectPracticesProvider.notifier).refresh();
+      ref.read(discoverConnectPracticesProvider.notifier).refresh();
+      _navigateToAccumulatorDetail(accumulator.id, practice);
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.group_accumulator_join_error),
+        backgroundColor: Colors.red,
+      ),
+    );
+  }
+
+  void _navigateToPlanDetail(GroupPractice practice, GroupPracticePlan plan) {
+    final planEntity = plan.toPlan();
+    context.push(
+      '/practice/plans/preview',
+      extra: {
+        'plan': planEntity,
+        if (plan.seriesId != null) 'seriesId': plan.seriesId,
+      },
+    );
+  }
+}
+
+class _ConnectPracticeMetaRow extends StatelessWidget {
+  const _ConnectPracticeMetaRow({
+    required this.practice,
+    required this.isDark,
+    this.lineHeight,
+    this.dateText,
+    this.joinCount = 0,
+  });
+
+  final GroupPractice practice;
+  final bool isDark;
+  final double? lineHeight;
+  final String? dateText;
+  final int joinCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasGroup = _hasGroup(practice);
+    final secondaryColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+    final trimmedDate = dateText?.trim();
+
+    if (!hasGroup &&
+        (trimmedDate == null || trimmedDate.isEmpty) &&
+        joinCount <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (hasGroup)
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _ConnectPracticeGroupAvatar(
+                avatarUrl: practice.groupAvatarUrl,
+                groupId: practice.groupId,
+                isDark: isDark,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _ConnectPracticeGroupName(
+                  name: practice.groupName ?? '',
+                  groupId: practice.groupId,
+                  isDark: isDark,
+                ),
+              ),
+            ],
+          ),
+        if ((trimmedDate != null && trimmedDate.isNotEmpty) || joinCount > 0) ...[
+          if (hasGroup) const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (trimmedDate != null && trimmedDate.isNotEmpty)
+                Expanded(
+                  child: Text(
+                    trimmedDate,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: secondaryColor,
+                      height: lineHeight,
+                    ),
+                  ),
+                )
+              else
+                const SizedBox.shrink(),
+              if (joinCount > 0)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(AppAssets.usercard, size: 16, color: secondaryColor),
+                    const SizedBox(width: 4),
+                    Text(
+                      '$joinCount',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: secondaryColor,
+                        height: lineHeight,
+                      ),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  bool _hasGroup(GroupPractice practice) {
+    return practice.groupId != null &&
+        (practice.groupName?.trim().isNotEmpty ?? false);
+  }
+}
+
+class _ConnectPracticeGroupAvatar extends StatelessWidget {
+  const _ConnectPracticeGroupAvatar({
+    this.avatarUrl,
+    this.groupId,
+    required this.isDark,
+  });
+
+  final String? avatarUrl;
+  final String? groupId;
+  final bool isDark;
+
+  static const double _avatarSize = 24;
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholderColor =
+        isDark ? AppColors.surfaceVariantDark : AppColors.grey100;
+    final trimmedAvatar = avatarUrl?.trim();
+
+    final avatar = ClipOval(
+      child: SizedBox(
+        width: _avatarSize,
+        height: _avatarSize,
+        child:
+            trimmedAvatar != null && trimmedAvatar.isNotEmpty
+                ? CachedNetworkImageWidget(
+                  imageUrl: trimmedAvatar,
+                  fit: BoxFit.cover,
+                  width: _avatarSize,
+                  height: _avatarSize,
+                )
+                : ColoredBox(
+                  color: placeholderColor,
+                  child: Icon(
+                    AppAssets.usersThree,
+                    size: 14,
+                    color: isDark ? AppColors.grey500 : AppColors.grey600,
+                  ),
+                ),
+      ),
+    );
+
+    final trimmedGroupId = groupId?.trim();
+    if (trimmedGroupId == null || trimmedGroupId.isEmpty) return avatar;
+
+    return GestureDetector(
+      onTap: () => context.push('/home/group/$trimmedGroupId'),
+      behavior: HitTestBehavior.opaque,
+      child: avatar,
+    );
+  }
+}
+
+class _ConnectPracticeGroupName extends StatelessWidget {
+  const _ConnectPracticeGroupName({
+    required this.name,
+    this.groupId,
+    required this.isDark,
+  });
+
+  final String name;
+  final String? groupId;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayName =
+        name.trim().isNotEmpty
+            ? name.trim()
+            : context.l10n.connect_group_fallback_title;
+
+    final text = Text(
+      displayName,
+      style: TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        color: isDark ? AppColors.textPrimaryDark : AppColors.primaryDark,
+      ),
+    );
+
+    final trimmedGroupId = groupId?.trim();
+    if (trimmedGroupId == null || trimmedGroupId.isEmpty) return text;
+
+    return GestureDetector(
+      onTap: () => context.push('/home/group/$trimmedGroupId'),
+      behavior: HitTestBehavior.opaque,
+      child: text,
+    );
+  }
+}

--- a/lib/features/connect/presentation/widgets/connect_practices_tab.dart
+++ b/lib/features/connect/presentation/widgets/connect_practices_tab.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/features/connect/presentation/providers/connect_practices_providers.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_lazy_segment_mixin.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_discover_tab_gate.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_my_empty_state.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_paginated_list_view.dart';
+import 'package:flutter_pecha/features/connect/presentation/widgets/connect_practice_card.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_practice.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Practices tab content with My / Discover sub-tabs.
+class ConnectPracticesTab extends ConsumerStatefulWidget {
+  const ConnectPracticesTab({super.key, this.isActive = true});
+
+  final bool isActive;
+
+  @override
+  ConsumerState<ConnectPracticesTab> createState() =>
+      _ConnectPracticesTabState();
+}
+
+class _ConnectPracticesTabState extends ConsumerState<ConnectPracticesTab>
+    with ConnectLazyMyDiscoverTabMixin<ConnectPracticesTab> {
+  @override
+  bool readTabActive(ConnectPracticesTab widget) => widget.isActive;
+
+  @override
+  void loadActiveSegment() {
+    if (!isTabActive) return;
+    if (selectedSegment == 0) {
+      ref.read(myConnectPracticesProvider.notifier).ensureLoaded();
+    } else {
+      ref.read(discoverConnectPracticesProvider.notifier).ensureLoaded();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final myState = ref.watch(myConnectPracticesProvider);
+    final discoverState = ref.watch(discoverConnectPracticesProvider);
+
+    return ConnectMyDiscoverTabGate(
+      myHasLoaded: myState.hasLoaded,
+      myIsEmpty: myState.practices.isEmpty,
+      myHasError: myState.error != null,
+      onSegmentChanged: handleSegmentChanged,
+      onMyRefresh: () => ref.read(myConnectPracticesProvider.notifier).refresh(),
+      onDiscoverRefresh:
+          () => ref.read(discoverConnectPracticesProvider.notifier).refresh(),
+      onMyLoadMore: () => ref.read(myConnectPracticesProvider.notifier).loadMore(),
+      onDiscoverLoadMore:
+          () => ref.read(discoverConnectPracticesProvider.notifier).loadMore(),
+      myBuilder: (context, scrollController, switchToDiscover) {
+        return ConnectPaginatedListView<GroupPractice>(
+          items: myState.practices,
+          isLoading: myState.isLoading,
+          isLoadingMore: myState.isLoadingMore,
+          error: myState.error,
+          hasMore: myState.hasMore,
+          hasLoaded: myState.hasLoaded,
+          scrollController: scrollController,
+          onRetry: () => ref.read(myConnectPracticesProvider.notifier).retry(),
+          myEmptyState: ConnectMyEmptyState(
+            type: ConnectMyEmptyStateType.practices,
+            onBrowseTap: switchToDiscover,
+          ),
+          itemBuilder:
+              (context, index) =>
+                  ConnectPracticeCard(practice: myState.practices[index]),
+        );
+      },
+      discoverBuilder: (context, scrollController, _) {
+        return ConnectPaginatedListView<GroupPractice>(
+          items: discoverState.practices,
+          isLoading: discoverState.isLoading,
+          isLoadingMore: discoverState.isLoadingMore,
+          error: discoverState.error,
+          hasMore: discoverState.hasMore,
+          hasLoaded: discoverState.hasLoaded,
+          scrollController: scrollController,
+          onRetry:
+              () => ref.read(discoverConnectPracticesProvider.notifier).retry(),
+          emptyDiscoverMessage: context.l10n.connect_empty_discover_practices,
+          itemBuilder:
+              (context, index) => ConnectPracticeCard(
+                practice: discoverState.practices[index],
+              ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/connect/presentation/widgets/discover_group_card.dart
+++ b/lib/features/connect/presentation/widgets/discover_group_card.dart
@@ -21,13 +21,11 @@ class DiscoverGroupCard extends ConsumerWidget {
     super.key,
     required this.group,
     this.showJoinButton = false,
-    this.showOpenButton = false,
     this.subtitleOverride,
   });
 
   final GroupProfile group;
   final bool showJoinButton;
-  final bool showOpenButton;
   final String? subtitleOverride;
 
   static const double _titleFontSize = 15;
@@ -79,8 +77,7 @@ class DiscoverGroupCard extends ConsumerWidget {
       leadingDistribution:
           hasTibetanSubtitle ? AppFontConfig.tibetanLeadingDistribution : null,
     );
-    final subtitleFontSize =
-        hasTibetanSubtitle ? 14.0 : _subtitleFontSize;
+    final subtitleFontSize = hasTibetanSubtitle ? 14.0 : _subtitleFontSize;
 
     return Material(
       color: Colors.transparent,
@@ -149,11 +146,7 @@ class DiscoverGroupCard extends ConsumerWidget {
               ),
               const SizedBox(width: 8),
               if (showJoinButton)
-                _JoinButton(group: group, isDark: isDark, followKey: followKey)
-              else if (showOpenButton)
-                _OpenButton(isDark: isDark)
-              else
-                Icon(AppAssets.caretRight, size: 16, color: subtitleColor),
+                _JoinButton(group: group, isDark: isDark, followKey: followKey),
             ],
           ),
         ),
@@ -237,35 +230,6 @@ class _GroupAvatar extends StatelessWidget {
                     color: isDark ? AppColors.grey500 : AppColors.grey600,
                   ),
                 ),
-      ),
-    );
-  }
-}
-
-class _OpenButton extends StatelessWidget {
-  const _OpenButton({required this.isDark});
-
-  final bool isDark;
-
-  @override
-  Widget build(BuildContext context) {
-    final borderColor = isDark ? AppColors.cardBorderDark : AppColors.grey300;
-
-    return Container(
-      height: 32,
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      decoration: BoxDecoration(
-        border: Border.all(color: borderColor),
-        borderRadius: BorderRadius.circular(16),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        context.l10n.connect_open,
-        style: TextStyle(
-          fontSize: 13,
-          fontWeight: FontWeight.w600,
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
       ),
     );
   }

--- a/lib/features/group_profile/data/datasource/group_profile_remote_datasource.dart
+++ b/lib/features/group_profile/data/datasource/group_profile_remote_datasource.dart
@@ -91,20 +91,29 @@ class GroupProfileRemoteDatasource {
     }
   }
 
-  Future<GroupPracticesPageModel> fetchGroupPractices(
-    String groupId, {
+  Future<GroupPracticesPageModel> fetchPractices({
+    String? groupId,
+    required bool includeUnfollowed,
     required String language,
     required int skip,
     required int limit,
   }) async {
     try {
+      final queryParameters = <String, dynamic>{
+        'language': language,
+        'skip': skip,
+        'limit': limit,
+      };
+      if (groupId != null) {
+        queryParameters['group_id'] = groupId;
+      }
+      if (includeUnfollowed) {
+        queryParameters['include_unfollowed'] = true;
+      }
+
       final response = await dio.get(
-        '/author/groups/$groupId/practices',
-        queryParameters: {
-          'language': language,
-          'skip': skip,
-          'limit': limit,
-        },
+        '/author/groups/practices',
+        queryParameters: queryParameters,
         options: Options(extra: {'no_cache': true}),
       );
 
@@ -115,14 +124,14 @@ class GroupProfileRemoteDatasource {
       }
 
       _logger.error(
-        'Failed to load group practices $groupId: ${response.statusCode}',
+        'Failed to load practices${groupId != null ? ' for $groupId' : ''}: ${response.statusCode}',
       );
       throw _statusToException(
         response.statusCode,
         'Failed to load group practices',
       );
     } on DioException catch (e) {
-      _logger.error('Dio error in fetchGroupPractices', e);
+      _logger.error('Dio error in fetchPractices', e);
       throw _dioToException(e, 'Failed to load group practices');
     }
   }

--- a/lib/features/group_profile/data/models/group_event_model.dart
+++ b/lib/features/group_profile/data/models/group_event_model.dart
@@ -97,6 +97,42 @@ class GroupEventParticipantModel {
   }
 }
 
+class GroupEventLocationModel {
+  final String id;
+  final String groupId;
+  final String name;
+  final double? latitude;
+  final double? longitude;
+
+  const GroupEventLocationModel({
+    required this.id,
+    required this.groupId,
+    required this.name,
+    this.latitude,
+    this.longitude,
+  });
+
+  factory GroupEventLocationModel.fromJson(Map<String, dynamic> json) {
+    return GroupEventLocationModel(
+      id: json['id'] as String? ?? '',
+      groupId: json['group_id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      latitude: (json['latitude'] as num?)?.toDouble(),
+      longitude: (json['longitude'] as num?)?.toDouble(),
+    );
+  }
+
+  GroupEventLocation toEntity() {
+    return GroupEventLocation(
+      id: id,
+      groupId: groupId,
+      name: name,
+      latitude: latitude,
+      longitude: longitude,
+    );
+  }
+}
+
 class GroupEventModel {
   final String id;
   final String groupId;
@@ -116,6 +152,8 @@ class GroupEventModel {
   final String? groupRecitationCollectionId;
   final String? groupName;
   final String? groupAvatarUrl;
+  final String? locationId;
+  final GroupEventLocationModel? location;
 
   const GroupEventModel({
     required this.id,
@@ -136,6 +174,8 @@ class GroupEventModel {
     this.groupRecitationCollectionId,
     this.groupName,
     this.groupAvatarUrl,
+    this.locationId,
+    this.location,
   });
 
   factory GroupEventModel.fromJson(
@@ -143,6 +183,7 @@ class GroupEventModel {
     String? language,
   }) {
     final imageJson = json['image'] as Map<String, dynamic>?;
+    final locationJson = json['location'] as Map<String, dynamic>?;
 
     return GroupEventModel(
       id: json['id'] as String? ?? '',
@@ -169,6 +210,11 @@ class GroupEventModel {
           json['group_recitation_collection_id'] as String?,
       groupName: json['group_name'] as String?,
       groupAvatarUrl: json['group_avatar_url'] as String?,
+      locationId: json['location_id'] as String?,
+      location:
+          locationJson != null
+              ? GroupEventLocationModel.fromJson(locationJson)
+              : null,
     );
   }
 
@@ -194,6 +240,8 @@ class GroupEventModel {
       groupRecitationCollectionId: groupRecitationCollectionId,
       groupName: groupName,
       groupAvatarUrl: groupAvatarUrl,
+      locationId: locationId,
+      location: location?.toEntity(),
     );
   }
 

--- a/lib/features/group_profile/data/models/group_event_model.dart
+++ b/lib/features/group_profile/data/models/group_event_model.dart
@@ -114,6 +114,8 @@ class GroupEventModel {
   final String? mantraId;
   final String? timerId;
   final String? groupRecitationCollectionId;
+  final String? groupName;
+  final String? groupAvatarUrl;
 
   const GroupEventModel({
     required this.id,
@@ -132,6 +134,8 @@ class GroupEventModel {
     this.mantraId,
     this.timerId,
     this.groupRecitationCollectionId,
+    this.groupName,
+    this.groupAvatarUrl,
   });
 
   factory GroupEventModel.fromJson(
@@ -163,6 +167,8 @@ class GroupEventModel {
       timerId: json['timer_id'] as String?,
       groupRecitationCollectionId:
           json['group_recitation_collection_id'] as String?,
+      groupName: json['group_name'] as String?,
+      groupAvatarUrl: json['group_avatar_url'] as String?,
     );
   }
 
@@ -186,6 +192,8 @@ class GroupEventModel {
       mantraId: mantraId,
       timerId: timerId,
       groupRecitationCollectionId: groupRecitationCollectionId,
+      groupName: groupName,
+      groupAvatarUrl: groupAvatarUrl,
     );
   }
 

--- a/lib/features/group_profile/data/models/group_practice_model.dart
+++ b/lib/features/group_profile/data/models/group_practice_model.dart
@@ -44,17 +44,100 @@ class GroupPracticeCollectionModel {
   }
 }
 
+class GroupPracticePlanModel {
+  final String id;
+  final String title;
+  final String description;
+  final String language;
+  final String? difficultyLevel;
+  final String? imageUrl;
+  final int totalDays;
+  final DateTime? startDate;
+  final String? seriesId;
+  final String? groupId;
+  final String? authorId;
+  final String? authorName;
+
+  GroupPracticePlanModel({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.language,
+    this.difficultyLevel,
+    this.imageUrl,
+    this.totalDays = 0,
+    this.startDate,
+    this.seriesId,
+    this.groupId,
+    this.authorId,
+    this.authorName,
+  });
+
+  factory GroupPracticePlanModel.fromJson(Map<String, dynamic> json) {
+    final author = json['author'] as Map<String, dynamic>?;
+    final firstName = author?['firstname'] as String? ?? '';
+    final lastName = author?['lastname'] as String? ?? '';
+    final authorName = '$firstName $lastName'.trim();
+
+    return GroupPracticePlanModel(
+      id: json['id'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      language: json['language'] as String? ?? 'en',
+      difficultyLevel: json['difficulty_level'] as String?,
+      imageUrl: json['image_url'] as String?,
+      totalDays: (json['total_days'] as num?)?.toInt() ?? 0,
+      startDate: GroupProfileModel.parseDate(json['start_date']),
+      seriesId: json['series_id'] as String?,
+      groupId: json['group_id'] as String?,
+      authorId: author?['id'] as String?,
+      authorName: authorName.isEmpty ? null : authorName,
+    );
+  }
+
+  GroupPracticePlan toEntity() {
+    return GroupPracticePlan(
+      id: id,
+      title: title,
+      description: description,
+      language: language,
+      difficultyLevel: difficultyLevel,
+      imageUrl: imageUrl,
+      totalDays: totalDays,
+      startDate: startDate,
+      seriesId: seriesId,
+      groupId: groupId,
+      authorId: authorId,
+      authorName: authorName,
+    );
+  }
+}
+
 class GroupPracticeModel {
   final GroupPracticeType type;
+  final DateTime? practiceAt;
+  final bool isJoined;
+  final String? groupId;
+  final String? groupName;
+  final String? groupSlug;
+  final String? groupAvatarUrl;
   final Map<String, dynamic>? seriesJson;
   final Map<String, dynamic>? accumulatorJson;
   final Map<String, dynamic>? collectionJson;
+  final Map<String, dynamic>? planJson;
 
   GroupPracticeModel({
     required this.type,
+    this.practiceAt,
+    this.isJoined = false,
+    this.groupId,
+    this.groupName,
+    this.groupSlug,
+    this.groupAvatarUrl,
     this.seriesJson,
     this.accumulatorJson,
     this.collectionJson,
+    this.planJson,
   });
 
   factory GroupPracticeModel.fromJson(Map<String, dynamic> json) {
@@ -62,22 +145,35 @@ class GroupPracticeModel {
     final type = switch (typeValue) {
       'accumulator' => GroupPracticeType.accumulator,
       'collection' => GroupPracticeType.collection,
+      'plan' => GroupPracticeType.plan,
       _ => GroupPracticeType.series,
     };
 
     return GroupPracticeModel(
       type: type,
+      practiceAt: GroupProfileModel.parseDate(json['practice_at']),
+      isJoined: json['is_joined'] as bool? ?? false,
+      groupId: json['group_id'] as String?,
+      groupName: json['group_name'] as String?,
+      groupSlug: json['group_slug'] as String?,
+      groupAvatarUrl: json['group_avatar_url'] as String?,
       seriesJson: json['series'] as Map<String, dynamic>?,
       accumulatorJson: json['accumulator'] as Map<String, dynamic>?,
       collectionJson: json['collection'] as Map<String, dynamic>?,
+      planJson: json['plan'] as Map<String, dynamic>?,
     );
   }
 
   GroupPractice toEntity() {
     return GroupPractice(
       type: type,
-      series:
-          seriesJson != null ? _parseSeries(seriesJson!) : null,
+      practiceAt: practiceAt,
+      isJoined: isJoined,
+      groupId: groupId,
+      groupName: groupName,
+      groupSlug: groupSlug,
+      groupAvatarUrl: groupAvatarUrl,
+      series: seriesJson != null ? _parseSeries(seriesJson!) : null,
       accumulator:
           accumulatorJson != null
               ? GroupAccumulatorModel.fromJson(accumulatorJson!).toEntity()
@@ -85,6 +181,10 @@ class GroupPracticeModel {
       collection:
           collectionJson != null
               ? GroupPracticeCollectionModel.fromJson(collectionJson!).toEntity()
+              : null,
+      plan:
+          planJson != null
+              ? GroupPracticePlanModel.fromJson(planJson!).toEntity()
               : null,
     );
   }

--- a/lib/features/group_profile/data/repositories/group_profile_repository_impl.dart
+++ b/lib/features/group_profile/data/repositories/group_profile_repository_impl.dart
@@ -92,9 +92,41 @@ class GroupProfileRepositoryImpl implements GroupProfileRepositoryInterface {
     required int skip,
     required int limit,
   }) async {
+    return _loadPractices(
+      groupId: groupId,
+      includeUnfollowed: true,
+      language: language,
+      skip: skip,
+      limit: limit,
+    );
+  }
+
+  @override
+  Future<Either<Failure, GroupPracticesPage>> getConnectPractices({
+    required bool includeUnfollowed,
+    required String language,
+    required int skip,
+    required int limit,
+  }) async {
+    return _loadPractices(
+      includeUnfollowed: includeUnfollowed,
+      language: language,
+      skip: skip,
+      limit: limit,
+    );
+  }
+
+  Future<Either<Failure, GroupPracticesPage>> _loadPractices({
+    String? groupId,
+    required bool includeUnfollowed,
+    required String language,
+    required int skip,
+    required int limit,
+  }) async {
     try {
-      final model = await remote.fetchGroupPractices(
-        groupId,
+      final model = await remote.fetchPractices(
+        groupId: groupId,
+        includeUnfollowed: includeUnfollowed,
         language: language,
         skip: skip,
         limit: limit,

--- a/lib/features/group_profile/domain/entities/group_event.dart
+++ b/lib/features/group_profile/domain/entities/group_event.dart
@@ -40,6 +40,22 @@ class GroupEventParticipant {
   }
 }
 
+class GroupEventLocation {
+  final String id;
+  final String groupId;
+  final String name;
+  final double? latitude;
+  final double? longitude;
+
+  const GroupEventLocation({
+    required this.id,
+    required this.groupId,
+    required this.name,
+    this.latitude,
+    this.longitude,
+  });
+}
+
 class GroupEvent {
   final String id;
   final String groupId;
@@ -61,6 +77,8 @@ class GroupEvent {
   final String? groupRecitationCollectionId;
   final String? groupName;
   final String? groupAvatarUrl;
+  final String? locationId;
+  final GroupEventLocation? location;
 
   const GroupEvent({
     required this.id,
@@ -83,6 +101,8 @@ class GroupEvent {
     this.groupRecitationCollectionId,
     this.groupName,
     this.groupAvatarUrl,
+    this.locationId,
+    this.location,
   });
 }
 

--- a/lib/features/group_profile/domain/entities/group_event.dart
+++ b/lib/features/group_profile/domain/entities/group_event.dart
@@ -59,6 +59,8 @@ class GroupEvent {
   final String? mantraId;
   final String? timerId;
   final String? groupRecitationCollectionId;
+  final String? groupName;
+  final String? groupAvatarUrl;
 
   const GroupEvent({
     required this.id,
@@ -79,6 +81,8 @@ class GroupEvent {
     this.mantraId,
     this.timerId,
     this.groupRecitationCollectionId,
+    this.groupName,
+    this.groupAvatarUrl,
   });
 }
 

--- a/lib/features/group_profile/domain/entities/group_practice.dart
+++ b/lib/features/group_profile/domain/entities/group_practice.dart
@@ -1,8 +1,10 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_accumulator.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
+import 'package:flutter_pecha/features/plans/domain/entities/plan.dart';
+import 'package:flutter_pecha/shared/domain/value_objects/responsive_image.dart';
 
-enum GroupPracticeType { accumulator, series, collection }
+enum GroupPracticeType { accumulator, series, collection, plan }
 
 class GroupPracticeCollection extends Equatable {
   final String id;
@@ -25,21 +27,118 @@ class GroupPracticeCollection extends Equatable {
   List<Object?> get props => [id, groupId, name, imageUrl, itemCount, createdAt];
 }
 
+class GroupPracticePlan extends Equatable {
+  final String id;
+  final String title;
+  final String description;
+  final String language;
+  final String? difficultyLevel;
+  final String? imageUrl;
+  final int totalDays;
+  final DateTime? startDate;
+  final String? seriesId;
+  final String? groupId;
+  final String? authorId;
+  final String? authorName;
+
+  const GroupPracticePlan({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.language,
+    this.difficultyLevel,
+    this.imageUrl,
+    this.totalDays = 0,
+    this.startDate,
+    this.seriesId,
+    this.groupId,
+    this.authorId,
+    this.authorName,
+  });
+
+  Plan toPlan() {
+    final difficulty = switch (difficultyLevel?.toUpperCase()) {
+      'BEGINNER' => DifficultyLevel.beginner,
+      'INTERMEDIATE' => DifficultyLevel.intermediate,
+      'ADVANCED' => DifficultyLevel.advanced,
+      _ => DifficultyLevel.allLevels,
+    };
+
+    return Plan(
+      id: id,
+      title: title,
+      description: description,
+      authorId: authorId ?? '',
+      authorName: authorName,
+      coverImage:
+          imageUrl != null && imageUrl!.isNotEmpty
+              ? ResponsiveImage.uniform(imageUrl!)
+              : null,
+      totalDays: totalDays,
+      difficulty: difficulty,
+      language: language,
+      startDate: startDate,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    title,
+    description,
+    language,
+    difficultyLevel,
+    imageUrl,
+    totalDays,
+    startDate,
+    seriesId,
+    groupId,
+    authorId,
+    authorName,
+  ];
+}
+
 class GroupPractice extends Equatable {
   final GroupPracticeType type;
+  final DateTime? practiceAt;
+  final bool isJoined;
+  final String? groupId;
+  final String? groupName;
+  final String? groupSlug;
+  final String? groupAvatarUrl;
   final GroupProfileSeries? series;
   final GroupAccumulator? accumulator;
   final GroupPracticeCollection? collection;
+  final GroupPracticePlan? plan;
 
   const GroupPractice({
     required this.type,
+    this.practiceAt,
+    this.isJoined = false,
+    this.groupId,
+    this.groupName,
+    this.groupSlug,
+    this.groupAvatarUrl,
     this.series,
     this.accumulator,
     this.collection,
+    this.plan,
   });
 
   @override
-  List<Object?> get props => [type, series, accumulator, collection];
+  List<Object?> get props => [
+    type,
+    practiceAt,
+    isJoined,
+    groupId,
+    groupName,
+    groupSlug,
+    groupAvatarUrl,
+    series,
+    accumulator,
+    collection,
+    plan,
+  ];
 }
 
 class GroupPracticesPage extends Equatable {

--- a/lib/features/group_profile/domain/repositories/group_profile_repository.dart
+++ b/lib/features/group_profile/domain/repositories/group_profile_repository.dart
@@ -34,6 +34,13 @@ abstract class GroupProfileRepositoryInterface {
     required int limit,
   });
 
+  Future<Either<Failure, GroupPracticesPage>> getConnectPractices({
+    required bool includeUnfollowed,
+    required String language,
+    required int skip,
+    required int limit,
+  });
+
   Future<Either<Failure, GroupMembersPage>> getGroupMembers(
     String groupId, {
     required int skip,

--- a/lib/features/group_profile/presentation/providers/group_profile_providers.dart
+++ b/lib/features/group_profile/presentation/providers/group_profile_providers.dart
@@ -143,7 +143,15 @@ class GroupFollowNotifier extends StateNotifier<GroupFollowState> {
 
   void _invalidateConnectProviders() {
     _ref.invalidate(myGroupsProvider);
-    _ref.invalidate(discoverGroupsProvider);
+  }
+
+  void _refreshDiscoverGroupsIfLoaded() {
+    if (!_ref.exists(discoverGroupsProvider)) return;
+
+    final discoverState = _ref.read(discoverGroupsProvider);
+    if (!discoverState.hasLoaded) return;
+
+    _ref.read(discoverGroupsProvider.notifier).refresh();
   }
 
   void _addPendingJoinedGroup(GroupProfile group) {
@@ -298,6 +306,7 @@ class GroupFollowNotifier extends StateNotifier<GroupFollowState> {
         if (connectGroup != null) {
           _removePendingJoinedGroup(connectGroup.id);
           _markPendingUnjoined(connectGroup.id);
+          _refreshDiscoverGroupsIfLoaded();
         }
         return true;
       },

--- a/lib/features/group_profile/presentation/screens/group_event_detail_screen.dart
+++ b/lib/features/group_profile/presentation/screens/group_event_detail_screen.dart
@@ -134,6 +134,7 @@ class _GroupEventDetailScreenState
     final isAttending = _attendingOverride ?? event.isJoined;
     final totalAttending = _attendeeCount(event, isAttending);
     final hasVideos = _hasVideos(event);
+    final isPast = isGroupEventPast(event);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(14, 8, 14, 32),
@@ -147,8 +148,10 @@ class _GroupEventDetailScreenState
             totalAttending: totalAttending,
             isDark: isDark,
           ),
-          const SizedBox(height: 14),
-          _buildActionRow(event, isAttending, isDark),
+          if (!isPast) ...[
+            const SizedBox(height: 14),
+            _buildActionRow(event, isAttending, isDark),
+          ],
           const SizedBox(height: 16),
           _EventInfoCard(event: event, isDark: isDark),
           const SizedBox(height: 16),
@@ -257,6 +260,8 @@ class _GroupEventDetailScreenState
   }
 
   Future<void> _attendEvent(GroupEvent event) async {
+    if (isGroupEventPast(event)) return;
+
     final authState = ref.read(authProvider);
     if (authState.isGuest || !authState.isLoggedIn) {
       LoginDrawer.show(context, ref);
@@ -278,6 +283,8 @@ class _GroupEventDetailScreenState
   }
 
   Future<void> _leaveEvent(GroupEvent event) async {
+    if (isGroupEventPast(event)) return;
+
     final authState = ref.read(authProvider);
     if (authState.isGuest || !authState.isLoggedIn) {
       LoginDrawer.show(context, ref);

--- a/lib/features/group_profile/presentation/screens/group_event_detail_screen.dart
+++ b/lib/features/group_profile/presentation/screens/group_event_detail_screen.dart
@@ -574,14 +574,6 @@ class _EventInfoCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'WHEN',
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w800,
-              color: AppColors.primaryDark,
-            ),
-          ),
           const SizedBox(height: 7),
           if (dateText != null)
             Row(

--- a/lib/features/group_profile/presentation/widgets/group_accumulator_card.dart
+++ b/lib/features/group_profile/presentation/widgets/group_accumulator_card.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
 import 'package:flutter_pecha/core/extensions/context_ext.dart';
 import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/core/widgets/cached_network_image_widget.dart';
 import 'package:flutter_pecha/core/widgets/responsive_cover_image.dart';
 import 'package:flutter_pecha/features/group_profile/domain/entities/group_accumulator.dart';
 import 'package:flutter_pecha/features/plans/data/utils/plan_date_format.dart';
+import 'package:go_router/go_router.dart';
 
 class GroupAccumulatorCard extends StatelessWidget {
   final GroupAccumulator accumulator;
@@ -14,6 +16,9 @@ class GroupAccumulatorCard extends StatelessWidget {
   final bool isJoining;
   final VoidCallback? onTap;
   final VoidCallback? onJoinTap;
+  final String? groupName;
+  final String? groupAvatarUrl;
+  final String? groupId;
 
   const GroupAccumulatorCard({
     super.key,
@@ -24,6 +29,9 @@ class GroupAccumulatorCard extends StatelessWidget {
     this.isJoining = false,
     this.onTap,
     this.onJoinTap,
+    this.groupName,
+    this.groupAvatarUrl,
+    this.groupId,
   });
 
   @override
@@ -127,41 +135,53 @@ class GroupAccumulatorCard extends StatelessWidget {
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  if (dateRange != null || accumulator.memberCount > 0) ...[
+                  if (dateRange != null ||
+                      accumulator.memberCount > 0 ||
+                      _hasGroupLabel) ...[
                     const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        if (dateRange != null)
-                          Expanded(
-                            child: Text(
-                              dateRange,
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: secondaryColor,
-                                height: lineHeight,
+                    _hasGroupLabel
+                        ? _ConnectGroupMetaRow(
+                          groupName: groupName!,
+                          groupAvatarUrl: groupAvatarUrl,
+                          groupId: groupId,
+                          isDark: isDark,
+                          lineHeight: lineHeight,
+                          dateText: dateRange,
+                          joinCount: accumulator.memberCount,
+                        )
+                        : Row(
+                          children: [
+                            if (dateRange != null)
+                              Expanded(
+                                child: Text(
+                                  dateRange,
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: secondaryColor,
+                                    height: lineHeight,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        if (accumulator.memberCount > 0) ...[
-                          Icon(
-                            AppAssets.usercard,
-                            size: 16,
-                            color: secondaryColor,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${accumulator.memberCount}',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: secondaryColor,
-                              height: lineHeight,
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
+                            if (accumulator.memberCount > 0) ...[
+                              Icon(
+                                AppAssets.usercard,
+                                size: 16,
+                                color: secondaryColor,
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                '${accumulator.memberCount}',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: secondaryColor,
+                                  height: lineHeight,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
                   ],
                 ],
               ),
@@ -176,6 +196,146 @@ class GroupAccumulatorCard extends StatelessWidget {
     return PlanDateFormat.formatRangeOrNull(
       accumulator.startDate,
       accumulator.endDate,
+    );
+  }
+
+  bool get _hasGroupLabel =>
+      groupName != null && groupName!.trim().isNotEmpty;
+}
+
+class _ConnectGroupMetaRow extends StatelessWidget {
+  const _ConnectGroupMetaRow({
+    required this.groupName,
+    this.groupAvatarUrl,
+    this.groupId,
+    required this.isDark,
+    this.lineHeight,
+    this.dateText,
+    this.joinCount = 0,
+  });
+
+  final String groupName;
+  final String? groupAvatarUrl;
+  final String? groupId;
+  final bool isDark;
+  final double? lineHeight;
+  final String? dateText;
+  final int joinCount;
+
+  static const double _avatarSize = 24;
+
+  @override
+  Widget build(BuildContext context) {
+    final secondaryColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+    final displayName =
+        groupName.trim().isNotEmpty
+            ? groupName.trim()
+            : context.l10n.connect_group_fallback_title;
+    final trimmedAvatar = groupAvatarUrl?.trim();
+    final trimmedDate = dateText?.trim();
+    final placeholderColor =
+        isDark ? AppColors.surfaceVariantDark : AppColors.grey100;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildGroupTapTarget(
+              context,
+              child: ClipOval(
+                child: SizedBox(
+                  width: _avatarSize,
+                  height: _avatarSize,
+                  child:
+                      trimmedAvatar != null && trimmedAvatar.isNotEmpty
+                          ? CachedNetworkImageWidget(
+                            imageUrl: trimmedAvatar,
+                            fit: BoxFit.cover,
+                            width: _avatarSize,
+                            height: _avatarSize,
+                          )
+                          : ColoredBox(
+                            color: placeholderColor,
+                            child: Icon(
+                              AppAssets.usersThree,
+                              size: 14,
+                              color:
+                                  isDark ? AppColors.grey500 : AppColors.grey600,
+                            ),
+                          ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _buildGroupTapTarget(
+                context,
+                child: Text(
+                  displayName,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color:
+                        isDark ? AppColors.textPrimaryDark : AppColors.primaryDark,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        if ((trimmedDate != null && trimmedDate.isNotEmpty) || joinCount > 0) ...[
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (trimmedDate != null && trimmedDate.isNotEmpty)
+                Expanded(
+                  child: Text(
+                    trimmedDate,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: secondaryColor,
+                      height: lineHeight,
+                    ),
+                  ),
+                )
+              else
+                const SizedBox.shrink(),
+              if (joinCount > 0)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(AppAssets.usercard, size: 16, color: secondaryColor),
+                    const SizedBox(width: 4),
+                    Text(
+                      '$joinCount',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: secondaryColor,
+                        height: lineHeight,
+                      ),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildGroupTapTarget(BuildContext context, {required Widget child}) {
+    final trimmedGroupId = groupId?.trim();
+    if (trimmedGroupId == null || trimmedGroupId.isEmpty) return child;
+
+    return GestureDetector(
+      onTap: () => context.push('/home/group/$trimmedGroupId'),
+      behavior: HitTestBehavior.opaque,
+      child: child,
     );
   }
 }

--- a/lib/features/group_profile/presentation/widgets/group_profile_body.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_body.dart
@@ -117,7 +117,8 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
             ? _visibleTabs[previous.index]
             : null;
     var initialIndex = selectedTab == null ? -1 : tabs.indexOf(selectedTab);
-    if (initialIndex < 0) initialIndex = tabs.indexOf(_GroupProfileTab.practices);
+    if (initialIndex < 0)
+      initialIndex = tabs.indexOf(_GroupProfileTab.practices);
     if (initialIndex < 0) initialIndex = 0;
 
     final controller = TabController(
@@ -163,30 +164,30 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
 
     if (_practicesScrollController.position.pixels >=
         _practicesScrollController.position.maxScrollExtent - 200) {
-      ref
-          .read(groupPracticesProvider(widget.profile.id).notifier)
-          .loadMore();
+      ref.read(groupPracticesProvider(widget.profile.id).notifier).loadMore();
     }
   }
 
   void _syncPracticeEnrollmentFromList(List<GroupPractice> practices) {
-    final accumulators = practices
-        .where((practice) => practice.type == GroupPracticeType.accumulator)
-        .map((practice) => practice.accumulator)
-        .whereType<GroupAccumulator>()
-        .toList();
+    final accumulators =
+        practices
+            .where((practice) => practice.type == GroupPracticeType.accumulator)
+            .map((practice) => practice.accumulator)
+            .whereType<GroupAccumulator>()
+            .toList();
     ref
         .read(groupAccumulatorJoinCacheProvider(widget.profile.id).notifier)
         .syncFromApi(accumulators);
 
-    final apiEnrolledIds = practices
-        .where(
-          (practice) =>
-              practice.series != null &&
-              practice.series!.isGroupEnrolled == true,
-        )
-        .map((practice) => practice.series!.id)
-        .toSet();
+    final apiEnrolledIds =
+        practices
+            .where(
+              (practice) =>
+                  practice.series != null &&
+                  practice.series!.isGroupEnrolled == true,
+            )
+            .map((practice) => practice.series!.id)
+            .toSet();
     final apiNotEnrolledIds = practices
         .where(
           (practice) =>
@@ -292,7 +293,9 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     // Keep the events tab when loading failed so its retry action stays
     // reachable.
     final hasEvents = eventsAsync.maybeWhen(
-      data: (either) => either.fold((_) => true, (page) => page.events.isNotEmpty),
+      data:
+          (either) =>
+              either.fold((_) => true, (page) => page.events.isNotEmpty),
       error: (_, _) => true,
       orElse: () => false,
     );
@@ -359,7 +362,11 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     double? lineHeight,
   ) {
     return switch (tab) {
-      _GroupProfileTab.posts => _buildEmptyTab('No posts yet', isDark, lineHeight),
+      _GroupProfileTab.posts => _buildEmptyTab(
+        'No posts yet',
+        isDark,
+        lineHeight,
+      ),
       _GroupProfileTab.events => GroupProfileEventsTab(
         groupId: profile.id,
         isDark: isDark,
@@ -743,7 +750,8 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     }
 
     final itemCount =
-        practicesState.practices.length + (practicesState.isLoadingMore ? 1 : 0);
+        practicesState.practices.length +
+        (practicesState.isLoadingMore ? 1 : 0);
 
     return ListView.builder(
       controller: _practicesScrollController,
@@ -764,12 +772,7 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
           padding: EdgeInsets.only(bottom: isLast ? 0 : 16),
           child: switch (practice.type) {
             GroupPracticeType.series when practice.series != null =>
-              _buildSeriesCard(
-                profile,
-                practice.series!,
-                isDark,
-                lineHeight,
-              ),
+              _buildSeriesCard(profile, practice.series!, isDark, lineHeight),
             GroupPracticeType.accumulator when practice.accumulator != null =>
               _buildAccumulatorCard(
                 profile,
@@ -778,11 +781,7 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
                 lineHeight,
               ),
             GroupPracticeType.collection when practice.collection != null =>
-              _buildCollectionCard(
-                practice.collection!,
-                isDark,
-                lineHeight,
-              ),
+              _buildCollectionCard(practice.collection!, isDark, lineHeight),
             _ => const SizedBox.shrink(),
           },
         );

--- a/lib/features/group_profile/presentation/widgets/group_profile_body.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_body.dart
@@ -772,6 +772,8 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
               ),
             GroupPracticeType.collection when practice.collection != null =>
               _buildCollectionCard(practice.collection!, isDark, lineHeight),
+            GroupPracticeType.plan when practice.plan != null =>
+              _buildPlanCard(profile, practice.plan!, isDark, lineHeight),
             _ => const SizedBox.shrink(),
           },
         );
@@ -849,6 +851,99 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildPlanCard(
+    GroupProfile profile,
+    GroupPracticePlan plan,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    final secondaryColor =
+        isDark ? AppColors.textTertiaryDark : AppColors.textSecondary;
+    final cardColor =
+        isDark ? AppColors.cardBackgroundDark : AppColors.surfaceWhite;
+    final dateRange = PlanDateFormat.formatRangeOrNull(plan.startDate, null);
+
+    return Material(
+      color: cardColor,
+      elevation: isDark ? 0 : 1,
+      shadowColor: Colors.black.withValues(alpha: 0.08),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {
+          context.push(
+            '/practice/plans/preview',
+            extra: {
+              'plan': plan.toPlan(),
+              if (plan.seriesId != null) 'seriesId': plan.seriesId,
+            },
+          );
+        },
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              height: 140,
+              width: double.infinity,
+              child:
+                  plan.imageUrl != null && plan.imageUrl!.isNotEmpty
+                      ? CachedNetworkImageWidget(
+                        imageUrl: plan.imageUrl!,
+                        fit: BoxFit.cover,
+                      )
+                      : ColoredBox(
+                        color:
+                            isDark
+                                ? AppColors.surfaceVariantDark
+                                : AppColors.grey100,
+                        child: Icon(
+                          AppAssets.bookOpenText,
+                          size: 40,
+                          color: isDark ? AppColors.grey500 : AppColors.grey600,
+                        ),
+                      ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    plan.title,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      height: lineHeight,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (dateRange != null || plan.totalDays > 0) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      [
+                        if (dateRange != null) dateRange,
+                        if (plan.totalDays > 0)
+                          context.l10n.days_count(plan.totalDays),
+                      ].join(' · '),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: secondaryColor,
+                        height: lineHeight,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/group_profile/presentation/widgets/group_profile_body.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_body.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_pecha/core/constants/app_assets.dart';
@@ -45,12 +46,12 @@ class GroupProfileBody extends ConsumerStatefulWidget {
   ConsumerState<GroupProfileBody> createState() => _GroupProfileBodyState();
 }
 
-class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
-    with SingleTickerProviderStateMixin {
-  static const int _practicesTabIndex = 2;
-  static const int _membersTabIndex = 3;
+enum _GroupProfileTab { posts, events, practices, members }
 
+class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
+    with TickerProviderStateMixin {
   TabController? _tabController;
+  List<_GroupProfileTab> _visibleTabs = const [];
   final ScrollController _practicesScrollController = ScrollController();
   String? _enrollingSeriesId;
   String? _joiningAccumulatorId;
@@ -60,6 +61,9 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
   late final TapGestureRecognizer _moreRecognizer;
 
   bool _isCommunityGroup(GroupProfile profile) => !profile.groupType.isPage;
+
+  /// Posts have no data source yet, so the tab never has content to show.
+  bool get _hasPosts => false;
 
   bool _hasBanner(GroupProfile profile) =>
       profile.bannerUrl != null && profile.bannerUrl!.isNotEmpty;
@@ -83,12 +87,8 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     super.initState();
     _moreRecognizer = TapGestureRecognizer();
     if (_isCommunityGroup(widget.profile)) {
-      _tabController = TabController(
-        length: 4,
-        initialIndex: _practicesTabIndex,
-        vsync: this,
-      );
-      _tabController!.addListener(_onTabChanged);
+      // The tab set depends on which sections actually have content, so the
+      // controller is created in build() once that data is known.
       _practicesScrollController.addListener(_onPracticesScroll);
 
       final groupId = widget.profile.id;
@@ -106,12 +106,46 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     }
   }
 
+  /// Rebuilds the tab controller whenever the visible tab set changes, keeping
+  /// the currently selected tab selected when it is still present.
+  void _syncTabController(List<_GroupProfileTab> tabs) {
+    final previous = _tabController;
+    if (previous != null && listEquals(_visibleTabs, tabs)) return;
+
+    final selectedTab =
+        previous != null && previous.index < _visibleTabs.length
+            ? _visibleTabs[previous.index]
+            : null;
+    var initialIndex = selectedTab == null ? -1 : tabs.indexOf(selectedTab);
+    if (initialIndex < 0) initialIndex = tabs.indexOf(_GroupProfileTab.practices);
+    if (initialIndex < 0) initialIndex = 0;
+
+    final controller = TabController(
+      length: tabs.length,
+      initialIndex: initialIndex,
+      vsync: this,
+    );
+    controller.addListener(_onTabChanged);
+
+    _visibleTabs = tabs;
+    _tabController = controller;
+
+    if (previous != null) {
+      previous.removeListener(_onTabChanged);
+      // The old TabBar/TabBarView still reference it for the current frame.
+      WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+    }
+  }
+
   void _onTabChanged() {
-    if (_tabController == null || _tabController!.indexIsChanging) return;
+    final controller = _tabController;
+    if (controller == null || controller.indexIsChanging) return;
     if (!mounted) return;
 
     final groupId = widget.profile.id;
-    final isMembersTab = _tabController!.index == _membersTabIndex;
+    final isMembersTab =
+        controller.index < _visibleTabs.length &&
+        _visibleTabs[controller.index] == _GroupProfileTab.members;
     ref.read(groupMembersTabActiveProvider(groupId).notifier).state =
         isMembersTab;
 
@@ -246,6 +280,37 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     double? lineHeight,
     List<GroupProfileSocialLink> orderedLinks,
   ) {
+    final (hasPractices, isPracticesLoading) = ref.watch(
+      groupPracticesProvider(profile.id).select(
+        (state) => (
+          state.practices.isNotEmpty,
+          state.isLoading && state.practices.isEmpty,
+        ),
+      ),
+    );
+    final eventsAsync = ref.watch(groupEventsProvider(profile.id));
+    // Keep the events tab when loading failed so its retry action stays
+    // reachable.
+    final hasEvents = eventsAsync.maybeWhen(
+      data: (either) => either.fold((_) => true, (page) => page.events.isNotEmpty),
+      error: (_, _) => true,
+      orElse: () => false,
+    );
+    final isEventsLoading =
+        eventsAsync.isLoading && !eventsAsync.hasValue && !eventsAsync.hasError;
+
+    // Wait for both sections before laying out the tabs, otherwise tabs would
+    // pop in and out as each request settles.
+    final isTabDataLoading = isPracticesLoading || isEventsLoading;
+    final tabs = <_GroupProfileTab>[
+      if (_hasPosts) _GroupProfileTab.posts,
+      if (hasEvents) _GroupProfileTab.events,
+      if (hasPractices) _GroupProfileTab.practices,
+      _GroupProfileTab.members,
+    ];
+    if (!isTabDataLoading) _syncTabController(tabs);
+    final controller = _tabController;
+
     return NestedScrollView(
       headerSliverBuilder:
           (context, _) => [
@@ -269,30 +334,49 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
                   const SizedBox(height: 20),
                   _GroupFollowButton(profile: profile, isDark: isDark),
                   const SizedBox(height: 24),
-                  _buildTabBar(isDark, profile),
+                  if (controller != null) _buildTabBar(isDark, profile),
                 ],
               ),
             ),
           ],
-      body: TabBarView(
-        controller: _tabController!,
-        children: [
-          _buildEmptyTab('No posts yet', isDark, lineHeight),
-          GroupProfileEventsTab(
-            groupId: profile.id,
-            isDark: isDark,
-            lineHeight: lineHeight,
-          ),
-          _buildPracticesTab(profile, isDark, lineHeight),
-          GroupProfileMembersTab(
-            groupId: profile.id,
-            groupType: profile.groupType,
-            isDark: isDark,
-            lineHeight: lineHeight,
-          ),
-        ],
-      ),
+      body:
+          controller == null
+              ? const Center(child: CircularProgressIndicator())
+              : TabBarView(
+                controller: controller,
+                children: [
+                  for (final tab in _visibleTabs)
+                    _buildTabContent(tab, profile, isDark, lineHeight),
+                ],
+              ),
     );
+  }
+
+  Widget _buildTabContent(
+    _GroupProfileTab tab,
+    GroupProfile profile,
+    bool isDark,
+    double? lineHeight,
+  ) {
+    return switch (tab) {
+      _GroupProfileTab.posts => _buildEmptyTab('No posts yet', isDark, lineHeight),
+      _GroupProfileTab.events => GroupProfileEventsTab(
+        groupId: profile.id,
+        isDark: isDark,
+        lineHeight: lineHeight,
+      ),
+      _GroupProfileTab.practices => _buildPracticesTab(
+        profile,
+        isDark,
+        lineHeight,
+      ),
+      _GroupProfileTab.members => GroupProfileMembersTab(
+        groupId: profile.id,
+        groupType: profile.groupType,
+        isDark: isDark,
+        lineHeight: lineHeight,
+      ),
+    };
   }
 
   GroupProfile _resolveProfile() {
@@ -605,10 +689,6 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     final labelColor =
         isDark ? AppColors.textPrimaryDark : AppColors.textPrimary;
     final dividerColor = isDark ? AppColors.grey800 : AppColors.grey300;
-    final membersTabLabel =
-        profile.groupType.isPage
-            ? context.l10n.group_tab_followers
-            : context.l10n.group_tab_members;
 
     return Column(
       children: [
@@ -627,15 +707,24 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
             fontWeight: FontWeight.w500,
           ),
           tabs: [
-            const Tab(text: 'Post'),
-            const Tab(text: 'Events'),
-            Tab(text: context.l10n.tab_practices),
-            Tab(text: membersTabLabel),
+            for (final tab in _visibleTabs) Tab(text: _tabLabel(tab, profile)),
           ],
         ),
         Divider(height: 1, thickness: 1, color: dividerColor),
       ],
     );
+  }
+
+  String _tabLabel(_GroupProfileTab tab, GroupProfile profile) {
+    return switch (tab) {
+      _GroupProfileTab.posts => 'Post',
+      _GroupProfileTab.events => 'Events',
+      _GroupProfileTab.practices => context.l10n.tab_practices,
+      _GroupProfileTab.members =>
+        profile.groupType.isPage
+            ? context.l10n.group_tab_followers
+            : context.l10n.group_tab_members,
+    };
   }
 
   Widget _buildPracticesTab(

--- a/lib/features/group_profile/presentation/widgets/group_profile_body.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_body.dart
@@ -20,6 +20,7 @@ import 'package:flutter_pecha/features/group_profile/presentation/screens/group_
 import 'package:flutter_pecha/features/group_profile/presentation/widgets/group_accumulator_card.dart';
 import 'package:flutter_pecha/features/group_profile/presentation/widgets/group_profile_events_tab.dart';
 import 'package:flutter_pecha/features/group_profile/presentation/utils/group_profile_link_utils.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/widgets/group_profile_links_drawer.dart';
 import 'package:flutter_pecha/features/group_profile/presentation/widgets/group_profile_members_tab.dart';
 import 'package:flutter_pecha/features/home/presentation/providers/series_enrollment_provider.dart';
 import 'package:flutter_pecha/features/plans/presentation/widgets/plan_inline_markdown_view.dart';
@@ -29,6 +30,7 @@ import 'package:flutter_pecha/features/plans/data/utils/plan_date_format.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class GroupProfileBody extends ConsumerStatefulWidget {
   final GroupProfile profile;
@@ -499,9 +501,6 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
               isDark,
               lineHeight,
             ),
-          ] else if (orderedLinks.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            _buildLinksEntryRow(profile, orderedLinks, isDark, lineHeight),
           ] else if (profile.subTitle != null &&
               profile.subTitle!.trim().isNotEmpty) ...[
             const SizedBox(height: 8),
@@ -513,6 +512,10 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
                 height: lineHeight,
               ),
             ),
+          ],
+          if (orderedLinks.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            _buildLinksEntryRow(profile, orderedLinks, isDark, lineHeight),
           ],
         ],
       ),
@@ -571,20 +574,8 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
           recognizer: _moreRecognizer,
         );
 
-        // Description fits within the collapsed height, but if there are
-        // links to show, keep a "more" affordance so users can still reach
-        // the About screen where those links live.
         if (!textPainter.didExceedMaxLines) {
-          if (orderedLinks.isEmpty) {
-            return Text.rich(textSpan);
-          }
-          return Text.rich(
-            TextSpan(
-              text: description,
-              style: style,
-              children: [const TextSpan(text: '  '), moreTapSpan],
-            ),
-          );
+          return Text.rich(textSpan);
         }
 
         final moreSpan = TextSpan(
@@ -651,12 +642,11 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
 
     return GestureDetector(
       onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder:
-                (_) => GroupAboutScreen(title: profile.title, links: links),
-          ),
-        );
+        if (moreCount > 0) {
+          GroupProfileLinksDrawer.show(context, links);
+        } else {
+          _launchUrl(primaryLink.url);
+        }
       },
       behavior: HitTestBehavior.opaque,
       child: Row(
@@ -1224,6 +1214,15 @@ class _GroupProfileBodyState extends ConsumerState<GroupProfileBody>
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message), backgroundColor: Colors.red),
     );
+  }
+
+  Future<void> _launchUrl(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      }
+    } catch (_) {}
   }
 }
 

--- a/lib/features/group_profile/presentation/widgets/group_profile_links_drawer.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_links_drawer.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pecha/core/extensions/context_ext.dart';
+import 'package:flutter_pecha/core/theme/app_colors.dart';
+import 'package:flutter_pecha/features/group_profile/domain/entities/group_profile.dart';
+import 'package:flutter_pecha/features/group_profile/presentation/utils/group_profile_link_utils.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class GroupProfileLinksDrawer extends StatelessWidget {
+  final List<GroupProfileSocialLink> links;
+
+  const GroupProfileLinksDrawer({super.key, required this.links});
+
+  static Future<void> show(
+    BuildContext context,
+    List<GroupProfileSocialLink> links,
+  ) {
+    return showModalBottomSheet<void>(
+      context: context,
+      useRootNavigator: true,
+      backgroundColor: Colors.transparent,
+      isDismissible: true,
+      enableDrag: true,
+      barrierColor: Colors.black.withValues(alpha: 0.5),
+      builder: (context) => GroupProfileLinksDrawer(links: links),
+    );
+  }
+
+  Future<void> _launchUrl(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      }
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final ordered = GroupProfileLinkUtils.orderedLinks(links);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.cardDark : AppColors.surfaceWhite,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildDragHandle(context),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                context.l10n.group_links_title,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+          Divider(
+            height: 1,
+            color: isDark ? AppColors.cardBorderDark : AppColors.grey100,
+          ),
+          ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            itemCount: ordered.length,
+            separatorBuilder:
+                (_, __) => Divider(
+                  height: 1,
+                  color: isDark ? AppColors.cardBorderDark : AppColors.grey100,
+                ),
+            itemBuilder: (context, index) {
+              final link = ordered[index];
+              return _LinkTile(
+                icon: GroupProfileLinkUtils.iconForPlatform(link.platform),
+                title: GroupProfileLinkUtils.labelForPlatform(
+                  link.platform,
+                  context,
+                ),
+                subtitle: link.url,
+                isDark: isDark,
+                onTap: () => _launchUrl(link.url),
+              );
+            },
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDragHandle(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12, bottom: 12),
+      child: Container(
+        width: 40,
+        height: 4,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+class _LinkTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool isDark;
+  final VoidCallback onTap;
+
+  const _LinkTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.isDark,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 14),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 24,
+              color: isDark ? AppColors.textPrimaryDark : AppColors.textPrimary,
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color:
+                          isDark
+                              ? AppColors.textTertiaryDark
+                              : AppColors.textSecondary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/group_profile/presentation/widgets/group_profile_links_drawer.dart
+++ b/lib/features/group_profile/presentation/widgets/group_profile_links_drawer.dart
@@ -17,6 +17,7 @@ class GroupProfileLinksDrawer extends StatelessWidget {
     return showModalBottomSheet<void>(
       context: context,
       useRootNavigator: true,
+      isScrollControlled: true,
       backgroundColor: Colors.transparent,
       isDismissible: true,
       enableDrag: true,
@@ -44,52 +45,62 @@ class GroupProfileLinksDrawer extends StatelessWidget {
         color: isDark ? AppColors.cardDark : AppColors.surfaceWhite,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _buildDragHandle(context),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                context.l10n.group_links_title,
-                style: Theme.of(
-                  context,
-                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+      child: SafeArea(
+        top: false,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height * 0.6,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildDragHandle(context),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    context.l10n.group_links_title,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                ),
               ),
-            ),
-          ),
-          Divider(
-            height: 1,
-            color: isDark ? AppColors.cardBorderDark : AppColors.grey100,
-          ),
-          ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            itemCount: ordered.length,
-            separatorBuilder:
-                (_, __) => Divider(
-                  height: 1,
-                  color: isDark ? AppColors.cardBorderDark : AppColors.grey100,
+              Divider(
+                height: 1,
+                color: isDark ? AppColors.cardBorderDark : AppColors.grey100,
+              ),
+              Flexible(
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  itemCount: ordered.length,
+                  separatorBuilder:
+                      (_, __) => Divider(
+                        height: 1,
+                        color:
+                            isDark ? AppColors.cardBorderDark : AppColors.grey100,
+                      ),
+                  itemBuilder: (context, index) {
+                    final link = ordered[index];
+                    return _LinkTile(
+                      icon: GroupProfileLinkUtils.iconForPlatform(link.platform),
+                      title: GroupProfileLinkUtils.labelForPlatform(
+                        link.platform,
+                        context,
+                      ),
+                      subtitle: link.url,
+                      isDark: isDark,
+                      onTap: () => _launchUrl(link.url),
+                    );
+                  },
                 ),
-            itemBuilder: (context, index) {
-              final link = ordered[index];
-              return _LinkTile(
-                icon: GroupProfileLinkUtils.iconForPlatform(link.platform),
-                title: GroupProfileLinkUtils.labelForPlatform(
-                  link.platform,
-                  context,
-                ),
-                subtitle: link.url,
-                isDark: isDark,
-                onTap: () => _launchUrl(link.url),
-              );
-            },
+              ),
+              const SizedBox(height: 8),
+            ],
           ),
-          const SizedBox(height: 8),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Fixes #601 , #610

## Backend Related
- [x] adding logo to the post right before the name of the group (waiting for @tenkus47 to send it from backend)
- [x] seeing person instead of group on the posts
- [x] check with (Tenzin Tsering HR, menla, YashDixit, tenkal, Tigerboy) for like and comment of a post
> checked with menla, when she logout and login, she was able to both like and comment
- [ ] Event invite link shared without contextual note** — Connect > Events · Shared URL gives receiver no indication it is an invitation; needs accompanying message copy or an in-app share sheet with pre-filled text

- [x] Group page: show practices, accumulations, group prayers ( group practices Tab in connect page)

## App
- [x] "WHEN" label is all-caps red on Event detail
- [x] fix for the tibetan characters being cut off from the top
- [x]  Red org labels under event cards feel visually harsh ( update the color and adding the logo ) And it should be clickable, it should take you to the group's page.
- [x] Joining a single group clears the entire discover list of the groups.
- [x] Attend button active on past/backdated events
- [x] Open button on the my groups list can be removed, it is redundant
- [x] don't show the tab if there are no content in it for a group 
- [x] Default Connect view to Discover when user has no groups, "My" in the tab is empty for new/ungrouped users; Discover is more useful as a default.
- [x] make the tab spacing propotional
- [x] the gap between the back button and the top of the phone is too large, waste of realeaste and then adding the links to the social and website on the group's page.
- [x] update group page to only show the discover state
- [x] localization missing on connect page
- [x] Tab labels "My" / "Me" feel incomplete** — Connect (tab toggle), bottom nav · 3 reporters (tenkal, Tenzin Tsering HR x2) ·  "My" should contextually read "My Feed" / "My Posts" / "My Events" / "My Groups"; "Me" tab should be "Profile" or "My Profile" `Discussion needed`
> kept For you instead of my, discover remain same
