### PR TITLE
localization strings for Tibetan language support

### DIFF
--- a/lib/core/l10n/app_bo.arb
+++ b/lib/core/l10n/app_bo.arb
@@ -135,7 +135,7 @@
   "less": "ཉུང་བ།",
   "no_content": "ནང་དོན་རྙེད་མ་སོང་།",
   "no_commentary": "འགྲེལ་བ་རྙེད་མ་སོང་།",
-  "commentary_not_available_for_language": "{language} ཡི་འགྲེལ་བ་མི་འདུག",
+  "commentary_not_available_for_language": "{language}་གི་འགྲེལ་བ་མི་འདུག",
   "@commentary_not_available_for_language": {
     "placeholders": {
       "language": {

--- a/lib/core/l10n/generated/app_localizations_bo.dart
+++ b/lib/core/l10n/generated/app_localizations_bo.dart
@@ -320,7 +320,7 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String commentary_not_available_for_language(String language) {
-    return '$language ཡི་འགྲེལ་བ་མི་འདུག';
+    return '$language་གི་འགྲེལ་བ་མི་འདུག';
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1161,10 +1161,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   tibetan_calendar:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This PR is Regarding the tibetan localization message not being shown properly when there are no commentaries found. 

Issue Card:
[Card](https://github.com/orgs/OpenPecha/projects/160/views/7?pane=issue&itemId=224440305&issue=OpenPecha%7CWeBuddhist-app%7C586)